### PR TITLE
Upgrade node and npm. Hopefully fix NPM failures? Fix #1768

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,10 @@ services:
   - postgresql
   - neo4j
   - docker
-
 install:
+  # If Travis does not have a current npm, install.
+  # (If it does, exit: This line should then be removed.)
+  - if [[ `npm -v` != 5.* ]]; then npm install -g npm@5; else exit 1; fi
   - pip install -r requirements.txt --quiet
   # Install geckodriver required for selenium testing
   - GECKODRIVER_VERSION=v0.15.0

--- a/deployment/refinery-modules/refinery/manifests/init.pp
+++ b/deployment/refinery-modules/refinery/manifests/init.pp
@@ -82,7 +82,7 @@ class ui {
   apt::source { 'nodejs':
     ensure      => 'present',
     comment     => 'Nodesource NodeJS repo.',
-    location    => 'https://deb.nodesource.com/node_6.x',
+    location    => 'https://deb.nodesource.com/node_8.x',
     release     => 'trusty',
     repos       => 'main',
     key         => {


### PR DESCRIPTION
Here are the corresponding node and npm versions: https://nodejs.org/en/download/releases/

The Travis line wouldn't need to be so complicated, but I want to be sure that we remove it when it is no longer needed.