### PR TITLE
Try installing the latest NPM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ services:
   - neo4j
   - docker
 
+before_install:
+  - npm --version
+  - npm install -g npm@5.0.3
 install:
   - pip install -r requirements.txt --quiet
   # Install geckodriver required for selenium testing


### PR DESCRIPTION
Towards #1768.

[Travis has been running npm 2.14.4](https://travis-ci.org/refinery-platform/refinery-platform/builds/240132244#L292-L297):
```
$ npm --version
2.14.4
$ npm install -g npm@5.0.3
-e/travis/.nvm/versions/node/v4.1.2/bin/npm -> /home/travis/.nvm/versions/node/v4.1.2/lib/node_modules/npm/bin/npm-cli.js
npm@5.0.3 /home/travis/.nvm/versions/node/v4.1.2/lib/node_modules/npm
```

Some folks seem to have success upgrading just npm, others believe that upgrading node made the difference. I would suggest just doing this, for now, waiting a few weeks to see if you still have these errors, and then judge whether we should also try upgrading node itself, and/or reverting this.

Related: https://github.com/npm/npm/issues/9418 https://github.com/npm/npm/issues/12484 https://github.com/npm/registry/issues/10

