### PR TITLE
Mccalluc/better fold on facet search

### DIFF
--- a/refinery/ui/source/js/user-file-browser/ctrls/user-file-browser-filters-ctrl.js
+++ b/refinery/ui/source/js/user-file-browser/ctrls/user-file-browser-filters-ctrl.js
@@ -20,10 +20,10 @@
     var vm = this;
 
     vm.togglePanel = function (attribute) {
-      vm.visible[attribute] = ! vm.visible[attribute];
+      vm.folded_down[attribute] = ! vm.folded_down[attribute];
     };
 
-    vm.visible = {};
+    vm.folded_down = {};
 
     vm.filterUpdate = function (attribute, value) {
       if (typeof userFileFiltersService[attribute] === 'undefined') {

--- a/refinery/ui/source/js/user-file-browser/ctrls/user-file-browser-filters-ctrl.js
+++ b/refinery/ui/source/js/user-file-browser/ctrls/user-file-browser-filters-ctrl.js
@@ -20,10 +20,15 @@
     var vm = this;
 
     vm.togglePanel = function (attribute) {
-      vm.folded_down[attribute] = ! vm.folded_down[attribute];
+      vm.foldedDown[attribute] = ! vm.foldedDown[attribute];
     };
 
-    vm.folded_down = {};
+    vm.foldedDown = {};
+    vm.isDown = function (attribute, search) {
+      var attributeObj = vm.attributeFilters[attribute];
+      return vm.foldedDown[attribute] ||
+          attributeObj.lowerCaseNames.includes(search.toLowerCase()) && search.length;
+    };
 
     vm.filterUpdate = function (attribute, value) {
       if (typeof userFileFiltersService[attribute] === 'undefined') {

--- a/refinery/ui/source/js/user-file-browser/partials/user-file-browser-filters.html
+++ b/refinery/ui/source/js/user-file-browser/partials/user-file-browser-filters.html
@@ -54,9 +54,7 @@
                       <div class="col-xs-8">
                         <label for="{{ field.name | replaceWhiteSpaceWithHyphen
                           }}-{{ $index }}">
-                          <span>
-                            {{ field.name }}
-                          </span>
+                          <span ng-bind-html="field.name | highlight:search"></span>
                         </label>
                       </div>
                       <div class="col-xs-3">

--- a/refinery/ui/source/js/user-file-browser/partials/user-file-browser-filters.html
+++ b/refinery/ui/source/js/user-file-browser/partials/user-file-browser-filters.html
@@ -11,13 +11,13 @@
       <div class="panel panel-default">
         <div class="panel-heading" role="tab">
           <h4 class="panel-title" ng-click="$ctrl.togglePanel(attribute)">
-            <i class="fa fa-caret-down fa-pull-left" ng-hide="!$ctrl.folded_down[attribute]"></i>
-            <i class="fa fa-caret-right fa-pull-left" ng-hide="$ctrl.folded_down[attribute]"></i>
+            <i class="fa fa-caret-down fa-pull-left" ng-hide="!($ctrl.folded_down[attribute] || attributeObj.lowerCaseNames.includes(search.toLowerCase()) && search.length)"></i>
+            <i class="fa fa-caret-right fa-pull-left" ng-hide="$ctrl.folded_down[attribute] || attributeObj.lowerCaseNames.includes(search.toLowerCase()) && search.length"></i>
             {{ attribute }} &nbsp; ({{ attributeObj.facetObj.length }})
           </h4>
         </div>
       <div id="{{attribute | replaceWhiteSpaceWithHyphen}}"
-        ng-hide="!$ctrl.folded_down[attribute]"
+        ng-hide="!($ctrl.folded_down[attribute] || attributeObj.lowerCaseNames.includes(search.toLowerCase()) && search.length)"
         class="panel-collapse collapse in"
         role="tabpanel"
         aria-labelledby="{{ attribute }}">

--- a/refinery/ui/source/js/user-file-browser/partials/user-file-browser-filters.html
+++ b/refinery/ui/source/js/user-file-browser/partials/user-file-browser-filters.html
@@ -26,10 +26,20 @@
                 <div class="row">
                   <div class="col-xs-1"></div>
                   <div class="col-xs-8">
-                    <button ng-click="order = 'name'" ng-show="order === '-count'" class="btn btn-sm">sort</button>
+                    <button
+                      ng-click="order = 'name'"
+                      ng-class="{'btn-primary': order == 'name', 'btn': order != 'name'}"
+                      class="btn btn-xs">
+                      <i class="fa fa-sort-alpha-asc" aria-hidden="true"></i>
+                    </button>
                   </div>
                   <div class="col-xs-3">
-                    <button ng-click="order = '-count'" ng-show="order === 'name'" class="btn btn-sm">sort</button>
+                    <button
+                      ng-click="order = '-count'"
+                      ng-class="{'btn-primary': order == '-count', 'btn': order != '-count'}"
+                      class="btn btn-primary btn-xs">
+                      <i class="fa fa-sort-numeric-desc" aria-hidden="true"></i>
+                    </button>
                   </div>
                 </div>
               </div>

--- a/refinery/ui/source/js/user-file-browser/partials/user-file-browser-filters.html
+++ b/refinery/ui/source/js/user-file-browser/partials/user-file-browser-filters.html
@@ -7,17 +7,17 @@
     </div>
     <div
       ng-repeat="(attribute, attributeObj) in $ctrl.attributeFilters track by $index"
-      ng-init="attributeIndex = $index; folded_down = ">
+      ng-init="attributeIndex = $index">
       <div class="panel panel-default">
         <div class="panel-heading" role="tab">
           <h4 class="panel-title" ng-click="$ctrl.togglePanel(attribute)">
-            <i class="fa fa-caret-down fa-pull-left" ng-hide="!($ctrl.folded_down[attribute] || attributeObj.lowerCaseNames.includes(search.toLowerCase()) && search.length)"></i>
-            <i class="fa fa-caret-right fa-pull-left" ng-hide="$ctrl.folded_down[attribute] || attributeObj.lowerCaseNames.includes(search.toLowerCase()) && search.length"></i>
+            <i class="fa fa-caret-down fa-pull-left" ng-hide="!$ctrl.isDown(attribute, search)"></i>
+            <i class="fa fa-caret-right fa-pull-left" ng-hide="$ctrl.isDown(attribute, search)"></i>
             {{ attribute }} &nbsp; ({{ attributeObj.facetObj.length }})
           </h4>
         </div>
       <div id="{{attribute | replaceWhiteSpaceWithHyphen}}"
-        ng-hide="!($ctrl.folded_down[attribute] || attributeObj.lowerCaseNames.includes(search.toLowerCase()) && search.length)"
+        ng-hide="!$ctrl.isDown(attribute, search)"
         class="panel-collapse collapse in"
         role="tabpanel"
         aria-labelledby="{{ attribute }}">

--- a/refinery/ui/source/js/user-file-browser/partials/user-file-browser-filters.html
+++ b/refinery/ui/source/js/user-file-browser/partials/user-file-browser-filters.html
@@ -7,17 +7,17 @@
     </div>
     <div
       ng-repeat="(attribute, attributeObj) in $ctrl.attributeFilters track by $index"
-      ng-init="attributeIndex = $index">
+      ng-init="attributeIndex = $index; folded_down = ">
       <div class="panel panel-default">
         <div class="panel-heading" role="tab">
           <h4 class="panel-title" ng-click="$ctrl.togglePanel(attribute)">
-            <i class="fa fa-caret-down fa-pull-left" ng-hide="!$ctrl.visible[attribute]"></i>
-            <i class="fa fa-caret-right fa-pull-left" ng-hide="$ctrl.visible[attribute]"></i>
+            <i class="fa fa-caret-down fa-pull-left" ng-hide="!$ctrl.folded_down[attribute]"></i>
+            <i class="fa fa-caret-right fa-pull-left" ng-hide="$ctrl.folded_down[attribute]"></i>
             {{ attribute }} &nbsp; ({{ attributeObj.facetObj.length }})
           </h4>
         </div>
       <div id="{{attribute | replaceWhiteSpaceWithHyphen}}"
-        ng-hide="!$ctrl.visible[attribute]"
+        ng-hide="!$ctrl.folded_down[attribute]"
         class="panel-collapse collapse in"
         role="tabpanel"
         aria-labelledby="{{ attribute }}">

--- a/refinery/ui/source/js/user-file-browser/partials/user-file-browser-filters.html
+++ b/refinery/ui/source/js/user-file-browser/partials/user-file-browser-filters.html
@@ -7,7 +7,7 @@
     </div>
     <div
       ng-repeat="(attribute, attributeObj) in $ctrl.attributeFilters track by $index"
-      ng-init="attributeIndex = $index">
+      ng-init="attributeIndex = $index; order = '-count'">
       <div class="panel panel-default">
         <div class="panel-heading" role="tab">
           <h4 class="panel-title" ng-click="$ctrl.togglePanel(attribute)">
@@ -16,41 +16,52 @@
             {{ attribute }} &nbsp; ({{ attributeObj.facetObj.length }})
           </h4>
         </div>
-      <div id="{{attribute | replaceWhiteSpaceWithHyphen}}"
-        ng-hide="!$ctrl.isDown(attribute, search)"
-        class="panel-collapse collapse in"
-        role="tabpanel"
-        aria-labelledby="{{ attribute }}">
-        <div class="panel-body">
-          <div ng-repeat="field in attributeObj.facetObj track by $index">
-            <div ng-show="field.name.toLowerCase().includes(search.toLowerCase())" class="checkbox container">
+        <div id="{{attribute | replaceWhiteSpaceWithHyphen}}"
+            ng-hide="!$ctrl.isDown(attribute, search)"
+            class="panel-collapse collapse in"
+            role="tabpanel"
+            aria-labelledby="{{ attribute }}">
+            <div class="panel-body">
+              <div class="checkbox container">
                 <div class="row">
-                  <div class="col-xs-1">
-                    <input
-                      type="checkbox"
-                      name="optionsCheckboxes"
-                      ng-click="$ctrl.filterUpdate(attribute, field.name)"
-                      id="{{ field.name | replaceWhiteSpaceWithHyphen }}-{{ $index }}">
-                  </div>
+                  <div class="col-xs-1"></div>
                   <div class="col-xs-8">
-                    <label for="{{ field.name | replaceWhiteSpaceWithHyphen
-                      }}-{{ $index }}">
-                      <span>
-                        {{ field.name }}
-                      </span>
-                    </label>
+                    <button ng-click="order = 'name'" ng-show="order === '-count'" class="btn btn-sm">sort</button>
                   </div>
                   <div class="col-xs-3">
