### PR TITLE
Scottx611x/update index on post save

### DIFF
--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -827,8 +827,9 @@ def _dataset_delete(sender, instance, *args, **kwargs):
 
 
 @receiver(post_save, sender=DataSet)
-def _dataset_saved(**kwargs):
+def _dataset_saved(sender, instance, *args, **kwargs):
     update_annotation_sets_neo4j()
+    update_data_set_index(instance)
 
 
 class InvestigationLink(models.Model):

--- a/refinery/core/tests.py
+++ b/refinery/core/tests.py
@@ -1898,8 +1898,8 @@ class DataSetResourceTest(ResourceTestCase):
         self.assertEqual(data['analyses'], [])
 
 
-class DataSetClassMethodsTest(TestCase):
-    """ Testing of methods specific to the DataSet model
+class DataSetTests(TestCase):
+    """ Testing of the DataSet model
     """
 
     def setUp(self):
@@ -1973,6 +1973,20 @@ class DataSetClassMethodsTest(TestCase):
         self.assertIn(self.file_store_item, file_store_items)
         self.assertIn(self.file_store_item1, file_store_items)
         self.assertIn(self.file_store_item2, file_store_items)
+
+    def test_neo4j_called_on_post_save(self):
+        with mock.patch(
+            "core.models.update_annotation_sets_neo4j"
+        ) as neo4j_mock:
+            self.dataset.save()
+            self.assertTrue(neo4j_mock.called)
+
+    def test_solr_called_on_post_save(self):
+        with mock.patch(
+            "core.models.update_data_set_index"
+        ) as solr_mock:
+            self.dataset.save()
+            self.assertTrue(solr_mock.called)
 
 
 class DataSetApiV2Tests(APITestCase):


### PR DESCRIPTION
While playing around with the DataSets2 Details tab, I noticed that the editing functionality works great, except that I was not able to search for the information that I just edited in the Dashboard search bar.

The same scenario occurs when editing a dataset's info in the admin UI.

Adding a call to `update_data_set_index` in the `post_save` signal handler addresses this issue.