### PR TITLE
Add svgxuse dependency to allow for external svgs to properly be loaded

### DIFF
--- a/refinery/templates/base.html
+++ b/refinery/templates/base.html
@@ -323,7 +323,7 @@
   <script src="{% static "js/data-set-import.js" %}"></script>
 
   <!-- Fetch external SVGs referenced in <use> elements when the browser fails to do so -->
-  <script defer src="{% static "vendor/svgxuse/svgxuse.js" %}"></script>
+  <script defer src="{% static "vendor/svgxuse/svgxuse.min.js" %}"></script>
 
   {% block script %}
   {% endblock %}

--- a/refinery/templates/base.html
+++ b/refinery/templates/base.html
@@ -322,6 +322,9 @@
   <script src="{% static "vendor/jquery-file-upload/js/jquery.fileupload-angular.js" %}"></script>
   <script src="{% static "js/data-set-import.js" %}"></script>
 
+  <!-- Fetch external SVGs referenced in <use> elements when the browser fails to do so -->
+  <script defer src="{% static "vendor/svgxuse/svgxuse.js" %}"></script>
+
   {% block script %}
   {% endblock %}
 

--- a/refinery/ui/bower.json
+++ b/refinery/ui/bower.json
@@ -46,6 +46,7 @@
     "ng-webworker": "0.2.3",
     "spark-md5": "2.0.2",
     "spectrum": "1.7.0",
+    "svgxuse": "1.2.4",
     "tipsy": "0.1.7",
     "d3-list-graph": "flekschas/d3-list-graph#v1.1.8",
     "angular-drag-and-drop-lists": "1.4.0",

--- a/refinery/ui/config.json
+++ b/refinery/ui/config.json
@@ -106,7 +106,7 @@
         "angular-ui-grid/ui-grid.min.js",
         "spark-md5/spark-md5.min.js",
         "spectrum/spectrum.js",
-        "svgxuse/svgxuse.js",
+        "svgxuse/svgxuse.min.js",
         "tipsy/src/javascripts/jquery.tipsy.js",
         "aws-sdk-js/dist/aws-sdk.min.js"
       ],

--- a/refinery/ui/config.json
+++ b/refinery/ui/config.json
@@ -106,6 +106,7 @@
         "angular-ui-grid/ui-grid.min.js",
         "spark-md5/spark-md5.min.js",
         "spectrum/spectrum.js",
+        "svgxuse/svgxuse.js",
         "tipsy/src/javascripts/jquery.tipsy.js",
         "aws-sdk-js/dist/aws-sdk.min.js"
       ],


### PR DESCRIPTION
Addresses issue here: #1905 but is probably not a great solution. See: https://github.com/refinery-platform/refinery-platform/pull/1919#issuecomment-315373543

Will leave #1905 open but merge this as a workaround until a better solution can be found.