### PR TITLE
add librarian config file to use a different temporary directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,6 @@ refinery/fabric/*
 supervisord.conf
 codekit-config.json
 .vagrant/
-deployment/.librarian/
 deployment/.tmp/
 deployment/modules/
 deployment/Puppetfile.lock

--- a/deployment/.librarian/puppet/config
+++ b/deployment/.librarian/puppet/config
@@ -1,0 +1,3 @@
+--- 
+  LIBRARIAN_PUPPET_TMP: /var/tmp/puppet
+  LIBRARIAN_PUPPET_DESTRUCTIVE: "false"


### PR DESCRIPTION
on windows, when I do a `vagrant up` it will eventually raise an error with permission denied and a very long path. The reason seems to be that librarian-puppet tries to access a shared temporary path with more then 256 characters. Since it is just a temporary working directory the pull request, change the config file of librarian puppet, such that it will use a different one.