-                    <label for="{{ field.name | replaceWhiteSpaceWithHyphen }}-{{ $index }}">
-                      <span class="text-right pull-right">
-                        {{ field.count }}
-                      </span>
-                    </label>
+                    <button ng-click="order = '-count'" ng-show="order === 'name'" class="btn btn-sm">sort</button>
                   </div>
                 </div>
               </div>
+              <div ng-repeat="field in attributeObj.facetObj | orderBy: order track by $index">
+                <div ng-show="field.name.toLowerCase().includes(search.toLowerCase())" class="checkbox container">
+                    <div class="row">
+                      <div class="col-xs-1">
+                        <input
+                          type="checkbox"
+                          name="optionsCheckboxes"
+                          ng-click="$ctrl.filterUpdate(attribute, field.name)"
+                          id="{{ field.name | replaceWhiteSpaceWithHyphen }}-{{ $index }}">
+                      </div>
+                      <div class="col-xs-8">
+                        <label for="{{ field.name | replaceWhiteSpaceWithHyphen
+                          }}-{{ $index }}">
+                          <span>
+                            {{ field.name }}
+                          </span>
+                        </label>
+                      </div>
+                      <div class="col-xs-3">
+                        <label for="{{ field.name | replaceWhiteSpaceWithHyphen }}-{{ $index }}">
+                          <span class="text-right pull-right">
+                            {{ field.count }}
+                          </span>
+                        </label>
+                      </div>
+                    </div>
+                </div>
+              </div>
             </div>
