### PR TITLE
Hide zero facets

### DIFF
--- a/refinery/data_set_manager/tests.py
+++ b/refinery/data_set_manager/tests.py
@@ -777,7 +777,8 @@ class UtilitiesTest(TestCase):
                          '&q=django_ct%3Adata_set_manager.node'
                          '&wt=json'
                          '&facet=true'
-                         '&facet.limit=-1'.format(
+                         '&facet.limit=-1'
+                         '&facet.mincount=1'.format(
                                  self.valid_uuid))
 
     def test_generate_solr_params_for_assay_with_params(self):
@@ -813,7 +814,8 @@ class UtilitiesTest(TestCase):
                          '&q=django_ct%3Adata_set_manager.node'
                          '&wt=json'
                          '&facet=true'
-                         '&facet.limit=-1'.format(
+                         '&facet.limit=-1'
+                         '&facet.mincount=1'.format(
                                  self.valid_uuid))
 
     def test_generate_filtered_facet_fields(self):

--- a/refinery/data_set_manager/utils.py
+++ b/refinery/data_set_manager/utils.py
@@ -657,7 +657,8 @@ def generate_solr_params(params, assay_uuids, facets_from_config=False):
                   'rows=%s' % row,
                   'q=django_ct:data_set_manager.node&wt=json',
                   'facet=%s' % facet_count,
-                  'facet.limit=-1'
+                  'facet.limit=-1',
+                  'facet.mincount=1'
                   ])
 
     if len(assay_uuids) == 0:

--- a/refinery/user_files_manager/tests.py
+++ b/refinery/user_files_manager/tests.py
@@ -90,4 +90,5 @@ class UserFilesUtilsTests(TestCase):
                          'q=django_ct%3Adata_set_manager.node',
                          'wt=json',
                          'facet=true',
-                         'facet.limit=-1'])
+                         'facet.limit=-1',
+                         'facet.mincount=1'])


### PR DESCRIPTION
Fix #1973 : If the user doesn't have privs for a document, it will not be included in the found set... but its facet values will still potentially be exposed. This limits the facets to those with non-zero counts. 