### PR TITLE
Scottx611x/td api url routing

### DIFF
--- a/refinery/config/urls.py
+++ b/refinery/config/urls.py
@@ -24,7 +24,7 @@ from core.forms import RegistrationFormWithCustomFields
 from core.models import DataSet, AuthenticationFormUsernameOrEmail
 from core.views import (AnalysesViewSet, CustomRegistrationView,
                         DataSetsViewSet, NodeGroups)
-from core.urls import router as core_router
+from core.urls import core_router
 from data_set_manager.api import (AssayResource, AttributeOrderResource,
                                   AttributeResource, InvestigationResource,
                                   ProtocolReferenceResource,
@@ -33,7 +33,7 @@ from data_set_manager.api import (AssayResource, AttributeOrderResource,
                                   StudyResource)
 from data_set_manager.views import Assays, AssaysAttributes, AssaysFiles
 from file_store.views import FileStoreItems
-from tool_manager.urls import router as tool_manager_router
+from tool_manager.urls import tool_manager_router
 
 
 logger = logging.getLogger(__name__)

--- a/refinery/config/urls.py
+++ b/refinery/config/urls.py
@@ -9,9 +9,9 @@ from haystack.forms import FacetedSearchForm
 from haystack.query import SearchQuerySet
 from haystack.views import FacetedSearchView
 from registration.backends.default.views import ActivationView
-from rest_framework import routers
 from tastypie.api import Api
 
+from config.utils import RouterCombiner
 from core.api import (AnalysisResource, DataSetResource, ExtendedGroupResource,
                       FastQCResource, GroupManagementResource,
                       InvitationResource, NodePairResource,
@@ -23,8 +23,8 @@ from core.api import (AnalysisResource, DataSetResource, ExtendedGroupResource,
 from core.forms import RegistrationFormWithCustomFields
 from core.models import DataSet, AuthenticationFormUsernameOrEmail
 from core.views import (AnalysesViewSet, CustomRegistrationView,
-                        DataSetsViewSet, NodeGroups, NodeViewSet,
-                        WorkflowViewSet)
+                        DataSetsViewSet, NodeGroups)
+from core.urls import router as core_router
 from data_set_manager.api import (AssayResource, AttributeOrderResource,
                                   AttributeResource, InvestigationResource,
                                   ProtocolReferenceResource,
@@ -33,7 +33,7 @@ from data_set_manager.api import (AssayResource, AttributeOrderResource,
                                   StudyResource)
 from data_set_manager.views import Assays, AssaysAttributes, AssaysFiles
 from file_store.views import FileStoreItems
-from tool_manager.views import ToolDefinitionsViewSet
+from tool_manager.urls import router as tool_manager_router
 
 
 logger = logging.getLogger(__name__)
@@ -45,11 +45,13 @@ sqs = (SearchQuerySet().using("core")
                        .facet('technology')
                        .highlight())
 
-# Django REST Framework urls
-router = routers.DefaultRouter()
-router.register(r'workflows', WorkflowViewSet)
-router.register(r'nodes', NodeViewSet)
-router.register(r'tools/definitions', ToolDefinitionsViewSet)
+# Django REST Framework Url Routing
+# RouterCombiner.extend(<router instance>) to include DRF Routers defined in
+# other apps urls.py files
+router = RouterCombiner()
+router.extend(core_router)
+router.extend(tool_manager_router)
+
 
 # NG: added for tastypie URL
 v1_api = Api(api_name='v1')

--- a/refinery/config/urls.py
+++ b/refinery/config/urls.py
@@ -22,8 +22,8 @@ from core.api import (AnalysisResource, DataSetResource, ExtendedGroupResource,
                       WorkflowInputRelationshipsResource, WorkflowResource)
 from core.forms import RegistrationFormWithCustomFields
 from core.models import DataSet, AuthenticationFormUsernameOrEmail
-from core.views import CustomRegistrationView
 from core.urls import core_router
+from core.views import CustomRegistrationView
 from data_set_manager.api import (AssayResource, AttributeOrderResource,
                                   AttributeResource, InvestigationResource,
                                   ProtocolReferenceResource,

--- a/refinery/config/urls.py
+++ b/refinery/config/urls.py
@@ -22,8 +22,7 @@ from core.api import (AnalysisResource, DataSetResource, ExtendedGroupResource,
                       WorkflowInputRelationshipsResource, WorkflowResource)
 from core.forms import RegistrationFormWithCustomFields
 from core.models import DataSet, AuthenticationFormUsernameOrEmail
-from core.views import (AnalysesViewSet, CustomRegistrationView,
-                        DataSetsViewSet, NodeGroups)
+from core.views import CustomRegistrationView
 from core.urls import core_router
 from data_set_manager.api import (AssayResource, AttributeOrderResource,
                                   AttributeResource, InvestigationResource,
@@ -31,8 +30,9 @@ from data_set_manager.api import (AssayResource, AttributeOrderResource,
                                   ProtocolReferenceParameterResource,
                                   ProtocolResource, PublicationResource,
                                   StudyResource)
-from data_set_manager.views import Assays, AssaysAttributes, AssaysFiles
-from file_store.views import FileStoreItems
+from data_set_manager.urls import data_set_manager_router
+from file_store.urls import file_store_router
+
 from tool_manager.urls import tool_manager_router
 
 
@@ -44,14 +44,6 @@ sqs = (SearchQuerySet().using("core")
                        .facet('measurement')
                        .facet('technology')
                        .highlight())
-
-# Django REST Framework Url Routing
-# RouterCombiner.extend(<router instance>) to include DRF Routers defined in
-# other apps urls.py files
-router = RouterCombiner()
-router.extend(core_router)
-router.extend(tool_manager_router)
-
 
 # NG: added for tastypie URL
 v1_api = Api(api_name='v1')
@@ -155,34 +147,6 @@ urlpatterns = patterns(
         ),
         name='search'
     ),
-    # Wire up our API using automatic URL routing.
-    url(r"^api/v2/", include(router.urls)),
-
-    url(r'^api/v2/node_groups/$', NodeGroups.as_view()),
-
-    url(r'^api/v2/assays/$', Assays.as_view()),
-
-    url(r'^api/v2/assays/(?P<uuid>'
-        r'[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{'
-        r''r'12})/files/$', AssaysFiles.as_view()),
-
-    url(r'^api/v2/assays/(?P<uuid>'
-        r'[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{'
-        r''r'12})/attributes/$', AssaysAttributes.as_view()),
-
-    url(r'^api/v2/file_store_items/(?P<uuid>'
-        r'[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{'
-        r''r'12})/$', FileStoreItems.as_view()),
-
-    url(r'^api/v2/data_sets/(?P<uuid>'
-        r'[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{'
-        r''r'12})/$',
-        DataSetsViewSet.as_view()),
-
-    url(r'^api/v2/analyses/(?P<uuid>'
-        r'[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{'
-        r''r'12})/$',
-        AnalysesViewSet.as_view()),
 
     # (r'^favicon\.ico$',
     # 'django.views.generic.simple.redirect_to',
@@ -205,3 +169,18 @@ if settings.DEBUG:
         urlpatterns += patterns(
             '', url(r'^__debug__/', include(debug_toolbar.urls)),
         )
+
+
+# Django REST Framework Url Routing
+# RouterCombiner.extend(<router instance>) to include DRF Routers defined in
+# other apps urls.py files
+router = RouterCombiner()
+router.extend(core_router)
+router.extend(data_set_manager_router)
+router.extend(file_store_router)
+router.extend(tool_manager_router)
+
+# Wire up our DRF APIs using automatic URL routing.
+urlpatterns += patterns(
+    '', url(r"^api/v2/", include(router.urls))
+)

--- a/refinery/config/utils.py
+++ b/refinery/config/utils.py
@@ -1,0 +1,17 @@
+from rest_framework.routers import DefaultRouter
+
+
+class RouterCombiner(DefaultRouter):
+    """
+    Extends `DefaultRouter` class to add a method for extending url routes
+    from another router.
+
+    Allows for app-specific url definitions to stay inside their own apps.
+    """
+    def extend(self, router):
+        """
+        Extend the routes with url routes of the passed in router.
+
+        router: DRF Router instance containing route definitions.
+        """
+        self.registry.extend(router.registry)

--- a/refinery/config/utils.py
+++ b/refinery/config/utils.py
@@ -14,4 +14,5 @@ class RouterCombiner(DefaultRouter):
 
         router: DRF Router instance containing route definitions.
         """
+        self.urls.extend(router.urls)
         self.registry.extend(router.registry)

--- a/refinery/core/urls.py
+++ b/refinery/core/urls.py
@@ -87,6 +87,6 @@ urlpatterns = patterns(
 )
 
 # DRF url routing
-router = DefaultRouter()
-router.register(r'nodes', NodeViewSet)
-router.register(r'workflows', WorkflowViewSet)
+core_router = DefaultRouter()
+core_router.register(r'nodes', NodeViewSet)
+core_router.register(r'workflows', WorkflowViewSet)

--- a/refinery/core/urls.py
+++ b/refinery/core/urls.py
@@ -7,7 +7,7 @@ Created on Feb 20, 2012
 from django.conf.urls import patterns, url
 from rest_framework.routers import DefaultRouter
 
-from .views import WorkflowViewSet, NodeViewSet
+from .views import NodeViewSet, WorkflowViewSet
 
 urlpatterns = patterns(
     'core.views',

--- a/refinery/core/urls.py
+++ b/refinery/core/urls.py
@@ -5,7 +5,9 @@ Created on Feb 20, 2012
 '''
 
 from django.conf.urls import patterns, url
+from rest_framework.routers import DefaultRouter
 
+from core.views import WorkflowViewSet, NodeViewSet
 
 urlpatterns = patterns(
     'core.views',
@@ -83,3 +85,8 @@ urlpatterns = patterns(
     url(r'^neo4j/annotations/$', 'neo4j_dataset_annotations',
         name="neo4j_dataset_annotations")
 )
+
+# DRF url routing
+router = DefaultRouter()
+router.register(r'nodes', NodeViewSet)
+router.register(r'workflows', WorkflowViewSet)

--- a/refinery/core/urls.py
+++ b/refinery/core/urls.py
@@ -7,7 +7,7 @@ Created on Feb 20, 2012
 from django.conf.urls import patterns, url
 from rest_framework.routers import DefaultRouter
 
-from core.views import WorkflowViewSet, NodeViewSet
+from .views import WorkflowViewSet, NodeViewSet
 
 urlpatterns = patterns(
     'core.views',

--- a/refinery/core/urls.py
+++ b/refinery/core/urls.py
@@ -7,7 +7,9 @@ Created on Feb 20, 2012
 from django.conf.urls import patterns, url
 from rest_framework.routers import DefaultRouter
 
-from .views import NodeViewSet, WorkflowViewSet
+from .views import (AnalysesViewSet, DataSetsViewSet, NodeGroups,
+                    NodeViewSet, WorkflowViewSet)
+
 
 urlpatterns = patterns(
     'core.views',
@@ -90,3 +92,14 @@ urlpatterns = patterns(
 core_router = DefaultRouter()
 core_router.register(r'nodes', NodeViewSet)
 core_router.register(r'workflows', WorkflowViewSet)
+core_router.urls.extend([
+    url(r'^node_groups/$', NodeGroups.as_view()),
+    url(r'^data_sets/(?P<uuid>'
+        r'[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{'
+        r''r'12})/$',
+        DataSetsViewSet.as_view()),
+    url(r'^analyses/(?P<uuid>'
+        r'[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{'
+        r''r'12})/$',
+        AnalysesViewSet.as_view())
+])

--- a/refinery/data_set_manager/urls.py
+++ b/refinery/data_set_manager/urls.py
@@ -7,8 +7,10 @@ Created on May 11, 2012
 from django.conf.urls import patterns, url
 from django.contrib.auth.decorators import login_required
 from django.views.decorators.csrf import csrf_exempt
+from rest_framework.routers import DefaultRouter
 
-from .views import (CheckDataFilesView, ChunkedFileUploadCompleteView,
+from .views import (Assays, AssaysAttributes, AssaysFiles, CheckDataFilesView,
+                    ChunkedFileUploadCompleteView,
                     ChunkedFileUploadView, DataSetImportView, ImportISATabView,
                     ProcessISATabView, ProcessMetadataTableView,
                     TakeOwnershipOfPublicDatasetView)
@@ -43,3 +45,15 @@ urlpatterns = patterns(
         name='take_ownership_of_public_dataset'),
 
 )
+
+# DRF url routing
+data_set_manager_router = DefaultRouter()
+data_set_manager_router.urls.extend([
+    url(r'^assays/$', Assays.as_view()),
+    url(r'^assays/(?P<uuid>'
+        r'[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{'
+        r''r'12})/files/$', AssaysFiles.as_view()),
+    url(r'^assays/(?P<uuid>'
+        r'[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{'
+        r''r'12})/attributes/$', AssaysAttributes.as_view()),
+])

--- a/refinery/file_store/urls.py
+++ b/refinery/file_store/urls.py
@@ -1,0 +1,12 @@
+from django.conf.urls import url
+from rest_framework.routers import DefaultRouter
+
+from file_store.views import FileStoreItems
+
+# DRF url routing
+file_store_router = DefaultRouter()
+file_store_router.urls.extend([
+    url(r'^file_store_items/(?P<uuid>'
+        r'[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{'
+        r''r'12})/$', FileStoreItems.as_view())
+])

--- a/refinery/tool_manager/urls.py
+++ b/refinery/tool_manager/urls.py
@@ -1,0 +1,6 @@
+from rest_framework.routers import DefaultRouter
+from .views import ToolDefinitionsViewSet
+
+# DRF url routing
+router = DefaultRouter()
+router.register(r'tools/definitions', ToolDefinitionsViewSet)

--- a/refinery/tool_manager/urls.py
+++ b/refinery/tool_manager/urls.py
@@ -2,5 +2,5 @@ from rest_framework.routers import DefaultRouter
 from .views import ToolDefinitionsViewSet
 
 # DRF url routing
-router = DefaultRouter()
-router.register(r'tools/definitions', ToolDefinitionsViewSet)
+tool_manager_router = DefaultRouter()
+tool_manager_router.register(r'tools/definitions', ToolDefinitionsViewSet)


### PR DESCRIPTION
Allows for individual apps to define their own DRF api urls rather than polluting `config/urls.py`