### PR TITLE
Modify /sharing to return only owner and share_list.

### DIFF
--- a/refinery/core/api.py
+++ b/refinery/core/api.py
@@ -324,7 +324,12 @@ class SharableResourceAPIInterface(object):
             if not user.has_perm('core.read_dataset', res):
                 return HttpUnauthorized()
             kwargs['sharing'] = True
-            return self.process_get(request, res, **kwargs)
+            mod_res = self.transform_res_list(user, [res], request, **kwargs)
+            perm_obj = {
+                'owner': mod_res[0].owner,
+                'share_list': mod_res[0].share_list
+            }
+            return self.build_response(request, perm_obj, **kwargs)
         elif request.method == 'PUT':
             # user must be admin or owner
             if not user.is_superuser and user != res.get_owner():


### PR DESCRIPTION
This modifies the data_set sharing get to return only the owner and share_list. This fix is not too involved because we are revisiting our security and upgrading the tasty pie apis.