### PR TITLE
isort prehook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,8 @@
     hooks:
     -   id: eslint
         files: ui/source/js/.+\.js
+
+-   repo: git://github.com/hvdklauw/pre-commit-isort
+    sha: 3cddb8006cd2188e4af72454f2faeec25b040821
+    hooks:
+    -   id: isort

--- a/refinery/user_files_manager/tests.py
+++ b/refinery/user_files_manager/tests.py
@@ -2,7 +2,6 @@ import logging
 
 from django.test import TestCase
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/refinery/user_files_manager/urls.py
+++ b/refinery/user_files_manager/urls.py
@@ -1,5 +1,4 @@
 from django.conf.urls import url
-
 from rest_framework.routers import DefaultRouter
 
 from .views import UserFiles

--- a/refinery/user_files_manager/views.py
+++ b/refinery/user_files_manager/views.py
@@ -2,7 +2,6 @@ import logging
 
 from data_set_manager.utils import (format_solr_response,
                                     generate_solr_params_for_user, search_solr)
-
 from django.shortcuts import render_to_response
 from django.template import RequestContext
 

--- a/refinery/user_files_manager/views.py
+++ b/refinery/user_files_manager/views.py
@@ -4,7 +4,6 @@ from data_set_manager.utils import (format_solr_response,
                                     generate_solr_params_for_user, search_solr)
 from django.shortcuts import render_to_response
 from django.template import RequestContext
-
 from rest_framework.response import Response
 from rest_framework.views import APIView
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ enum34==1.0.4
 factory_boy==2.8.1
 flake8==2.5.4
 flower==0.9.1
+isort==4.2.15
 Jinja2==2.6
 jsonpickle==0.4.0
 jsonschema==2.6.0


### PR DESCRIPTION
Fix #1770

Developers will need to install `isort`: With the default settings, the imports are sorted in place, and the pre-commit will fail, and you then need to `git add` and `git commit` again. 

There are a lot of [config options](https://github.com/timothycrosley/isort/wiki/isort-Settings), but there doesn't seem to be a way to keep our blank lines between libraries.

It seems that this only checks the files which were touched in the commit. I don't think it would be that useful to do a bulk reformat of everything retrospectively. I've touched the files under `user_files_manager` just as a demonstration.

I think the increment of build complexity is worth not having to worry about import order, but it's not really a big gain, either.