### PR TITLE
Scottx611x/tool manager updates

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -11,6 +11,7 @@ known_first_party =
     file_server,
     file_store,
     galaxy_connector,
+    selenium_testing,
     tool_manager,
     user_files_manager,
     visualization_manager,

--- a/refinery/selenium_testing/utils.py
+++ b/refinery/selenium_testing/utils.py
@@ -1,11 +1,33 @@
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as ec
+from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from pyvirtualdisplay import Display
+from selenium import webdriver
 from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as ec
+from selenium.webdriver.support.ui import WebDriverWait
 
 # The maximum amount of time that we allow an ExpectedCondition to wait
 # before timing out.
 MAX_WAIT = 60
+
+
+class SeleniumTestBaseGeneric(StaticLiveServerTestCase):
+    """Base class to be used for all selenium-based tests"""
+
+    # Don't delete data migration data after test runs: http://bit.ly/2lAYqVJ
+    serialized_rollback = True
+
+    def setUp(self):
+        self.display = Display(visible=0, size=(1366, 768))
+        self.display.start()
+        self.browser = webdriver.Firefox()
+        self.browser.maximize_window()
+
+    def tearDown(self):
+        # NOTE: quit() destroys ANY currently running webdriver instances.
+        # This could become an issue if tests are ever run in parallel.
+        self.browser.quit()
+        self.display.stop()
 
 
 def login(selenium, live_server_url):

--- a/refinery/tool_manager/migrations/0018_auto_20170615_1629.py
+++ b/refinery/tool_manager/migrations/0018_auto_20170615_1629.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tool_manager', '0017_tooldefinition_extra_directories'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='tool',
+            old_name='file_relationships',
+            new_name='tool_launch_configuration',
+        ),
+        migrations.RemoveField(
+            model_name='tool',
+            name='parameters',
+        ),
+        migrations.RemoveField(
+            model_name='tooldefinition',
+            name='extra_directories',
+        ),
+        migrations.AddField(
+            model_name='tooldefinition',
+            name='annotation',
+            field=models.TextField(default='{}'),
+            preserve_default=False,
+        ),
+    ]

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -1,4 +1,5 @@
 import ast
+import json
 import logging
 import re
 
@@ -8,11 +9,9 @@ from django.db.models.signals import post_delete, pre_delete
 from django.dispatch import receiver
 from django.http import (HttpResponseBadRequest, HttpResponseServerError,
                          JsonResponse)
-
-from django_extensions.db.fields import UUIDField
 from django_docker_engine.docker_utils import (DockerClientWrapper,
                                                DockerContainerSpec)
-
+from django_extensions.db.fields import UUIDField
 from docker.errors import APIError
 
 from core.models import Analysis, OwnableResource, WorkflowEngine
@@ -161,10 +160,7 @@ class ToolDefinition(models.Model):
         max_length=500,
         blank=True
     )
-    extra_directories = models.CharField(
-        max_length=500,
-        blank=True
-    )
+    annotation = models.TextField()
     galaxy_workflow_id = models.CharField(
         max_length=250,
         blank=True
@@ -173,6 +169,20 @@ class ToolDefinition(models.Model):
 
     def __str__(self):
         return "{}: {} {}".format(self.tool_type, self.name, self.uuid)
+
+    def get_annotation(self):
+        return json.loads(self.annotation)
+
+    def get_extra_directories(self):
+        if self.tool_type == ToolDefinition.VISUALIZATION:
+            try:
+                return self.get_annotation()["extra_directories"]
+            except KeyError:
+                logger.error("ToolDefinition: %s's annotation is missing its "
+                             "`extra_directories` key.", self.name)
+                raise
+        else:
+            raise NotImplementedError
 
 
 @receiver(pre_delete, sender=ToolDefinition)
@@ -228,8 +238,7 @@ class Tool(OwnableResource):
         unique=True,
         blank=True
     )
-    file_relationships = models.TextField()
-    parameters = models.TextField()
+    tool_launch_configuration = models.TextField()
     tool_definition = models.ForeignKey(ToolDefinition)
 
     class Meta:
@@ -254,13 +263,9 @@ class Tool(OwnableResource):
                 container_input_path=(
                     self.tool_definition.container_input_path
                 ),
-                input={
-                    "file_relationships": ast.literal_eval(
-                        self.file_relationships
-                    )
-                },
-                extra_directories=ast.literal_eval(
-                    self.tool_definition.extra_directories
+                input={"file_relationships": self.get_file_relationships()},
+                extra_directories=(
+                    self.tool_definition.get_extra_directories()
                 )
             )
             try:
@@ -288,11 +293,23 @@ class Tool(OwnableResource):
             self.container_name
         )
 
+    def get_tool_launch_config(self):
+        return json.loads(self.tool_launch_configuration)
+
+    def get_file_relationships(self):
+        return ast.literal_eval(
+            self.get_tool_launch_config()["file_relationships"]
+        )
+
     def get_tool_name(self):
         return self.tool_definition.name
 
     def get_tool_type(self):
         return self.tool_definition.tool_type
