### PR TITLE
Scottx611x/indexing updates

### DIFF
--- a/refinery/core/search_indexes.py
+++ b/refinery/core/search_indexes.py
@@ -76,6 +76,8 @@ class DataSetIndex(indexes.SearchIndex, indexes.Indexable):
                     "{}, {}".format(contact.last_name, contact.first_name)
                 )
 
+        # Cast to `list` looks redundant, but MultiValueField stores sets
+        # improperly, introducing a search bug. See: http://bit.ly/2pZLE5c
         return list(set(submitters))
 
     def prepare_measurement(self, object):
@@ -91,6 +93,8 @@ class DataSetIndex(indexes.SearchIndex, indexes.Indexable):
             for assay in study.assay_set.all():
                 measurements.append(assay.measurement)
 
+        # Cast to `list` looks redundant, but MultiValueField stores sets
+        # improperly, introducing a search bug. See: http://bit.ly/2pZLE5c
         return list(set(measurements))
 
     def prepare_technology(self, object):
@@ -106,6 +110,8 @@ class DataSetIndex(indexes.SearchIndex, indexes.Indexable):
             for assay in study.assay_set.all():
                 technologies.append(assay.technology)
 
+        # Cast to `list` looks redundant, but MultiValueField stores sets
+        # improperly, introducing a search bug. See: http://bit.ly/2pZLE5c
         return list(set(technologies))
 
     # from:

--- a/refinery/core/search_indexes.py
+++ b/refinery/core/search_indexes.py
@@ -65,13 +65,16 @@ class DataSetIndex(indexes.SearchIndex, indexes.Indexable):
         submitters = []
 
         for contact in investigation.contact_set.all():
-            submitters.append(contact.last_name + ", " + contact.first_name)
+            submitters.append(
+                "{}, {}".format(contact.last_name, contact.first_name)
+            )
 
         studies = investigation.study_set.all()
         for study in studies:
             for contact in study.contact_set.all():
                 submitters.append(
-                    contact.last_name + ", " + contact.first_name)
+                    "{}, {}".format(contact.last_name, contact.first_name)
+                )
 
         return set(submitters)
 

--- a/refinery/core/search_indexes.py
+++ b/refinery/core/search_indexes.py
@@ -26,7 +26,7 @@ class DataSetIndex(indexes.SearchIndex, indexes.Indexable):
     dbid = indexes.IntegerField(model_attr='id')
     uuid = indexes.CharField(model_attr='uuid')
     summary = indexes.CharField(model_attr='summary', null=True)
-    description = indexes.CharField(null=True)
+    description = indexes.EdgeNgramField(null=True)
     creation_date = indexes.DateTimeField(model_attr='creation_date')
     modification_date = indexes.DateTimeField(model_attr='modification_date')
     submitter = indexes.MultiValueField(null=True)

--- a/refinery/core/search_indexes.py
+++ b/refinery/core/search_indexes.py
@@ -76,7 +76,7 @@ class DataSetIndex(indexes.SearchIndex, indexes.Indexable):
                     "{}, {}".format(contact.last_name, contact.first_name)
                 )
 
-        return set(submitters)
+        return list(set(submitters))
 
     def prepare_measurement(self, object):
         investigation = object.get_investigation()
@@ -91,7 +91,7 @@ class DataSetIndex(indexes.SearchIndex, indexes.Indexable):
             for assay in study.assay_set.all():
                 measurements.append(assay.measurement)
 
-        return set(measurements)
+        return list(set(measurements))
 
     def prepare_technology(self, object):
         investigation = object.get_investigation()
@@ -106,7 +106,7 @@ class DataSetIndex(indexes.SearchIndex, indexes.Indexable):
             for assay in study.assay_set.all():
                 technologies.append(assay.technology)
 
-        return set(technologies)
+        return list(set(technologies))
 
     # from:
     # http://django-haystack.readthedocs.org/en/latest/rich_content_extraction.html

--- a/refinery/core/utils.py
+++ b/refinery/core/utils.py
@@ -21,6 +21,9 @@ from urlparse import urlparse, urljoin
 import core
 import data_set_manager
 
+from core.search_indexes import DataSetIndex
+from data_set_manager.search_indexes import NodeIndex
+
 logger = logging.getLogger(__name__)
 
 
@@ -44,8 +47,7 @@ def update_data_set_index(data_set):
 
     logger.info('Updated data set (uuid: %s) index', data_set.uuid)
     try:
-        core.search_indexes.DataSetIndex().update_object(data_set,
-                                                         using='core')
+        DataSetIndex().update_object(data_set, using='core')
     except Exception as e:
         """ Solr is expected to fail and raise an exception when
         it is not running.
@@ -355,8 +357,7 @@ def delete_data_set_index(data_set):
 
     logger.debug('Deleted data set (uuid: %s) index', data_set.uuid)
     try:
-        core.search_indexes.DataSetIndex().remove_object(data_set,
-                                                         using='core')
+        DataSetIndex().remove_object(data_set, using='core')
     except Exception as e:
         """ Solr is expected to fail and raise an exception when
         it is not running.
