### PR TITLE
Try new travis environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 sudo: required
+dist: trusty
+group: edge
+
 language: python
 cache: pip
 addons:


### PR DESCRIPTION
https://blog.travis-ci.com/2017-06-19-trusty-updates-2017-Q2

@hackdna / @scottx611x / @jkmarx : Travis is rolling out a new environment on Wednesday and this is just to make sure we'll have no problems. If someone else already checked this, sorry for the redundancy.

... and, actually, it did fail [just now](https://travis-ci.org/refinery-platform/refinery-platform/builds/244720692#L1409):

```
$ bower install --config.interactive=false --quiet
module.js:472
    throw err;
    ^
Error: Cannot find module 'internal/fs'
```

Hopefully a fluke? I'll re-run, and if it does reproduce, I'll try to make a fix in this branch.