+
+    def set_tool_launch_config(self, tool_launch_config):
+        self.tool_launch_configuration = json.dumps(tool_launch_config)
+        self.save()
 
     def update_file_relationships_string(self):
         """
@@ -300,19 +317,22 @@ class Tool(OwnableResource):
         their respective FileStoreItem's urls. No error handling here since
         this method is only called in an atomic transaction.
         """
+
+        tool_launch_config = self.get_tool_launch_config()
+
         node_uuids = re.findall(
             r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}',
-            self.file_relationships
+            tool_launch_config["file_relationships"]
         )
 
         for uuid in node_uuids:
             file_url = get_file_url_from_node_uuid(uuid)
-            self.file_relationships = self.file_relationships.replace(
-                uuid,
-                "'{}'".format(file_url)
+            tool_launch_config["file_relationships"] = (
+                tool_launch_config["file_relationships"].replace(
+                    uuid, "'{}'".format(file_url)
+                )
             )
-
-        self.save()
+        self.set_tool_launch_config(tool_launch_config)
 
 
 @receiver(pre_delete, sender=Tool)

--- a/refinery/tool_manager/test_data/workflows/LIST:PAIR:LIST.json
+++ b/refinery/tool_manager/test_data/workflows/LIST:PAIR:LIST.json
@@ -1,0 +1,61 @@
+{ "name": "Test LIST:PAIR:LIST",
+  "tool_type": "WORKFLOW",
+  "galaxy_workflow_id": "66b2fe95-9250-425d-86ae-5953c1d6e5b6",
+  "annotation": {
+    "refinery_type": "analysis",
+    "description": "This workflow has a nested LIST of PAIRs of LISTs",
+    "parameters": [
+       {
+        "name": "Integer Param",
+        "description": "Integer Param description",
+        "value_type": "INTEGER",
+        "default_value": 1337,
+        "galaxy_workflow_step": 1
+      },
+      {
+        "name": "Attribute Param",
+        "description": "Attribute Param description",
+        "value_type": "ATTRIBUTE",
+        "default_value": "Species",
+        "galaxy_workflow_step": 4
+      },
+      {
+        "name": "File Param",
+        "description": "File Param description",
+        "value_type": "FILE",
+        "default_value": "/media/file_store/file.cool",
+        "galaxy_workflow_step": 5
+      }
+    ],
+    "output_files": [
+      {
+        "filetype": {"name": "FASTQ"},
+        "name": "Cool Input File",
+        "description": "Cool Input File Description"
+      }
+    ],
+    "file_relationship": {
+      "value_type": "LIST",
+      "name": "List of Pairs",
+      "file_relationship": {
+        "value_type": "PAIR",
+        "name": "Pair of Lists",
+        "file_relationship": {
+          "file_relationship": {},
+          "value_type": "LIST",
+          "name": "Lists",
+          "input_files": [
+            {
+              "allowed_filetypes": [
+                {"name": "FASTQ"},
+                {"name": "BAM"}
+              ],
+              "name": "Cool Input Files",
+              "description": "Cool Input Files Description"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -65,7 +65,7 @@ class ToolManagerTestBase(TestCase):
             }
         )
 
-        self.tools_url_root = '/api/v2/tools'
+        self.tools_url_root = '/api/v2/tools/'
         self.tool_defs_url_root = '/api/v2/tool_definitions/'
 
     def tearDown(self):

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -1,64 +1,153 @@
 import json
 import logging
-import uuid
-
-import mock
 import re
 import StringIO
 import time
+import uuid
 from urlparse import urljoin
 
+import mock
 from django.contrib.auth.models import User
-from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.core.files.uploadedfile import InMemoryUploadedFile
-from django.core.management import call_command, CommandError
-from django.http import HttpResponseBadRequest
+from django.core.management import CommandError, call_command
+from django.http import HttpResponseBadRequest, JsonResponse
 from django.test import TestCase
-
-from pyvirtualdisplay import Display
 from rest_framework.test import (APIRequestFactory, APITestCase,
                                  force_authenticate)
-from selenium import webdriver
+from selenium_testing.utils import (MAX_WAIT, SeleniumTestBaseGeneric,
+                                    wait_until_class_visible)
 
 from core.models import (DataSet, ExtendedGroup, InvestigationLink,
                          WorkflowEngine)
-
 from data_set_manager.models import Assay, Investigation, Node, Study
 from file_store.models import FileStoreItem
 from galaxy_connector.models import Instance
-from selenium_testing.utils import MAX_WAIT, wait_until_class_visible
 
-from .models import (FileRelationship, GalaxyParameter, InputFile,
-                     OutputFile, Parameter, Tool, ToolDefinition)
-from .utils import (create_tool,
-                    create_tool_definition,
-                    FileTypeValidationError,
-                    validate_tool_annotation,
-                    validate_workflow_step_annotation,
-                    validate_tool_launch_configuration)
-from .views import (ToolDefinitionsViewSet, ToolsViewSet)
+from .models import (FileRelationship, GalaxyParameter, InputFile, OutputFile,
+                     Parameter, Tool, ToolDefinition)
+from .utils import (FileTypeValidationError, create_tool,
+                    create_tool_definition, validate_tool_annotation,
+                    validate_tool_launch_configuration,
+                    validate_workflow_step_annotation)
+from .views import ToolDefinitionsViewSet, ToolsViewSet
 
 logger = logging.getLogger(__name__)
 TEST_DATA_PATH = "tool_manager/test_data"
 
 
-class ToolDefinitionAPITests(APITestCase):
+class ToolManagerTestBase(TestCase):
     def setUp(self):
-        self.public_group_name = ExtendedGroup.objects.public_group().name
-        self.username = 'coffee_lover'
-        self.password = 'coffeecoffee'
-        self.user = User.objects.create_user(self.username, '',
-                                             self.password)
-
-        self.factory = APIRequestFactory()
-        self.view = ToolDefinitionsViewSet.as_view({'get': 'list'})
-
-        self.url_root = '/api/v2/tool_definitions/'
-
         self.galaxy_instance = Instance.objects.create()
         self.workflow_engine = WorkflowEngine.objects.create(
             instance=self.galaxy_instance
         )
+
+        self.public_group_name = ExtendedGroup.objects.public_group().name
+        self.mock_vis_annotations_reference = (
+            "tool_manager.management.commands.generate_tool_definitions"
+            ".get_visualization_annotations_list"
+        )
+
+        self.username = 'coffee_lover'
+        self.password = 'coffeecoffee'
+        self.user = User.objects.create_user(self.username, '', self.password)
+        self.factory = APIRequestFactory()
+        self.tools_view = ToolsViewSet.as_view(
+            {
+                'get': 'list',
+                'post': 'create'
+            }
+        )
+        self.tool_defs_view = ToolDefinitionsViewSet.as_view(
+            {
+                'get': 'list',
+                'post': 'create'
+            }
+        )
+
+        self.tools_url_root = '/api/v2/tools'
+        self.tool_defs_url_root = '/api/v2/tool_definitions/'
+
+    def tearDown(self):
+        # Trigger the pre_delete signal so that datafiles are purged
+        FileStoreItem.objects.all().delete()
+
+    def create_valid_tool_definition(self):
+        with open("{}/visualizations/igv.json".format(TEST_DATA_PATH)) as f:
+            self.td = create_tool_definition(json.loads(f.read()))
+
+    def create_valid_tool(self):
+        self.create_valid_tool_definition()
+        # Create mock ToolLaunchConfiguration
+        self.post_data = {
+            "tool_definition_uuid": self.td.uuid,
+            "file_relationships":
+                "['http://www.example.com/tool_manager/test_data/sample.seg']",
+        }
+
+        self.post_request = self.factory.post(
+            self.tools_url_root,
+            data=self.post_data,
+            format="json"
+        )
+        force_authenticate(self.post_request, self.user)
+
+        with mock.patch(
+                "django_docker_engine.docker_utils.DockerClientWrapper.run"
+        ) as run_mock:
+            self.post_response = self.tools_view(self.post_request)
+            self.assertTrue(run_mock.called)
+
+        self.tool_launch = Tool.objects.get(
+            tool_definition__uuid=self.td.uuid
+        )
+
+        self.get_request = self.factory.get(self.tools_url_root)
+        force_authenticate(self.get_request, self.user)
+        self.get_response = self.tools_view(self.get_request)
+
+        self.tool_json = self.get_response.data[0]
+
+        self.delete_request = self.factory.delete(
+            urljoin(self.tools_url_root, self.tool_json['uuid']))
+        force_authenticate(self.delete_request, self.user)
+        self.delete_response = self.tools_view(self.delete_request)
+        self.put_request = self.factory.put(
+            self.tools_url_root,
+            data=self.tool_json,
+            format="json"
+        )
+        force_authenticate(self.put_request, self.user)
+        self.put_response = self.tools_view(self.put_request)
+        self.options_request = self.factory.options(
+            self.tools_url_root,
+            data=self.tool_json,
+            format="json"
+        )
+        force_authenticate(self.options_request, self.user)
+        self.options_response = self.tools_view(self.options_request)
+
+    def create_vis_tool_definition(self):
+        self.tool_annotation = "{}/visualizations/igv.json".format(
+            TEST_DATA_PATH)
+        with open(self.tool_annotation) as f:
+            self.tool_annotation_json = json.loads(f.read())
+            self.td = create_tool_definition(self.tool_annotation_json)
+
+    def create_workflow_tool_definition(self):
+        self.tool_annotation = "{}/workflows/LIST.json".format(TEST_DATA_PATH)
+
+        with open(self.tool_annotation) as f:
+            self.tool_annotation_data = json.loads(f.read())
+            self.tool_annotation_data["workflow_engine_uuid"] = (
+                self.workflow_engine.uuid
+            )
+            self.td = create_tool_definition(self.tool_annotation_data)
+
+
+class ToolDefinitionAPITests(ToolManagerTestBase, APITestCase):
+    def setUp(self):
+        super(ToolDefinitionAPITests, self).setUp()
 
         # Make some sample data
         with open(
@@ -82,37 +171,37 @@ class ToolDefinitionAPITests(APITestCase):
             create_tool_definition(tool_annotation)
 
         # Make reusable requests & responses
-        self.get_request = self.factory.get(self.url_root)
+        self.get_request = self.factory.get(self.tool_defs_url_root)
         force_authenticate(self.get_request, self.user)
-        self.get_response = self.view(self.get_request)
+        self.get_response = self.tool_defs_view(self.get_request)
 
         self.tool_json = self.get_response.data[0]
 
         self.delete_request = self.factory.delete(
-            urljoin(self.url_root, self.tool_json['uuid']))
+            urljoin(self.tool_defs_url_root, self.tool_json['uuid']))
         force_authenticate(self.delete_request, self.user)
-        self.delete_response = self.view(self.delete_request)
+        self.delete_response = self.tool_defs_view(self.delete_request)
         self.put_request = self.factory.put(
-            self.url_root,
+            self.tool_defs_url_root,
             data=self.tool_json,
             format="json"
         )
         force_authenticate(self.put_request, self.user)
-        self.put_response = self.view(self.put_request)
+        self.put_response = self.tool_defs_view(self.put_request)
         self.post_request = self.factory.post(
-            self.url_root,
+            self.tool_defs_url_root,
             data=self.tool_json,
             format="json"
         )
         force_authenticate(self.post_request, self.user)
-        self.post_response = self.view(self.post_request)
+        self.post_response = self.tool_defs_view(self.post_request)
         self.options_request = self.factory.options(
-            self.url_root,
+            self.tool_defs_url_root,
             data=self.tool_json,
             format="json"
         )
         force_authenticate(self.options_request, self.user)
-        self.options_response = self.view(self.options_request)
+        self.options_response = self.tool_defs_view(self.options_request)
 
     def test_tool_definitions_exist(self):
         self.assertEqual(ToolDefinition.objects.count(), 4)
@@ -133,8 +222,8 @@ class ToolDefinitionAPITests(APITestCase):
         self.assertIsNotNone(self.get_response)
 
     def test_get_request_no_auth(self):
-        self.get_request = self.factory.get(self.url_root)
-        self.get_response = self.view(self.get_request)
+        self.get_request = self.factory.get(self.tool_defs_url_root)
+        self.get_response = self.tool_defs_view(self.get_request)
         self.assertEqual(self.get_response.status_code, 403)
 
     def test_unallowed_http_verbs(self):
@@ -162,17 +251,7 @@ class ToolDefinitionAPITests(APITestCase):
                     self.assertNotIn("galaxy_workflow_step", parameter.keys())
 
 
-class ToolDefinitionGenerationTests(TestCase):
-    def setUp(self):
-        self.mock_vis_annotations_reference = (
-            "tool_manager.management.commands.generate_tool_definitions"
-            ".get_visualization_annotations_list"
-        )
-        self.galaxy_instance = Instance.objects.create()
-        self.workflow_engine = WorkflowEngine.objects.create(
-            instance=self.galaxy_instance
-        )
-
+class ToolDefinitionGenerationTests(ToolManagerTestBase):
     def test_tool_definition_model_str(self):
         with open("{}/visualizations/igv.json".format(TEST_DATA_PATH)) as f:
             tool_annotation = [json.loads(f.read())]
@@ -670,24 +749,30 @@ class ToolDefinitionGenerationTests(TestCase):
             self.assertEqual(ToolDefinition.objects.count(), 0)
 
 
-class ToolTests(TestCase):
-    def setUp(self):
-        self.mock_vis_annotations_reference = (
-            "tool_manager.management.commands.generate_tool_definitions"
-            ".get_visualization_annotations_list"
+class ToolDefinitionTests(ToolManagerTestBase):
+    # Some members in assertions are truncated if they are too long, but we
+    # want to test them in their entirety
+    maxDiff = None
+
+    def test_get_annotation(self):
+        self.create_vis_tool_definition()
+        self.assertEqual(self.td.get_annotation(),
+                         self.tool_annotation_json["annotation"])
+
+    def test_get_extra_directories_vis_tool_def(self):
+        self.create_vis_tool_definition()
+        self.assertEqual(
+            self.td.get_extra_directories(),
+            ["/refinery-data"]
         )
 
-        self.username = 'coffee_lover'
-        self.password = 'coffeecoffee'
-        self.user = User.objects.create_user(self.username, '', self.password)
-        self.factory = APIRequestFactory()
-        self.view = ToolsViewSet.as_view({'post': 'create'})
-        self.url_root = '/api/v2/tools'
+    def test_get_extra_directories_workflow_tool_def(self):
+        self.create_workflow_tool_definition()
+        with self.assertRaises(NotImplementedError):
+            self.td.get_extra_directories()
 
-    def tearDown(self):
-        # Trigger the pre_delete signal so that datafiles are purged
-        FileStoreItem.objects.all().delete()
 
+class ToolTests(ToolManagerTestBase):
     def test_tool_model_str(self):
         with open("{}/visualizations/igv.json".format(TEST_DATA_PATH)) as f:
             tool_annotation = [json.loads(f.read())]
@@ -706,7 +791,7 @@ class ToolTests(TestCase):
             "file_relationships": "['www.example.com/cool_file.txt']"
         }
         post_request = self.factory.post(
-            self.url_root,
+            self.tools_url_root,
             data=post_data,
             format="json"
         )
@@ -716,7 +801,7 @@ class ToolTests(TestCase):
         with mock.patch(
                 "django_docker_engine.docker_utils.DockerClientWrapper.run"
         ) as run_mock:
-            self.post_response = self.view(post_request)
+            self.post_response = self.tools_view(post_request)
             self.assertTrue(run_mock.called)
 
         tool = Tool.objects.get(
@@ -743,7 +828,7 @@ class ToolTests(TestCase):
             "file_relationships": "['www.example.com/cool_file.txt']"
         }
         post_request = self.factory.post(
-            self.url_root,
+            self.tools_url_root,
             data=post_data,
             format="json"
         )
@@ -753,7 +838,7 @@ class ToolTests(TestCase):
         with mock.patch(
                 "django_docker_engine.docker_utils.DockerClientWrapper.run"
         ) as run_mock:
-            self.view(post_request)
+            self.tools_view(post_request)
             self.assertTrue(run_mock.called)
 
         with mock.patch(
@@ -833,7 +918,7 @@ class ToolTests(TestCase):
             )
         }
         post_request = self.factory.post(
-            self.url_root,
+            self.tools_url_root,
             data=post_data,
             format="json"
         )
@@ -843,14 +928,14 @@ class ToolTests(TestCase):
         with mock.patch(
                 "django_docker_engine.docker_utils.DockerClientWrapper.run"
         ) as run_mock:
-            self.post_response = self.view(post_request)
+            self.post_response = self.tools_view(post_request)
             self.assertTrue(run_mock.called)
 
         tool_launch = Tool.objects.get(
             tool_definition__uuid=td.uuid
         )
 
-        file_relationships = eval(tool_launch.file_relationships)
+        file_relationships = tool_launch.get_file_relationships()
 
         # Build regex and assert that the file_relationships structure is
         # populated from the FileStoreItem's datafiles that we've associated
@@ -859,79 +944,13 @@ class ToolTests(TestCase):
         for url in file_relationships:
             self.assertIsNotNone(regex.search(url))
 
+    def test_get_tool_launch_config(self):
+        self.create_valid_tool()
 
-class ToolAPITests(APITestCase):
-    def setUp(self):
-        self.public_group_name = ExtendedGroup.objects.public_group().name
-        self.username = 'coffee_lover'
-        self.password = 'coffeecoffee'
-        self.user = User.objects.create_user(self.username, '',
-                                             self.password)
 
-        self.factory = APIRequestFactory()
-        self.view = ToolsViewSet.as_view(
-            {
-                'get': 'list',
-                'post': 'create'
-            }
-        )
-
-        self.url_root = '/api/v2/tools/'
-
-        # Make some sample data
-        with open("{}/visualizations/igv.json".format(TEST_DATA_PATH)) as f:
-            self.td = create_tool_definition(json.loads(f.read()))
-
-        # Create mock ToolLaunchConfiguration
-        self.post_data = {
-            "tool_definition_uuid": self.td.uuid,
-            "file_relationships":
-                "['http://www.example.com/tool_manager/test_data/sample.seg']",
-        }
-
-        self.post_request = self.factory.post(
-            self.url_root,
-            data=self.post_data,
-            format="json"
-        )
-        force_authenticate(self.post_request, self.user)
-
-        with mock.patch(
-                "django_docker_engine.docker_utils.DockerClientWrapper.run"
-        ) as run_mock:
-            self.post_response = self.view(self.post_request)
-            self.assertTrue(run_mock.called)
-
-        self.tool_launch = Tool.objects.get(
-            tool_definition__uuid=self.td.uuid
-        )
-
-        self.get_request = self.factory.get(self.url_root)
-        force_authenticate(self.get_request, self.user)
-        self.get_response = self.view(self.get_request)
-
-        self.tool_json = self.get_response.data[0]
-
-        self.delete_request = self.factory.delete(
-            urljoin(self.url_root, self.tool_json['uuid']))
-        force_authenticate(self.delete_request, self.user)
-        self.delete_response = self.view(self.delete_request)
-        self.put_request = self.factory.put(
-            self.url_root,
-            data=self.tool_json,
-            format="json"
-        )
-        force_authenticate(self.put_request, self.user)
-        self.put_response = self.view(self.put_request)
-        self.options_request = self.factory.options(
-            self.url_root,
-            data=self.tool_json,
-            format="json"
-        )
-        force_authenticate(self.options_request, self.user)
-        self.options_response = self.view(self.options_request)
-
+class ToolAPITests(APITestCase, ToolManagerTestBase):
     def test_tools_exist(self):
+        self.create_valid_tool()
         self.assertEqual(Tool.objects.count(), 1)
         self.assertEqual(
             Tool.objects.filter(
@@ -941,14 +960,17 @@ class ToolAPITests(APITestCase):
         )
 
     def test_get_request_authenticated(self):
+        self.create_valid_tool()
         self.assertIsNotNone(self.get_response)
 
     def test_get_request_no_auth(self):
-        self.get_request = self.factory.get(self.url_root)
-        self.get_response = self.view(self.get_request)
+        self.create_valid_tool()
+        self.get_request = self.factory.get(self.tools_url_root)
+        self.get_response = self.tools_view(self.get_request)
         self.assertEqual(self.get_response.status_code, 403)
 
     def test_unallowed_http_verbs(self):
+        self.create_valid_tool()
         self.assertEqual(
             self.put_response.data['detail'],
             'Method "PUT" not allowed.'
@@ -963,7 +985,6 @@ class ToolAPITests(APITestCase):
         )
 
     def test_TLC_workflow_no_output_files(self):
-        self.td.delete()
         galaxy_instance = Instance.objects.create()
         workflow_engine = WorkflowEngine.objects.create(
             instance=galaxy_instance
@@ -991,22 +1012,23 @@ class ToolAPITests(APITestCase):
             )
         }
         self.post_request = self.factory.post(
-            self.url_root,
+            self.tools_url_root,
             data=tool_launch_configuration,
             format="json"
         )
-        force_authenticate(self.post_request, self.user)
-        self.post_response = self.view(self.post_request)
 
-        self.assertIsInstance(self.post_response, HttpResponseBadRequest)
-        self.assertEqual(
-            self.post_response.content,
-            '`output_files` are required for Workflow Tools'
-        )
-        self.assertEqual(Tool.objects.count(), 0)
+        with mock.patch(
+            "tool_manager.models.Tool.launch",
+            return_value=JsonResponse(
+                {"tool_url": "www.example.com/cool_tool"}
+            )
+        ) as launch_mock:
+            force_authenticate(self.post_request, self.user)
+            self.post_response = self.tools_view(self.post_request)
+            self.assertTrue(launch_mock.called)
+            self.assertEqual(Tool.objects.count(), 1)
 
     def test_invalid_TLC_against_schema(self):
-        self.td.delete()
         galaxy_instance = Instance.objects.create()
         workflow_engine = WorkflowEngine.objects.create(
             instance=galaxy_instance
@@ -1035,12 +1057,12 @@ class ToolAPITests(APITestCase):
             }
         }
         self.post_request = self.factory.post(
-            self.url_root,
+            self.tools_url_root,
             data=tool_launch_configuration,
             format="json"
         )
         force_authenticate(self.post_request, self.user)
-        self.post_response = self.view(self.post_request)
+        self.post_response = self.tools_view(self.post_request)
 
         self.assertIsInstance(self.post_response, HttpResponseBadRequest)
         self.assertIn(
@@ -1050,8 +1072,7 @@ class ToolAPITests(APITestCase):
         self.assertEqual(Tool.objects.count(), 0)
 
     def test_bad_POST_transaction_rollback(self):
-        Tool.objects.all().delete()
-
+        self.create_valid_tool_definition()
         post_data = {
             "tool_definition_uuid": self.td.uuid,
             "file_relationships": str(
@@ -1066,12 +1087,12 @@ class ToolAPITests(APITestCase):
         }
 
         post_request = self.factory.post(
-            self.url_root,
+            self.tools_url_root,
             data=post_data,
             format="json"
         )
         force_authenticate(post_request, self.user)
-        self.post_response = self.view(post_request)
+        self.post_response = self.tools_view(post_request)
 
         self.assertIsInstance(self.post_response, HttpResponseBadRequest)
         self.assertEqual(Tool.objects.count(), 0)
@@ -1079,7 +1100,6 @@ class ToolAPITests(APITestCase):
                       self.post_response.content)
 
     def test_bad_extra_directories_path(self):
-        Tool.objects.all().delete()
         with open("{}/visualizations/"
                   "LIST_visualization_bad_extra_directories_path.json"
                   .format(TEST_DATA_PATH)) as f:
@@ -1095,12 +1115,12 @@ class ToolAPITests(APITestCase):
             "file_relationships": str(["www.example.com"])
         }
         self.post_request = self.factory.post(
-            self.url_root,
+            self.tools_url_root,
             data=tool_launch_configuration,
             format="json"
         )
         force_authenticate(self.post_request, self.user)
-        self.post_response = self.view(self.post_request)
+        self.post_response = self.tools_view(self.post_request)
 
         self.assertIsInstance(self.post_response, HttpResponseBadRequest)
         self.assertEqual(
@@ -1110,7 +1130,6 @@ class ToolAPITests(APITestCase):
         self.assertEqual(Tool.objects.count(), 1)
 
     def test_good_extra_directories_path(self):
-        Tool.objects.all().delete()
         with open("{}/visualizations/"
                   "LIST_visualization_good_extra_directories.json"
                   .format(TEST_DATA_PATH)) as f:
@@ -1126,52 +1145,34 @@ class ToolAPITests(APITestCase):
             "file_relationships": str(["www.example.com"])
         }
         self.post_request = self.factory.post(
-            self.url_root,
+            self.tools_url_root,
             data=tool_launch_configuration,
             format="json"
         )
         force_authenticate(self.post_request, self.user)
         # We don't want to spin up containers for unit testing
         with mock.patch(
-                "django_docker_engine.docker_utils.DockerClientWrapper.run"
+            "django_docker_engine.docker_utils.DockerClientWrapper.run"
         ) as run_mock:
-            self.post_response = self.view(self.post_request)
+            self.post_response = self.tools_view(self.post_request)
             self.assertTrue(run_mock.called)
 
         self.assertEqual(self.post_response.status_code, 200)
         self.assertEqual(Tool.objects.count(), 1)
 
 
-class ToolIntegrationTests(StaticLiveServerTestCase):
-    # Don't delete data migration data after test runs: http://bit.ly/2lAYqVJ
-    serialized_rollback = True
-
+class ToolIntegrationTests(ToolManagerTestBase, SeleniumTestBaseGeneric):
     def setUp(self):
-        self.display = Display(visible=0, size=(1366, 768))
-        self.display.start()
-        self.browser = webdriver.Firefox()
-        self.browser.maximize_window()
-
-        self.mock_vis_annotations_reference = (
-            "tool_manager.management.commands.generate_tool_definitions"
-            ".get_visualization_annotations_list"
-        )
-
-        self.username = 'coffee_lover'
-        self.password = 'coffeecoffee'
-        self.user = User.objects.create_user(self.username, '', self.password)
-        self.factory = APIRequestFactory()
-        self.view = ToolsViewSet.as_view({'post': 'create'})
-        self.url_root = '/api/v2/tools'
+        # super() will only ever resolve a single class type for a given method
+        ToolManagerTestBase.setUp(self)
+        SeleniumTestBaseGeneric.setUp(self)
 
     def tearDown(self):
-        # NOTE: quit() destroys ANY currently running webdriver instances.
-        # This could become an issue if tests are ever run in parallel.
-        self.browser.quit()
-        self.display.stop()
+        # super() will only ever resolve a single class type for a given method
+        ToolManagerTestBase.tearDown(self)
+        SeleniumTestBaseGeneric.tearDown(self)
 
-        # Explicitly delete Tool's so that the post_delete signal is
-        # triggered and their Docker containers are purged
+        # Explicitly call delete() to purge any containers we spun up
         Tool.objects.all().delete()
 
     def test_visualization_container_launch_IGV(self):
@@ -1201,12 +1202,12 @@ class ToolIntegrationTests(StaticLiveServerTestCase):
             }
 
             self.post_request = self.factory.post(
-                self.url_root,
+                self.tools_url_root,
                 data=self.post_data,
                 format="json"
             )
             force_authenticate(self.post_request, self.user)
-            self.post_response = self.view(self.post_request)
+            self.post_response = self.tools_view(self.post_request)
 
             tool_launch = Tool.objects.get(
                 tool_definition__uuid=self.td.uuid
@@ -1265,12 +1266,12 @@ class ToolIntegrationTests(StaticLiveServerTestCase):
             }
 
             self.post_request = self.factory.post(
-                self.url_root,
+                self.tools_url_root,
                 data=self.post_data,
                 format="json"
             )
             force_authenticate(self.post_request, self.user)
-            self.post_response = self.view(self.post_request)
+            self.post_response = self.tools_view(self.post_request)
 
             tool_launch = Tool.objects.get(
                 tool_definition__uuid=self.td.uuid
@@ -1283,17 +1284,9 @@ class ToolIntegrationTests(StaticLiveServerTestCase):
             # TODO: Add selenium-based test once higlass relative paths fixed
 
 
-class ToolLaunchConfigurationTests(TestCase):
-
+class ToolLaunchConfigurationTests(ToolManagerTestBase):
     def setUp(self):
-        self.username = 'coffee_lover'
-        self.password = 'coffeecoffee'
-        self.user = User.objects.create_user(self.username, '',
-                                             self.password)
-        self.mock_vis_annotations_reference = (
-            "tool_manager.management.commands.generate_tool_definitions"
-            ".get_visualization_annotations_list"
-        )
+        super(ToolLaunchConfigurationTests, self).setUp()
 
         with open(
             "{}/visualizations/higlass.json".format(TEST_DATA_PATH)

--- a/refinery/tool_manager/utils.py
+++ b/refinery/tool_manager/utils.py
@@ -1,15 +1,13 @@
-import ast
 import glob
 import json
 import logging
 import os
 
+from bioblend.galaxy.client import ConnectionError
 from django.conf import settings
 from django.contrib import admin
 from django.db import transaction
-
-from bioblend.galaxy.client import ConnectionError
-from jsonschema import RefResolver, validate, ValidationError
+from jsonschema import RefResolver, ValidationError, validate
 
 from core.models import WorkflowEngine
 from factory_boy.django_model_factories import (FileRelationshipFactory,
@@ -19,8 +17,8 @@ from factory_boy.django_model_factories import (FileRelationshipFactory,
                                                 ParameterFactory,
                                                 ToolDefinitionFactory,
                                                 ToolFactory)
-
 from file_store.models import FileType
+
 from .models import ToolDefinition
 
 logger = logging.getLogger(__name__)
@@ -96,8 +94,10 @@ def create_tool_definition(annotation_data):
             ),
             image_name=annotation["image_name"],
             container_input_path=annotation["container_input_path"],
-            extra_directories=annotation["extra_directories"]
         )
+
+    tool_definition.annotation = json.dumps(annotation)
+    tool_definition.save()
 
     create_and_associate_output_files(
         tool_definition,
@@ -126,48 +126,25 @@ def create_tool(tool_launch_configuration, user_instance):
     tool = ToolFactory(
         name="{}-launch".format(tool_definition.name),
         tool_definition=tool_definition,
-        file_relationships=tool_launch_configuration["file_relationships"]
+        tool_launch_configuration=json.dumps(tool_launch_configuration)
     )
-    try:
-        tool.parameters = tool_launch_configuration["parameters"]
-    except KeyError:
-        # parameters are not required for Tools to launch properly
-        pass
 
     if tool.get_tool_type() == ToolDefinition.VISUALIZATION:
-        try:
-            tool.output_files = tool_launch_configuration["output_files"]
-        except KeyError:
-            # output_files aren't required for Vis Tools
-            pass
-
         # Create a unique container name that adheres to docker's specs
         tool.container_name = "{}-{}".format(
             tool.name.replace(" ", ""),
             tool.uuid
         )
 
-    if tool.get_tool_type() == ToolDefinition.WORKFLOW:
-        try:
-            tool.output_files = tool_launch_configuration["output_files"]
-        except KeyError:
-            raise RuntimeError(
-                "`output_files` are required for Workflow Tools"
-            )
-
     tool.set_owner(user_instance)
     tool.update_file_relationships_string()
 
-    # Assert that the data structure being sent over is able to be evaluated
-    #  as a Pythonic Data structure
     try:
-        nesting = ast.literal_eval(tool.file_relationships)
-    except (SyntaxError, ValueError):
+        nesting = tool.get_file_relationships()
+    except (SyntaxError, ValueError) as e:
         raise RuntimeError(
             "ToolLaunchConfiguration's `file_relationships` could not be "
-            "evaluated as a Pythonic Data Structure: {}".format(
-                tool.file_relationships
-            )
+            "evaluated as a Pythonic Data Structure: {}".format(e)
         )
     else:
         parse_file_relationship_nesting(nesting)

--- a/refinery/tool_manager/views.py
+++ b/refinery/tool_manager/views.py
@@ -1,7 +1,6 @@
 import logging
 
 from django.http import HttpResponseBadRequest
-
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.viewsets import ModelViewSet
 
@@ -42,9 +41,5 @@ class ToolsViewSet(ModelViewSet):
                 tool = create_tool(tool_launch_configuration, request.user)
             except Exception as e:
                 return HttpResponseBadRequest(e)
-
-        if tool.get_tool_type() == ToolDefinition.VISUALIZATION:
-            return tool.launch()
-
-        elif tool.get_tool_type() == ToolDefinition.WORKFLOW:
-            raise NotImplementedError
+            else:
+                return tool.launch()


### PR DESCRIPTION
- Test refactoring
- Provide fields on `Tool` & `ToolDefinition` to dump json in rather than the `ast.literal_eval()` approach from before
- @mccalluc & @jkmarx: `tool_manager.tests.py`  has a lengthy diff, but most of it is just moving existing members into places that make more sense