### PR TITLE
download url in csv + map to ascii in csv

### DIFF
--- a/refinery/user_files_manager/tests.py
+++ b/refinery/user_files_manager/tests.py
@@ -41,7 +41,7 @@ class UserFilesAPITests(APITestCase):
 
 
 class UserFilesUITests(StaticLiveServerTestCase):
-    def test_get(self):
+    def test_ui(self):
         response = requests.get(
             urljoin(
                 self.live_server_url,
@@ -49,6 +49,19 @@ class UserFilesUITests(StaticLiveServerTestCase):
             )
         )
         self.assertIn("All Files", response.content)
+
+    def test_csv(self):
+        response = requests.get(
+            urljoin(
+                self.live_server_url,
+                'files_download'
+            )
+        )
+        self.assertEqual(
+            response.content,
+            'url,filename,organism,technology,'
+            'antibody,date,genotype,experimenter\r\n'
+        )
 
 
 class UserFilesUtilsTests(TestCase):

--- a/refinery/user_files_manager/tests.py
+++ b/refinery/user_files_manager/tests.py
@@ -4,7 +4,7 @@ from urlparse import urljoin
 from django.contrib.auth.models import User
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.http import QueryDict
-from django.test import TestCase
+from django.test import RequestFactory, TestCase
 
 from guardian.utils import get_anonymous_user
 import requests
@@ -15,7 +15,7 @@ from data_set_manager.models import Assay
 from factory_boy.utils import create_dataset_with_necessary_models
 
 from .utils import generate_solr_params_for_user
-from .views import UserFiles
+from .views import UserFiles, user_files_csv
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +57,19 @@ class UserFilesUITests(StaticLiveServerTestCase):
                 'files_download'
             )
         )
+        self.assertEqual(
+            response.content,
+            'url,filename,organism,technology,'
+            'antibody,date,genotype,experimenter\r\n'
+        )
+
+
+class UserFilesViewTests(TestCase):
+    def test_user_files_csv(self):
+        request = RequestFactory().get('/fake-url')
+        request.user = User.objects.create_user(
+            'testuser', 'test@example.com', 'password')
+        response = user_files_csv(request)
         self.assertEqual(
             response.content,
             'url,filename,organism,technology,'

--- a/refinery/user_files_manager/tests.py
+++ b/refinery/user_files_manager/tests.py
@@ -79,7 +79,7 @@ class UserFilesViewTests(TestCase):
             'filename_Characteristics' + NodeIndex.GENERIC_SUFFIX:
                 'fake-filename',
             'organism_Factor_Value' + NodeIndex.GENERIC_SUFFIX:
-                'fake-organism'
+                u'handles\u2013unicode'
             # Just want to exercise "_Characteristics" and "_Factor_Value":
             # Doesn't matter if the names are backwards.
         }
@@ -96,7 +96,7 @@ class UserFilesViewTests(TestCase):
                 response.content,
                 'url,filename,organism,technology,'
                 'antibody,date,genotype,experimenter\r\n'
-                'fake-url,fake-filename,fake-organism,,,,,\r\n'
+                'fake-url,fake-filename,handles-unicode,,,,,\r\n'
             )
 
 

--- a/refinery/user_files_manager/views.py
+++ b/refinery/user_files_manager/views.py
@@ -9,6 +9,7 @@ from django.template import RequestContext
 
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from unidecode import unidecode
 
 from data_set_manager.search_indexes import NodeIndex
 from data_set_manager.utils import format_solr_response, search_solr
@@ -39,8 +40,12 @@ def user_files_csv(request):
     for doc in docs:
         row = [doc.get(NodeIndex.DOWNLOAD_URL) or '']
         for col in cols:
-            row.append(doc.get(col + '_Characteristics_generic_s') or
-                       doc.get(col + '_Factor_Value_generic_s') or '')
+            possibly_unicode = (
+                doc.get(col + '_Characteristics_generic_s') or
+                doc.get(col + '_Factor_Value_generic_s') or
+                ''
+            )
+            row.append(unidecode(possibly_unicode))
         writer.writerow(row)
 
     return response

--- a/refinery/user_files_manager/views.py
+++ b/refinery/user_files_manager/views.py
@@ -10,6 +10,7 @@ from django.template import RequestContext
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from data_set_manager.search_indexes import NodeIndex
 from data_set_manager.utils import format_solr_response, search_solr
 
 from .utils import generate_solr_params_for_user
@@ -31,11 +32,12 @@ def user_files_csv(request):
     cols = settings.USER_FILES_COLUMNS.split(',')
 
     writer = csv.writer(response)
-    writer.writerow(cols)
+    writer.writerow(['url'] + cols)
+    # DOWNLOAD_URL's internal solr name not good for end-user.
 
     docs = loads(solr_response)['response']['docs']
     for doc in docs:
-        row = []
+        row = [doc.get(NodeIndex.DOWNLOAD_URL) or '']
         for col in cols:
             row.append(doc.get(col + '_Characteristics_generic_s') or
                        doc.get(col + '_Factor_Value_generic_s') or '')

--- a/requirements.txt
+++ b/requirements.txt
@@ -73,6 +73,7 @@ selenium==3.4.0
 six==1.10.0
 sqlparse==0.1.19
 supervisor==3.1.3
+unidecode==0.4.21
 uuid==1.30
 watchdog==0.6.0
 xmltodict==0.9.2


### PR DESCRIPTION
fix #1968 and fix #2064.

Could argue whether this is the best approach for handling characters like n-dash in the data. I'm using [unidecode](https://pypi.python.org/pypi/Unidecode) to get best approximate translation of unicode character. I'm working with the assumption that the end-user is not super-technical, and just wants the data in Excel. Alternatives:
- UTF-8 CSV: Possible, but not Excel's default. The user wouldn't notice during the import that the encoding is bad, only latter, and even then they wouldn't know how to fix it.
- Map no-ascii to `#` or ` ` or empty string: reasonable, but less helpful.
- Map individual problem cases: Why reinvent the wheel?
- Limit to ascii back at ingest. No.