-          </div>
         </div>
       </div>
     </div>

--- a/refinery/ui/source/js/user-file-browser/partials/user-file-browser-filters.html
+++ b/refinery/ui/source/js/user-file-browser/partials/user-file-browser-filters.html
@@ -10,10 +10,29 @@
       ng-init="attributeIndex = $index; order = '-count'">
       <div class="panel panel-default">
         <div class="panel-heading" role="tab">
-          <h4 class="panel-title" ng-click="$ctrl.togglePanel(attribute)">
-            <i class="fa fa-caret-down fa-pull-left" ng-hide="!$ctrl.isDown(attribute, search)"></i>
-            <i class="fa fa-caret-right fa-pull-left" ng-hide="$ctrl.isDown(attribute, search)"></i>
-            {{ attribute }} &nbsp; ({{ attributeObj.facetObj.length }})
+          <h4 class="panel-title">
+
+              <span ng-click="$ctrl.togglePanel(attribute)">
+                <i class="fa fa-caret-down fa-pull-left" ng-hide="!$ctrl.isDown(attribute, search)"></i>
+                <i class="fa fa-caret-right fa-pull-left" ng-hide="$ctrl.isDown(attribute, search)"></i>
+                {{ attribute }} &nbsp; ({{ attributeObj.facetObj.length }})
+              </span>
+
+              <span ng-hide="!$ctrl.isDown(attribute, search)">
+                <button
+                  ng-click="order = 'name'"
+                  ng-hide="order == 'name'"
+                  class="btn btn-xs">
+                  <i class="fa fa-sort-alpha-asc" aria-hidden="true"></i>
+                </button>
+                <button
+                  ng-click="order = '-count'"
+                  ng-hide="order == '-count'"
+                  class="btn btn-xs">
+                  <i class="fa fa-sort-numeric-desc" aria-hidden="true"></i>
+                </button>
+              </span>
+
           </h4>
         </div>
         <div id="{{attribute | replaceWhiteSpaceWithHyphen}}"
