### PR TITLE
Mccalluc/sorting facets

### DIFF
--- a/refinery/ui/source/js/user-file-browser/partials/user-file-browser-filters.html
+++ b/refinery/ui/source/js/user-file-browser/partials/user-file-browser-filters.html
@@ -9,7 +9,7 @@
     </div>
     <div
       ng-repeat="(attribute, attributeObj) in $ctrl.attributeFilters track by $index"
-      ng-init="attributeIndex = $index">
+      ng-init="attributeIndex = $index; order = '-count'">
       <div class="panel panel-default">
         <div class="panel-heading" role="tab">
           <h4 class="panel-title" ng-click="$ctrl.togglePanel(attribute)">
@@ -27,11 +27,15 @@
           <div class="checkbox container">
             <div class="row">
               <div class="col-xs-1"></div>
-              <div class="col-xs-8"><button class="btn btn-sm">sort</button></div>
-              <div class="col-xs-3"><button class="btn btn-sm">sort</button></div>
+              <div class="col-xs-8">
+                <button ng-click="order = 'name'" ng-show="order === '-count'" class="btn btn-sm">sort</button>
+              </div>
+              <div class="col-xs-3">
+                <button ng-click="order = '-count'" ng-show="order === 'name'" class="btn btn-sm">sort</button>
+              </div>
             </div>
           </div>
-          <div ng-repeat="field in attributeObj.facetObj | orderBy: 'name' track by $index">
+          <div ng-repeat="field in attributeObj.facetObj | orderBy: order track by $index">
             <div class="checkbox container">
                 <div class="row">
                   <div class="col-xs-1">

--- a/refinery/ui/source/js/user-file-browser/partials/user-file-browser-filters.html
+++ b/refinery/ui/source/js/user-file-browser/partials/user-file-browser-filters.html
@@ -24,7 +24,14 @@
         role="tabpanel"
         aria-labelledby="{{ attribute }}">
         <div class="panel-body">
-          <div ng-repeat="field in attributeObj.facetObj track by $index">
+          <div class="checkbox container">
+            <div class="row">
+              <div class="col-xs-1"></div>
+              <div class="col-xs-8"><button class="btn btn-sm">sort</button></div>
+              <div class="col-xs-3"><button class="btn btn-sm">sort</button></div>
+            </div>
+          </div>
+          <div ng-repeat="field in attributeObj.facetObj | orderBy: 'name' track by $index">
             <div class="checkbox container">
                 <div class="row">
                   <div class="col-xs-1">


### PR DESCRIPTION
![screen shot 2017-08-05 at 8 07 02 pm](https://user-images.githubusercontent.com/730388/28999602-0a5e9912-7a1a-11e7-9b65-6d8af5c364f1.png)

@ngehlenborg : Did you have something like this in mind?
- Not super-confident that this is more useful than distracting, but if it is:
- maybe sort all the facets either by name or by count, instead of allowing each section to be different?
- Make the buttons lighter, particularly if we're keeping them on each section? (Do we still need the arrows to collapse the sections if the hover part of #1975 is approved? If we could get rid of those arrows there, we might use them here instead to indicate sorting.)
- Instead of disappearing completely, maybe just a gray-out?
