### PR TITLE
Mccalluc/search facet labels

### DIFF
--- a/refinery/ui/source/js/user-file-browser/partials/user-file-browser-filters.html
+++ b/refinery/ui/source/js/user-file-browser/partials/user-file-browser-filters.html
@@ -6,6 +6,7 @@
       <h2>
         Attribute Filters
       </h2>
+      <input ng-model="search" ng-init="search = ''">
     </div>
     <div
       ng-repeat="(attribute, attributeObj) in $ctrl.attributeFilters track by $index"
@@ -25,7 +26,7 @@
         aria-labelledby="{{ attribute }}">
         <div class="panel-body">
           <div ng-repeat="field in attributeObj.facetObj track by $index">
-            <div class="checkbox container">
+            <div ng-show="field.name.includes(search) || search === ''" class="checkbox container">
                 <div class="row">
                   <div class="col-xs-1">
                     <input

--- a/refinery/ui/source/js/user-file-browser/partials/user-file-browser-filters.html
+++ b/refinery/ui/source/js/user-file-browser/partials/user-file-browser-filters.html
@@ -6,7 +6,7 @@
       <h2>
         Attribute Filters
       </h2>
-      <input ng-model="search" ng-init="search = ''">
+      <input ng-model="search" ng-init="search = ''" style="width: 100%;" placeholder="search...">
     </div>
     <div
       ng-repeat="(attribute, attributeObj) in $ctrl.attributeFilters track by $index"
@@ -26,7 +26,7 @@
         aria-labelledby="{{ attribute }}">
         <div class="panel-body">
           <div ng-repeat="field in attributeObj.facetObj track by $index">
-            <div ng-show="field.name.includes(search) || search === ''" class="checkbox container">
+            <div ng-show="field.name.toLowerCase().includes(search.toLowerCase())" class="checkbox container">
                 <div class="row">
                   <div class="col-xs-1">
                     <input


### PR DESCRIPTION
@ngehlenborg : Does this look like what you want? (Note that it's just a show-hide, so any previously selected checkboxes still apply... which might be confusing?)
![screen shot 2017-08-05 at 6 32 11 pm](https://user-images.githubusercontent.com/730388/28999243-6d43c1ae-7a0d-11e7-88d2-7c24599810c4.png)
![screen shot 2017-08-05 at 6 32 27 pm](https://user-images.githubusercontent.com/730388/28999244-7062d2bc-7a0d-11e7-9751-1489f6026f85.png)

(Is alphabetical sorting of facets really important? We started down this track because we wanted to make the long, concatenated facets more accessible, but sorting doesn't make a difference if they've been assembled in an arbitrary order.)