@@ -22,27 +41,6 @@
             role="tabpanel"
             aria-labelledby="{{ attribute }}">
             <div class="panel-body">
-              <div class="checkbox container">
-                <div class="row">
-                  <div class="col-xs-1"></div>
-                  <div class="col-xs-8">
-                    <button
-                      ng-click="order = 'name'"
-                      ng-class="{'btn-primary': order == 'name', 'btn': order != 'name'}"
-                      class="btn btn-xs">
-                      <i class="fa fa-sort-alpha-asc" aria-hidden="true"></i>
-                    </button>
-                  </div>
-                  <div class="col-xs-3">
-                    <button
-                      ng-click="order = '-count'"
-                      ng-class="{'btn-primary': order == '-count', 'btn': order != '-count'}"
-                      class="btn btn-primary btn-xs">
-                      <i class="fa fa-sort-numeric-desc" aria-hidden="true"></i>
-                    </button>
-                  </div>
-                </div>
-              </div>
               <div ng-repeat="field in attributeObj.facetObj | orderBy: order track by $index">
                 <div ng-show="field.name.toLowerCase().includes(search.toLowerCase())" class="checkbox container">
                     <div class="row">

--- a/refinery/ui/source/js/user-file-browser/services/factory.js
+++ b/refinery/ui/source/js/user-file-browser/services/factory.js
@@ -85,8 +85,14 @@
       Object.keys(solrFacetCounts).forEach(function (key) {
         if (solrFacetCounts[key].length > 0) {
           // TODO: can't use AttributeOrder (it's per dataset), but this is bad.
-          filters[mapInternalToDisplay(key)] =
-            { facetObj: solrFacetCounts[key] };
+          var facetObj = solrFacetCounts[key];
+          var lowerCaseNames = facetObj.map(function (nameCount) {
+            return nameCount.name.toLowerCase();
+          }).join(' ');
+          filters[mapInternalToDisplay(key)] = {
+            facetObj: facetObj,
+            lowerCaseNames: lowerCaseNames
+          };
         }
       });
       return filters;


### PR DESCRIPTION
I think this is reasonable behavior for the facet search, but there are certainly other ways it could be done.

There are two modes
- With no search, the facet folding is controlled only by the user.
- With a search, facets can be unfolded by the user, or by having a matching term; only matching terms are shown. So, it's possible to unfold a facet, but not have anything listed under it.

On load state:
![screen shot 2017-08-25 at 5 14 50 pm](https://user-images.githubusercontent.com/730388/29732894-c4fc49e2-89b8-11e7-92cb-f0c6b8b4a99c.png)

Fold down "technology":
![screen shot 2017-08-25 at 5 15 04 pm](https://user-images.githubusercontent.com/730388/29732909-d49149c0-89b8-11e7-95a8-b40d8fc537f9.png)

Type "n":
![screen shot 2017-08-25 at 5 15 21 pm](https://user-images.githubusercontent.com/730388/29732923-e414ec08-89b8-11e7-8293-fbf4a535f59a.png)

Type "na":
![screen shot 2017-08-25 at 5 15 41 pm](https://user-images.githubusercontent.com/730388/29732946-f983afac-89b8-11e7-83e2-19c128505d92.png)

Type "naX":
![screen shot 2017-08-25 at 5 16 00 pm](https://user-images.githubusercontent.com/730388/29732955-045c9de4-89b9-11e7-954c-a101ff52e7a6.png)

You can still unfold the facets, but with no matches there's nothing to see:
![screen shot 2017-08-25 at 5 16 22 pm](https://user-images.githubusercontent.com/730388/29732984-1c9ae424-89b9-11e7-8eda-23f7b25d0e91.png)
