### PR TITLE
zero-valued facets

### DIFF
--- a/refinery/data_set_manager/tests.py
+++ b/refinery/data_set_manager/tests.py
@@ -777,8 +777,7 @@ class UtilitiesTest(TestCase):
                          '&q=django_ct%3Adata_set_manager.node'
                          '&wt=json'
                          '&facet=true'
-                         '&facet.limit=-1'
-                         '&facet.mincount=1'.format(
+                         '&facet.limit=-1'.format(
                                  self.valid_uuid))
 
     def test_generate_solr_params_for_assay_with_params(self):
@@ -814,8 +813,7 @@ class UtilitiesTest(TestCase):
                          '&q=django_ct%3Adata_set_manager.node'
                          '&wt=json'
                          '&facet=true'
-                         '&facet.limit=-1'
-                         '&facet.mincount=1'.format(
+                         '&facet.limit=-1'.format(
                                  self.valid_uuid))
 
     def test_generate_filtered_facet_fields(self):

--- a/refinery/data_set_manager/utils.py
+++ b/refinery/data_set_manager/utils.py
@@ -657,8 +657,7 @@ def generate_solr_params(params, assay_uuids, facets_from_config=False):
                   'rows=%s' % row,
                   'q=django_ct:data_set_manager.node&wt=json',
                   'facet=%s' % facet_count,
-                  'facet.limit=-1',
-                  'facet.mincount=1'
+                  'facet.limit=-1'
                   ])
 
     if len(assay_uuids) == 0:

--- a/refinery/user_files_manager/tests.py
+++ b/refinery/user_files_manager/tests.py
@@ -140,5 +140,4 @@ class UserFilesUtilsTests(TestCase):
                          'q=django_ct%3Adata_set_manager.node',
                          'wt=json',
                          'facet=true',
-                         'facet.limit=-1',
-                         'facet.mincount=1'])
+                         'facet.limit=-1'])


### PR DESCRIPTION
Fix #2088; Towards #2089.

I think the one downside of this is that the "Type" facet in file-browser has a lot of zeros on first load: 

![screen shot 2017-09-05 at 4 43 43 pm](https://user-images.githubusercontent.com/730388/30082511-10c2cbbe-9259-11e7-9646-3595eca38222.png)

cross-data-sets is fine, and the other facets in FB are unique-ified.

I propose merging this work, and then removing it from the milestone. Getting the type menu to be handled correctly in FB may be trickier: Right now, all the facet values are coming from solr, and solr has no way of knowing whether we have a zero here because some other item in the data-set has it, but it's filtered out, or because some other item not in the data set has it. Possibilities:

- Uniquify type just like we do the other fields. ← My favorite, if we need to do this.
- Do an extra solr query each time (in the API itself) to figure out which types should be given.
- Same thing, leave it to the client to make the query.
- special logic in the rendering of type to not show 0s. (Not perfect.)