### PR TITLE
get_assays is buggy, and both are unused

### DIFF
--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -693,18 +693,6 @@ class DataSet(SharableResource):
         else:
             return None
 
-    def get_studies(self, version=None):
-        return Study.objects.filter(
-            investigation=self.get_investigation(version)
-        )
-
-    def get_assays(self, version=None):
-        return Assay.objects.filter(
-            study=Study.objects.filter(
-                investigation=self.get_investigation()
-            )
-        )
-
     def get_file_count(self):
         """Returns the number of files in the data set"""
         investigation = self.get_investigation()


### PR DESCRIPTION
I was in the neighborhood, and was almost going to use `get_assays`: `study:` should get a single object, not a list. I'm in favor of removing unused, buggy code.