### PR TITLE
Maybe this handles visualization warm up errors?

### DIFF
--- a/refinery/templates/500.html
+++ b/refinery/templates/500.html
@@ -13,7 +13,20 @@
 {% block content %}
 <div class="refinery-panel refinery-panel-content scrollable">
 	<div class="row">
-		<div class="refinery-header">
+      {% if DJANGO_DOCKER_ENGINE_BASE_URL in request.path %}
+          <p>
+              Please wait: The visualization is warming up.
+          </p>
+          <script>
+            window.setTimeout(
+                    function() {
+                        window.location.reload()
+                    },
+                    3000
+            )
+          </script>
+      {% else %}
+        <div class="refinery-header">
 			<span class="refinery-header-left">
 				<h3>Server Problem</h3>
 			</span>
@@ -23,6 +36,7 @@
 			Please contact your <a href='mailto:{{ADMIN_EMAIL}}?Subject=Refinery%20Error' target='_top'>System Administrator</a> if this is a recurring problem and describe
             anything you might have done that may have caused the error.
 		</p>
+      {% endif %}
 	</div>
 </div>
 {% endblock %}


### PR DESCRIPTION
I have not been able to test this in context:

- When I turn on `DEBUG`, my server doesn't start, so I must be doing it the wrong way: I have not seen the pretty error page locally.
- Other constants defined in the same file are referenced in the base.html template, but I'm not confident they can also be referenced in 500.html

I'm going to swap to something else, and then come back if I think I might have more clarity.