### PR TITLE
Allow for custom `RDS_SUPERUSER_PASSWORD`s to be set in `config.yml`

### DIFF
--- a/deployment/stack.py
+++ b/deployment/stack.py
@@ -190,7 +190,7 @@ def make_template(config, config_yaml):
         "EngineVersion": "9.3.14",
         # "KmsKeyId" ?
         "MasterUsername": "root",
-        "MasterUserPassword": "mypassword",
+        "MasterUserPassword": config['RDS_SUPERUSER_PASSWORD'],
         "MultiAZ": False,
         "Port": "5432",
         "PubliclyAccessible": False,


### PR DESCRIPTION
- Just brought up [all-files-test stack](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stack/detail?stackId=arn:aws:cloudformation:us-east-1:100836861126:stack%2Frefinery-all-files-test%2F9ca113c0-7d05-11e7-987f-500c285ebe99) with a custom RDS password successfully.

Fixes #1990