@@ -754,8 +755,7 @@ def delete_analysis_index(node_instance):
     """Remove a Analysis' related document from Solr's index.
     """
     try:
-        data_set_manager.search_indexes.NodeIndex().remove_object(
-            node_instance, using='data_set_manager')
+        NodeIndex().remove_object(node_instance, using='data_set_manager')
         logger.debug('Deleted Analysis\' NodeIndex with (uuid: %s)',
                      node_instance.uuid)
     except Exception as e:
@@ -763,7 +763,7 @@ def delete_analysis_index(node_instance):
         it is not running.
         (e.g. Travis CI doesn't support solr yet)
         """
-        logger.error("Could not delete from NodeIndex:", e)
+        logger.error("Could not delete from NodeIndex: %s", e)
 
 
 def invalidate_cached_object(instance, is_test=False):

--- a/refinery/core/utils.py
+++ b/refinery/core/utils.py
@@ -21,6 +21,8 @@ from urlparse import urlparse, urljoin
 import core
 import data_set_manager
 
+# These imports go against our coding style guide, but are necessary for the
+#  time being due to mutual import issues
 from core.search_indexes import DataSetIndex
 from data_set_manager.search_indexes import NodeIndex
 

--- a/refinery/solr/core/conf/schema.xml
+++ b/refinery/solr/core/conf/schema.xml
@@ -118,6 +118,21 @@
         <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1" splitOnNumerics="0"/>
       </analyzer>
     </fieldType>
+
+     <fieldType name="description_edge_ngram" class="solr.TextField" positionIncrementGap="1">
+      <analyzer type="index">
+        <tokenizer class="solr.WhitespaceTokenizerFactory" />
+        <filter class="solr.LowerCaseFilterFactory" />
+        <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1" splitOnNumerics="0"/>
+        <filter class="solr.EdgeNGramFilterFactory" minGramSize="3" maxGramSize="15" />
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.WhitespaceTokenizerFactory" />
+        <filter class="solr.LowerCaseFilterFactory" />
+        <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1" splitOnNumerics="0"/>
+        <filter class="solr.EdgeNGramFilterFactory" minGramSize="3" maxGramSize="15" />
+      </analyzer>
+    </fieldType>
   </types>
 
   <fields>
@@ -168,7 +183,7 @@
 
     <field name="name" type="text_en" indexed="true" stored="true" multiValued="false" />
 
-    <field name="description" type="edge_ngram" indexed="true" stored="true" multiValued="false" />
+    <field name="description" type="description_edge_ngram" indexed="true" stored="true" multiValued="false" />
 
     <field name="content_auto" type="edge_ngram" indexed="true" stored="true" multiValued="false" />
 

--- a/refinery/solr/core/conf/schema.xml
+++ b/refinery/solr/core/conf/schema.xml
@@ -168,7 +168,7 @@
 
     <field name="name" type="text_en" indexed="true" stored="true" multiValued="false" />
 
-    <field name="description" type="text_en" indexed="true" stored="true" multiValued="false" />
+    <field name="description" type="edge_ngram" indexed="true" stored="true" multiValued="false" />
 
     <field name="content_auto" type="edge_ngram" indexed="true" stored="true" multiValued="false" />
 

--- a/refinery/ui/source/js/commons/data-sets/search-api.js
+++ b/refinery/ui/source/js/commons/data-sets/search-api.js
@@ -37,7 +37,7 @@ function DataSetSearchApiFactory ($sce, settings, solrService, sessionService) {
           // Query
           q: searchQuery,
           // Query fields
-          qf: 'title^0.5 accession submitter text',
+          qf: 'title^0.5 accession submitter text description',
           // # results returned
           rows: limit,
           // Start of return

--- a/refinery/ui/source/js/commons/data-sets/search-api.spec.js
+++ b/refinery/ui/source/js/commons/data-sets/search-api.spec.js
@@ -68,7 +68,7 @@ describe('DataSet.search-api: unit tests', function () {
       'hl.simple.post': '%3C%2Fem%3E',
       'hl.simple.pre': '%3Cem%3E',
       q: _query,
-      qf: 'title%5E0.5+accession+submitter+text',
+      qf: 'title%5E0.5+accession+submitter+text+description',
       rows: _limit,
       start: _offset,
       synonyms: '' + !!_synonyms + '',


### PR DESCRIPTION
- Change `description` to an `EdgeNgramField` for better Dataset Description search by tokenizing on whitespace
- Fix `'module' object has no attribute 'search_indexes'` error to allow DataSet indexing to work again
- Add description to solr query fields
- Addresses: #1702
- Addresses: #1703 

Once merged a `./manage.py rebuild_index --using=core --batch-size=25` will need to be run