### PR TITLE
Masking errors not helpful

### DIFF
--- a/refinery/data_set_manager/tests.py
+++ b/refinery/data_set_manager/tests.py
@@ -979,10 +979,10 @@ class UtilitiesTest(TestCase):
         )
 
     def test_format_solr_response_invalid(self):
-        # invalid input, error checking
+        # invalid input, do not mask error
         solr_response = {"test_object": "not a string"}
-        error = format_solr_response(solr_response)
-        self.assertEqual(error, "Error loading json.")
+        with self.assertRaises(TypeError):
+            format_solr_response(solr_response)
 
     def test_customize_attribute_response_for_generics(self):
         attributes = ['technology_Characteristics_generic_s',

--- a/refinery/data_set_manager/utils.py
+++ b/refinery/data_set_manager/utils.py
@@ -805,10 +805,7 @@ def get_owner_from_assay(uuid):
 
 def format_solr_response(solr_response):
     # Returns a reformatted solr response
-    try:
-        solr_response_json = json.loads(solr_response)
-    except TypeError:
-        return "Error loading json."
+    solr_response_json = json.loads(solr_response)
 
     # Reorganizes solr response into easier to digest objects.
     try:


### PR DESCRIPTION
Masking the error like this made it harder for me to debug the root issue. AJAX response was 200, but body could not be parsed.