### PR TITLE
Mccalluc/details tab

### DIFF
--- a/refinery/ui/source/js/data-set-about/partials/details.html
+++ b/refinery/ui/source/js/data-set-about/partials/details.html
@@ -1,6 +1,6 @@
 <div class="refinery-header">
   <div class="refinery-header-left">
-    <h3>{{ ADCtrl.dataSet.accession }}: {{ ADCtrl.dataSet.title }}</h3>
+    <h3>{{ ADCtrl.dataSet.title }}</h3>
     <span ng-if="ADCtrl.dataSet.is_owner">
       <a
         ng-click="ADCtrl.isCollapsed.title = !ADCtrl.isCollapsed.title"
@@ -379,9 +379,9 @@
 </span>
 <p>
   {{ ADCtrl.dataSet.file_count }} files
-  <div ng-if="ADCtrl.dataSet.file_size > 0">
-   - {{ ADCtrl.dataSet.file_size | fileSizeFormat }}
-  </div>
+  <span ng-if="ADCtrl.dataSet.file_size > 0">
+   using {{ ADCtrl.dataSet.file_size | fileSizeFormat }}
+  </span>
 </p>
 
 <div class="refinery-header">

--- a/refinery/ui/source/js/data-set-about/partials/details.html
+++ b/refinery/ui/source/js/data-set-about/partials/details.html
@@ -356,7 +356,7 @@
 </span>
 <div ng-if="ADCtrl.dataSet.isa_archive">
 <p>
-   <a href="{{ADCtrl.fileStoreItem.datafile && ADCtrl.fileStoreItem.datafile}}">
+   <a href="{{ADCtrl.fileStoreItem.datafile}}">
     {{ADCtrl.fileStoreItem.datafile | isaArchiveName}}
   </a>
     - {{ADCtrl.fileStoreItem.file_size | fileSizeFormat}}
@@ -370,7 +370,7 @@
     - {{ADCtrl.fileStoreItem.file_size | fileSizeFormat}}
   </p>
 </div>
-<div ng-if="!(ADCtrl.dataSet.isa_archive || ADCtrl.dataSet.pre_isa_archive)">
+<div ng-if="!(ADCtrl.dataSet.isa_archive || ADCtrl.dataSet.pre_isa_archive && ADCtrl.fileStoreItem.datafile)">
 <p class="emphasized">Not available.</p>
 </div>
 

--- a/refinery/ui/source/js/data-set-about/partials/details.html
+++ b/refinery/ui/source/js/data-set-about/partials/details.html
@@ -391,6 +391,6 @@
 </div>
 <p>
   Current version <span class="emphasized">{{ ADCtrl.dataSet.version }}</span>.
-  Data set created <span class="emphasized">{{ ADCtrl.dataSet.creation_date }}</span>.
-  Last modified <span class="emphasized">{{ ADCtrl.dataSet.modification_date }}</span>.
+  Data set created <span class="emphasized">{{ ADCtrl.dataSet.creation_date | date:'medium' }}</span>.
+  Last modified <span class="emphasized">{{ ADCtrl.dataSet.modification_date | date:'medium' }}</span>.
 </p>


### PR DESCRIPTION
Towards #1890. 

Two questions about the old one, copied from the thread there:
> Missing `None:None` under `STUDIES`

This does not come through because in the source code we have
```
  <span ng-if="study.identifier">
    <strong>{{study.identifier}}</strong>
  </span>
  <span ng-if="study.title">
    : {{study.title}}
  </span>
```
... which seems more like a feature than a bug?

Also: New one is missing creation date of the current version: Should that also be ported from the old version?

`Import into Own Space` might be more complicated, but this much could be merged, I think.

original:
![screen shot 2017-07-10 at 5 14 02 pm](https://user-images.githubusercontent.com/5629547/28040294-58110fe6-6593-11e7-8817-c82f3fb41992.png)

with this pr:
![screen shot 2017-08-28 at 3 05 09 pm](https://user-images.githubusercontent.com/730388/29788908-4449cee0-8c02-11e7-978c-970579b6bff0.png)
