### PR TITLE
Require STACK_NAME in aws-config

### DIFF
--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -4,8 +4,7 @@ web.json: .PHONY
 	python stack.py > web.json
 
 web-stack: web.json .PHONY
-	TZ=UTC date +refinery-web-%Y%m%dT%H%M > aws-config/stack-name
-	aws cloudformation create-stack --capabilities CAPABILITY_IAM --stack-name $$(cat aws-config/stack-name) --template-body file://web.json
+	aws cloudformation create-stack --capabilities CAPABILITY_IAM --stack-name $$(python stack.py name) --template-body file://web.json
 
 volume.json: .PHONY
 	python volume_cfn.py > volume.json

--- a/deployment/aws-config/config.yaml.template
+++ b/deployment/aws-config/config.yaml.template
@@ -32,6 +32,10 @@
 SITE_NAME: Refinery
 SITE_URL: "192.168.50.50:8000"
 
+# STACK_NAME is used to name the stack
+# (in the Web UI and other places), and to name instances.
+STACK_NAME: "I forgot to set the stack name"
+
 # the AWS ARN for the TLS certifcate that you wish to present.
 # TLS_CERTIFICATE: "arn:aws:acm:--region--:--accountnumber--:certificate/--id--"
 

--- a/deployment/stack.py
+++ b/deployment/stack.py
@@ -26,8 +26,6 @@ Usually invoked via the Makefile: make web-stack
 # CloudInit
 #   https://help.ubuntu.com/community/CloudInit
 
-from __future__ import print_function
-
 import base64
 import datetime
 import json
@@ -60,7 +58,7 @@ def main(argv=None):
     # For now, just the "name" command,
     # which we plan to remove, when the Makefile goes.
     if len(argv) > 1 and argv[1] == "name":
-        print(stack_name)
+        sys.stdout.write("{}\n".format(stack_name))
         return 0
 
     # We discover the current git branch/commit so that the deployment script

--- a/deployment/stack.py
+++ b/deployment/stack.py
@@ -26,6 +26,8 @@ Usually invoked via the Makefile: make web-stack
 # CloudInit
 #   https://help.ubuntu.com/community/CloudInit
 
+from __future__ import print_function
+
 import base64
 import datetime
 import json
@@ -44,12 +46,22 @@ class ConfigError(Exception):
     pass
 
 
-def main():
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv
+
     config, config_yaml = load_config()
 
     derive_config(config)
 
-    unique_suffix = datetime.datetime.utcnow().strftime("%Y%m%dT%H%M")
+    stack_name = config['STACK_NAME']
+
+    # :todo: expand this into a proper command parser.
+    # For now, just the "name" command,
+    # which we plan to remove, when the Makefile goes.
+    if len(argv) > 1 and argv[1] == "name":
+        print(stack_name)
+        return 0
 
     # We discover the current git branch/commit so that the deployment script
     # can use it to clone the same commit
@@ -60,13 +72,13 @@ def main():
 
     instance_tags = load_tags()
 
-    # Set the `Name` as it appears on the EC2 web UI
+    # Stack Name is also used for instances.
     instance_tags.append({'Key': 'Name',
-                         'Value': "refinery-web-" + unique_suffix})
+                         'Value': stack_name})
 
     config['tags'] = instance_tags
 
-    config_uri = save_s3_config(config, unique_suffix)
+    config_uri = save_s3_config(config, stack_name)
     sys.stderr.write("Configuration saved to {}\n".format(config_uri))
 
     tls_rewrite = "false"
@@ -587,6 +599,7 @@ def report_missing_keys(config):
     """Collect and report list of missing keys"""
 
     required = [
+        'STACK_NAME',
         'KEY_NAME', 'RDS_SUPERUSER_PASSWORD', 'SITE_NAME', 'SITE_URL',
         'ADMIN_PASSWORD', 'AWS_STORAGE_BUCKET_NAME'
     ]


### PR DESCRIPTION
`STACK_NAME` is now required in aws-config.

And it is used to name the stack and the ec2 instances.

There is more to do here, this is just a start.
Quite a bit of this will change when we get rid of the `Makefile`.