### PR TITLE
Add security group

### DIFF
--- a/deployment/stack.py
+++ b/deployment/stack.py
@@ -373,12 +373,6 @@ def main():
                     "SourceSecurityGroupId": functions.get_att(
                         'ELBSecurityGroup', 'GroupId'),
                 },
-                {
-                    "IpProtocol": "tcp",
-                    "FromPort": "443",
-                    "ToPort": "443",
-                    "CidrIp": "0.0.0.0/0",
-                },
             ],
         })
     )

--- a/deployment/stack.py
+++ b/deployment/stack.py
@@ -124,6 +124,7 @@ def main():
         "AutoMinorVersionUpgrade": False,
         "AvailabilityZone": config['AVAILABILITY_ZONE'],
         "BackupRetentionPeriod": "0",
+        "CopyTagsToSnapshot": True,
         "DBInstanceClass": "db.t2.small",       # todo:?
         "DBInstanceIdentifier": config['RDS_NAME'],
         "Engine": "postgres",

--- a/deployment/stack.py
+++ b/deployment/stack.py
@@ -382,7 +382,13 @@ def main():
         'RDSSecurityGroup', 'AWS::EC2::SecurityGroup',
         core.Properties({
             'GroupDescription': "Refinery RDS",
-            'SecurityGroupEgress':  [],
+            'SecurityGroupEgress':  [
+                # We would like to remove all egress rules here,
+                # but you can't do that with this version
+                # of CloudFormation.
+                # We decided that the hacky workarounds are
+                # not worth it.
+            ],
             'SecurityGroupIngress': [
                 {
                     "IpProtocol": "tcp",

--- a/deployment/stack.py
+++ b/deployment/stack.py
@@ -177,7 +177,7 @@ def main():
             'UserData': functions.base64(user_data_script),
             'KeyName': config['KEY_NAME'],
             'IamInstanceProfile': functions.ref('WebInstanceProfile'),
-            'SecurityGroups' : [
+            'SecurityGroups': [
                 functions.ref("InstanceSecurityGroup")],
             'Tags': instance_tags,
         }),
@@ -320,7 +320,7 @@ def main():
             # Egress Rule defined via
             # AWS::EC2::SecurityGroupEgress resource,
             # to avoid circularity (below).
-            # See http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html
+            # See http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html # noqa: E501
             'SecurityGroupIngress': [
                 {
                     "IpProtocol": "tcp",
@@ -342,12 +342,12 @@ def main():
         'ELBEgress', 'AWS::EC2::SecurityGroupEgress',
         core.Properties({
             "GroupId": functions.get_att('ELBSecurityGroup',
-              'GroupId'),
+                                         'GroupId'),
             "IpProtocol": "tcp",
             "FromPort": "80",
             "ToPort": "80",
-            "DestinationSecurityGroupId":
-              functions.get_att('InstanceSecurityGroup', 'GroupId'),
+            "DestinationSecurityGroupId": functions.get_att(
+                'InstanceSecurityGroup', 'GroupId'),
         })
     )
 
@@ -370,8 +370,8 @@ def main():
                     "ToPort": "80",
                     # "CidrIp": "0.0.0.0/0",
                     # Only accept connections from the ELB.
-                    "SourceSecurityGroupId":
-                      functions.get_att('ELBSecurityGroup', 'GroupId'),
+                    "SourceSecurityGroupId": functions.get_att(
+                        'ELBSecurityGroup', 'GroupId'),
                 },
                 {
                     "IpProtocol": "tcp",
@@ -396,8 +396,8 @@ def main():
                     "ToPort": "5432",
                     # Only accept connections from the
                     # Instance Security Group.
-                    "SourceSecurityGroupId":
-                      functions.get_att('InstanceSecurityGroup', 'GroupId'),
+                    "SourceSecurityGroupId": functions.get_att(
+                        'InstanceSecurityGroup', 'GroupId'),
                 },
             ],
         })


### PR DESCRIPTION
As per https://trello.com/c/5FpMkUM2/352-create-a-separate-security-groups-for-elb-ec2-and-rds now have separate security groups for EC2 and RDS instance (and that is separate from the ELB security group).

