### PR TITLE
Scottx611x/test galaxy cleanup

### DIFF
--- a/refinery/analysis_manager/tests.py
+++ b/refinery/analysis_manager/tests.py
@@ -700,7 +700,7 @@ class AnalysisRunTests(AnalysisManagerTestBase):
     @mock.patch.object(LibraryClient, "delete_library")
     @mock.patch.object(HistoryClient, "delete_history")
     @mock.patch.object(WorkflowClient, "delete_workflow")
-    def test__galaxy_cleanup_methods_are_called_on_analysis_failure(
+    def test_galaxy_cleanup_methods_are_called_on_analysis_failure(
             self,
             delete_workflow_mock,
             delete_history_mock,
@@ -715,12 +715,8 @@ class AnalysisRunTests(AnalysisManagerTestBase):
 
         self.analysis.cancel()
 
-        # Fetch analysis & analysis status since they have changed during
-        # the course of this test and the old `self` references are stale
-        analysis = Analysis.objects.get(uuid=self.analysis.uuid)
-
-        self.assertEqual(analysis.status, Analysis.FAILURE_STATUS)
-        self.assertTrue(analysis.canceled)
+        self.assertEqual(self.analysis.status, Analysis.FAILURE_STATUS)
+        self.assertTrue(self.analysis.canceled)
 
         self.assertTrue(delete_workflow_mock.called)
         self.assertTrue(delete_history_mock.called)

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -1422,15 +1422,16 @@ class Analysis(OwnableResource):
             connection = self.galaxy_connection()
             error_msg = "Error deleting Galaxy %s for analysis '%s': %s"
 
-            # Delete Galaxy libraries, workflows and histories
+            # Delete Galaxy library
             if self.library_id:
                 try:
                     connection.libraries.delete_library(self.library_id)
                 except galaxy.client.ConnectionError as e:
                     logger.error(error_msg, 'library', self.name, e.message)
 
-            # Legacy analysis launches depended on uploading a copy of the
-            # Workflow into galaxy, while newer Tool-based ones utilize the
+            # Delete Galaxy Workflow
+            # NOTE: Legacy analysis launches depended on uploading a copy of
+            # the Workflow into galaxy, while newer Tool-based ones utilize the
             # original galaxy workflow which we don't want to delete
             if not self.is_tool_based:
                 if self.workflow_galaxy_id:
@@ -1439,18 +1440,12 @@ class Analysis(OwnableResource):
                             self.workflow_galaxy_id
                         )
                     except galaxy.client.ConnectionError as e:
-                        logger.error(
-                            error_msg,
-                            'workflow',
-                            self.name,
-                            e.message
-                        )
+                        logger.error(error_msg, 'workflow', self.name,
+                                     e.message)
             else:
                 workflow_tool = tool_manager.models.WorkflowTool
                 try:
-                    tool = workflow_tool.objects.get(
-                        analysis__uuid=self.uuid
-                    )
+                    tool = workflow_tool.objects.get(analysis__uuid=self.uuid)
                 except(workflow_tool.DoesNotExist,
                        workflow_tool.MultipleObjectsReturned) as e:
                     logger.error("Could not properly fetch Tool: %s", e)
@@ -1462,12 +1457,8 @@ class Analysis(OwnableResource):
                                 purge=True
                             )
                         except galaxy.client.ConnectionError as e:
-                            logger.error(
-                                error_msg,
-                                'history',
-                                self.name,
-                                e.message
-                            )
+                            logger.error(error_msg, 'history', self.name,
+                                         e.message)
             if self.history_id:
                 try:
                     connection.histories.delete_history(self.history_id,

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -442,7 +442,6 @@ class WorkflowTool(Tool):
     GALAXY_DATASET_HISTORY_ID = "galaxy_dataset_history_id"
     GALAXY_IMPORT_HISTORY_DICT = "import_history_dict"
     GALAXY_LIBRARY_DICT = "library_dict"
-    GALAXY_WORKFLOW_HISTORY_DICT = "workflow_history_dict"
     GALAXY_WORKFLOW_INVOCATION_DATA = "galaxy_workflow_invocation_data"
     LIST = "list"
     PAIRED = "paired"
@@ -476,8 +475,12 @@ class WorkflowTool(Tool):
         return nesting_string[:-1]
 
     @property
-    def galaxy_history_id(self):
+    def galaxy_import_history_id(self):
         return self.get_galaxy_dict()[self.GALAXY_IMPORT_HISTORY_DICT]["id"]
+
+    @property
+    def galaxy_workflow_history_id(self):
+        return self.analysis.history_id
 
     def _associate_collection_elements(self, galaxy_element_data):
         """
@@ -599,7 +602,7 @@ class WorkflowTool(Tool):
         """
         collection_info = (
             self.galaxy_connection.histories.create_dataset_collection(
-                history_id=self.galaxy_history_id,
+                history_id=self.galaxy_import_history_id,
                 collection_description=self._create_collection_description()
             )
         )

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -1562,14 +1562,9 @@ class WorkflowToolLaunchTests(ToolManagerTestBase):
 
         self.assertEqual(tool_a.dataset, tool_b.dataset)
 
-    def test__get_workflow_tool_no_analysis(self):
+    @mock.patch.object(Analysis, "galaxy_cleanup")
+    def test__get_workflow_tool_no_analysis(self, galaxy_cleanup_mock):
         self.create_valid_tool(ToolDefinition.WORKFLOW)
-        self.tool.update_galaxy_data(
-            self.tool.GALAXY_IMPORT_HISTORY_DICT,
-            {
-                "id": self.GALAXY_ID_MOCK
-            }
-        )
 
         analysis_uuid = self.tool.analysis.uuid
         self.tool.analysis.delete()
@@ -1577,6 +1572,7 @@ class WorkflowToolLaunchTests(ToolManagerTestBase):
         with mock.patch.object(run_analysis, "update_state") as update_mock:
             _get_workflow_tool(analysis_uuid)
             self.assertTrue(update_mock.called)
+        self.assertTrue(galaxy_cleanup_mock.called)
 
     def test__get_workflow_tool_with_analysis(self):
         self.create_valid_tool(ToolDefinition.WORKFLOW)

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -1913,7 +1913,7 @@ class WorkflowToolLaunchTests(ToolManagerTestBase):
     @mock.patch.object(LibraryClient, "delete_library")
     @mock.patch.object(HistoryClient, "delete_history")
     @mock.patch.object(WorkflowClient, "delete_workflow")
-    def test__galaxy_cleanup_methods_are_called_on_analysis_failure(
+    def test_galaxy_cleanup_methods_are_called_on_analysis_failure(
             self,
             delete_workflow_mock,
             delete_history_mock,
@@ -1937,12 +1937,8 @@ class WorkflowToolLaunchTests(ToolManagerTestBase):
 
         self.tool.analysis.cancel()
 
-        # Fetch analysis & analysis status since they have changed during
-        # the course of this test and the old `self` references are stale
-        analysis = Analysis.objects.get(uuid=self.tool.analysis.uuid)
-
-        self.assertEqual(analysis.status, Analysis.FAILURE_STATUS)
-        self.assertTrue(analysis.canceled)
+        self.assertEqual(self.tool.analysis.status, Analysis.FAILURE_STATUS)
+        self.assertTrue(self.tool.analysis.canceled)
 
         self.assertFalse(delete_workflow_mock.called)
         self.assertTrue(delete_history_mock.called)

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -1564,6 +1564,12 @@ class WorkflowToolLaunchTests(ToolManagerTestBase):
 
     def test__get_workflow_tool_no_analysis(self):
         self.create_valid_tool(ToolDefinition.WORKFLOW)
+        self.tool.update_galaxy_data(
+            self.tool.GALAXY_IMPORT_HISTORY_DICT,
+            {
+                "id": self.GALAXY_ID_MOCK
+            }
+        )
 
         analysis_uuid = self.tool.analysis.uuid
         self.tool.analysis.delete()


### PR DESCRIPTION
- Add test coverage for `Analysis.galaxy_cleanup()`
- Assert that `WorkflowTool`'s `Analyses` don't delete their Galaxy workflows in `galaxy_cleanup()` since the new way of launching workflows does not require uploading a Workflow copy to Galaxy