### PR TITLE
Remove Makefile

### DIFF
--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -1,15 +1,3 @@
-# This is a real file, but it depends on the github checksum,
-# so we always want to build it. (and it's fast)
-web.json: .PHONY
-	python stack.py > web.json
-
-web-stack: web.json .PHONY
-	aws cloudformation create-stack --capabilities CAPABILITY_IAM --stack-name $$(python stack.py name) --template-body file://web.json
-
-volume.json: .PHONY
-	python volume_cfn.py > volume.json
-
-volume-stack: volume.json .PHONY
-	aws cloudformation create-stack --stack-name refinery-volume-$$(date +%Y%m%dT%H%M) --template-body file://volume.json
-
-.PHONY:
+web-stack:
+	echo 1>&2 "Deprecated. Instead run: python stack.py create"
+	python stack.py create

--- a/deployment/stack.py
+++ b/deployment/stack.py
@@ -52,14 +52,22 @@ def main(argv=None):
 
     derive_config(config)
 
-    stack_name = config['STACK_NAME']
-
     # :todo: expand this into a proper command parser.
     # For now, just the "name" command,
     # which we plan to remove, when the Makefile goes.
     if len(argv) > 1 and argv[1] == "name":
+        stack_name = config['STACK_NAME']
         sys.stdout.write("{}\n".format(stack_name))
         return 0
+
+    template = make_template(config, config_yaml)
+    return(sys.stdout.write(str(template)))
+
+def make_template(config, config_yaml):
+    """Make a fresh CloudFormation template object and return it.
+    """
+
+    stack_name = config['STACK_NAME']
 
     # We discover the current git branch/commit so that the deployment script
     # can use it to clone the same commit
@@ -466,7 +474,7 @@ def main(argv=None):
         }),
         core.DeletionPolicy('Retain')
     ))
-    sys.stdout.write(str(cft))
+    return cft
 
 
 def load_tags():

--- a/deployment/stack.py
+++ b/deployment/stack.py
@@ -72,12 +72,14 @@ def main(argv=None):
 
     if command == 'create':
         cloudformation = boto3.client("cloudformation")
-        response = cloudformation.create_stack(StackName=config['STACK_NAME'],
+        response = cloudformation.create_stack(
+            StackName=config['STACK_NAME'],
             TemplateBody=str(template),
             Capabilities=['CAPABILITY_IAM'],
         )
         sys.stdout.write(json.dumps(response, indent=2) + '\n')
         return 0
+
 
 def make_template(config, config_yaml):
     """Make a fresh CloudFormation template object and return it.

--- a/deployment/stack.py
+++ b/deployment/stack.py
@@ -52,16 +52,32 @@ def main(argv=None):
 
     derive_config(config)
 
+    command = ''
+
     # :todo: expand this into a proper command parser.
     # For now, just the "name" command,
     # which we plan to remove, when the Makefile goes.
-    if len(argv) > 1 and argv[1] == "name":
+    if len(argv) > 1:
+        command = argv[1]
+
+    if command == 'name':
         stack_name = config['STACK_NAME']
         sys.stdout.write("{}\n".format(stack_name))
         return 0
 
     template = make_template(config, config_yaml)
-    return(sys.stdout.write(str(template)))
+
+    if command == 'dump':
+        return(sys.stdout.write(str(template)))
+
+    if command == 'create':
+        cloudformation = boto3.client("cloudformation")
+        response = cloudformation.create_stack(StackName=config['STACK_NAME'],
+            TemplateBody=str(template),
+            Capabilities=['CAPABILITY_IAM'],
+        )
+        sys.stdout.write(json.dumps(response, indent=2) + '\n')
+        return 0
 
 def make_template(config, config_yaml):
     """Make a fresh CloudFormation template object and return it.


### PR DESCRIPTION
The `cloudformation create-stack` operation is moved into the Python script.

To create the stack:

`python stack.py create`

(the `Makefile` has been stubbed out, but works for old-timers like me; we can get rid of it soon)