### PR TITLE
Scottx611x/fix same name analysis results

### DIFF
--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -1655,7 +1655,8 @@ class Analysis(OwnableResource):
             analysis=self, direction=INPUT_CONNECTION)[0].node.assay
         # 1. read workflow into graph
         graph = create_expanded_workflow_graph(
-            ast.literal_eval(self.workflow_copy))
+            ast.literal_eval(self.workflow_copy)
+        )
         # 2. create data transformation nodes for all tool nodes
         data_transformation_nodes = [graph.node[node_id]
                                      for node_id in graph.nodes()
@@ -1754,14 +1755,17 @@ class Analysis(OwnableResource):
                         derived_data_file_node.add_child(
                             data_transformation_input_node)
                         # TODO: here we could add a (Refinery internal)
-                        # attribute to the derived data file node to indicate
+                        # attribute to the derived data file node to
+                        # indicate
                         # which output of the tool it corresponds to
-            # connect outputs that are not inputs for any data transformation
+            # connect outputs that are not inputs for any data
+            # transformation
             if (output_connection.is_refinery_file and
                     derived_data_file_node.parents.count() == 0):
                 graph.node[output_connection.step]['node'].add_child(
                     derived_data_file_node)
-            # delete output nodes that are not refinery files and don't have
+            # delete output nodes that are not refinery files and
+            # don't have
             # any children
             if (not output_connection.is_refinery_file and
                     derived_data_file_node.children.count() == 0):

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -1699,9 +1699,8 @@ class Analysis(OwnableResource):
                 analysis_uuid=self.uuid,
                 file_name=output_connection_filename
             )
-            if analysis_results_counter is None:
-                analysis_results_counter = 0
-            if analysis_results_counter == analysis_results.count():
+            if (analysis_results_counter is None or
+                    analysis_results_counter == analysis_results.count()):
                 analysis_results_counter = 0
 
             # create derived data file node

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -1687,8 +1687,10 @@ class Analysis(OwnableResource):
         output_node_connections = AnalysisNodeConnection.objects.filter(
             analysis=self,
             direction=OUTPUT_CONNECTION
-        )
-        for index, output_connection in enumerate(output_node_connections):
+        ).order_by('filename')
+
+        analysis_results_counter = None
+        for output_connection in output_node_connections:
             output_connection_filename = "{}.{}".format(
                 output_connection.name,
                 output_connection.filetype
@@ -1697,6 +1699,11 @@ class Analysis(OwnableResource):
                 analysis_uuid=self.uuid,
                 file_name=output_connection_filename
             )
+            if analysis_results_counter is None:
+                analysis_results_counter = 0
+            if analysis_results_counter == analysis_results.count():
+                analysis_results_counter = 0
+
             # create derived data file node
             derived_data_file_node = (
                 Node.objects.create(
@@ -1721,7 +1728,10 @@ class Analysis(OwnableResource):
                             derived_data_file_node.uuid)
             else:
                 if analysis_results.count() > 1:
-                    analysis_result = analysis_results[index]
+                    analysis_result = analysis_results[
+                        analysis_results_counter
+                    ]
+                    analysis_results_counter += 1
                 else:
                     analysis_result = analysis_results[0]
 

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -1717,22 +1717,29 @@ class Analysis(OwnableResource):
                             file_name=(
                                 output_connection.name + "." +
                                 output_connection.filetype)).count()))
-            if len(analysis_results) > 1:
-                analysis_result = analysis_results[index]
+            if analysis_results.count() == 0:
+                logger.info(
+                    "No output file found for node '%s' ('%s')",
+                    derived_data_file_node.name,
+                    derived_data_file_node.uuid
+                )
             else:
-                analysis_result = analysis_results[0]
+                if analysis_results.count() > 1:
+                    analysis_result = analysis_results[index]
+                else:
+                    analysis_result = analysis_results[0]
 
-            derived_data_file_node.file_uuid = (
-                analysis_result.file_store_uuid
-            )
-            logger.debug(
-                "Output file %s.%s ('%s') assigned to node %s ('%s')",
-                output_connection.name,
-                output_connection.filetype,
-                analysis_result.file_store_uuid,
-                derived_data_file_node.name,
-                derived_data_file_node.uuid
-            )
+                derived_data_file_node.file_uuid = (
+                    analysis_result.file_store_uuid
+                )
+                logger.debug(
+                    "Output file %s.%s ('%s') assigned to node %s ('%s')",
+                    output_connection.name,
+                    output_connection.filetype,
+                    analysis_result.file_store_uuid,
+                    derived_data_file_node.name,
+                    derived_data_file_node.uuid
+                )
             output_connection.node = derived_data_file_node
             output_connection.save()
             # get graph edge that corresponds to this output node:

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -1684,6 +1684,7 @@ class Analysis(OwnableResource):
                     input_connection.node.add_child(data_transformation_node)
         # 4. create derived data file nodes for all entries and connect to data
         # transformation nodes
+
         for index, output_connection in enumerate(
                 AnalysisNodeConnection.objects.filter(
                     analysis=self,
@@ -1716,15 +1717,19 @@ class Analysis(OwnableResource):
                             file_name=(
                                 output_connection.name + "." +
                                 output_connection.filetype)).count()))
+            if len(analysis_results) > 1:
+                analysis_result = analysis_results[index]
+            else:
+                analysis_result = analysis_results[0]
 
             derived_data_file_node.file_uuid = (
-                analysis_results[index].file_store_uuid
+                analysis_result.file_store_uuid
             )
             logger.debug(
                 "Output file %s.%s ('%s') assigned to node %s ('%s')",
                 output_connection.name,
                 output_connection.filetype,
-                analysis_results[index].file_store_uuid,
+                analysis_result.file_store_uuid,
                 derived_data_file_node.name,
                 derived_data_file_node.uuid
             )

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -1727,6 +1727,8 @@ class Analysis(OwnableResource):
                             derived_data_file_node.uuid)
             else:
                 if analysis_results.count() > 1:
+                    logger.info("More than one AnalysisResult for: %s",
+                                output_connection_filename)
                     analysis_result = analysis_results[
                         analysis_results_counter
                     ]

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -1684,18 +1684,15 @@ class Analysis(OwnableResource):
                     input_connection.node.add_child(data_transformation_node)
         # 4. create derived data file nodes for all entries and connect to data
         # transformation nodes
-
-        for index, output_connection in enumerate(
-                AnalysisNodeConnection.objects.filter(
-                    analysis=self,
-                    direction=OUTPUT_CONNECTION
-                )
-        ):
+        output_node_connections = AnalysisNodeConnection.objects.filter(
+            analysis=self,
+            direction=OUTPUT_CONNECTION
+        )
+        for index, output_connection in enumerate(output_node_connections):
             output_connection_filename = "{}.{}".format(
                 output_connection.name,
                 output_connection.filetype
             )
-
             analysis_results = AnalysisResult.objects.filter(
                 analysis_uuid=self.uuid,
                 file_name=output_connection_filename

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -1692,11 +1692,9 @@ class Analysis(OwnableResource):
         ):
             analysis_results = AnalysisResult.objects.filter(
                 analysis_uuid=self.uuid,
-                file_name=(
-                    output_connection.name + "." + output_connection.filetype
-                )
+                file_name="{}.{}".format(output_connection.name,
+                                         output_connection.filetype)
             )
-
             # create derived data file node
             derived_data_file_node = (
                 Node.objects.create(
@@ -1719,15 +1717,17 @@ class Analysis(OwnableResource):
                                 output_connection.name + "." +
                                 output_connection.filetype)).count()))
 
-            derived_data_file_node.file_uuid = \
+            derived_data_file_node.file_uuid = (
                 analysis_results[index].file_store_uuid
+            )
             logger.debug(
                 "Output file %s.%s ('%s') assigned to node %s ('%s')",
                 output_connection.name,
                 output_connection.filetype,
                 analysis_results[index].file_store_uuid,
                 derived_data_file_node.name,
-                derived_data_file_node.uuid)
+                derived_data_file_node.uuid
+            )
             output_connection.node = derived_data_file_node
             output_connection.save()
             # get graph edge that corresponds to this output node:
@@ -1751,16 +1751,14 @@ class Analysis(OwnableResource):
                             data_transformation_input_node)
                         # TODO: here we could add a (Refinery internal)
                         # attribute to the derived data file node to
-                        # indicate
-                        # which output of the tool it corresponds to
+                        # indicate which output of the tool it corresponds to
             # connect outputs that are not inputs for any data
             # transformation
             if (output_connection.is_refinery_file and
                     derived_data_file_node.parents.count() == 0):
                 graph.node[output_connection.step]['node'].add_child(
                     derived_data_file_node)
-            # delete output nodes that are not refinery files and
-            # don't have
+            # delete output nodes that are not refinery files and don't have
             # any children
             if (not output_connection.is_refinery_file and
                     derived_data_file_node.children.count() == 0):

--- a/refinery/core/tests.py
+++ b/refinery/core/tests.py
@@ -1561,13 +1561,13 @@ class AnalysisTests(TestCase):
         )
 
     def test___get_output_connection_to_analysis_result_mapping(self):
-        analysis_result_a = AnalysisResult.objects.create(
+        analysis_result_b = AnalysisResult.objects.create(
             analysis_uuid=self.analysis.uuid,
             file_store_uuid=self.node.file_uuid,
             file_name=self.node_filename,
             file_type=self.node.get_file_store_item().filetype
         )
-        analysis_result_b = AnalysisResult.objects.create(
+        analysis_result_a = AnalysisResult.objects.create(
             analysis_uuid=self.analysis.uuid,
             file_store_uuid=self.node.file_uuid,
             file_name=self.node_filename,
@@ -1579,8 +1579,8 @@ class AnalysisTests(TestCase):
         self.assertEqual(
             output_mapping,
             {
-                self.analysis_node_connection_a: analysis_result_b,
-                self.analysis_node_connection_b: analysis_result_a
+                self.analysis_node_connection_a: analysis_result_a,
+                self.analysis_node_connection_b: analysis_result_b
             }
         )
 

--- a/refinery/core/tests.py
+++ b/refinery/core/tests.py
@@ -1578,10 +1578,10 @@ class AnalysisTests(TestCase):
         )
         self.assertEqual(
             output_mapping,
-            {
-                self.analysis_node_connection_a: analysis_result_a,
-                self.analysis_node_connection_b: analysis_result_b
-            }
+            [
+                (self.analysis_node_connection_b, analysis_result_b),
+                (self.analysis_node_connection_a, analysis_result_a)
+            ]
         )
 
 

--- a/refinery/galaxy_connector/galaxy_workflow.py
+++ b/refinery/galaxy_connector/galaxy_workflow.py
@@ -5,6 +5,7 @@ Created on Jan 11, 2012
 '''
 
 import ast
+import collections
 import copy
 import json
 import logging
@@ -529,7 +530,7 @@ def configure_workflow(workflow_dict, ret_list):
 
 def create_expanded_workflow_graph(dictionary):
     graph = nx.MultiDiGraph()
-    steps = dictionary["steps"]
+    steps = collections.OrderedDict(sorted(dictionary["steps"].items()))
     galaxy_input_types = tool_manager.models.WorkflowTool.GALAXY_INPUT_TYPES
 
     # iterate over steps to create nodes
@@ -539,20 +540,23 @@ def create_expanded_workflow_graph(dictionary):
         # create node
         graph.add_node(current_node_id)
         # add node attributes
-        graph.node[current_node_id]['name'] = \
-            str(current_node_id) + ": " + step['name']
+        graph.node[current_node_id]['name'] = "{}:{}".format(
+            current_node_id,
+            step['name']
+        )
         graph.node[current_node_id]['tool_id'] = step['tool_id']
         graph.node[current_node_id]['type'] = step['type']
         graph.node[current_node_id]['position'] = (
-            int(step['position']['left']), -int(step['position']['top']))
+            int(step['position']['left']), -int(step['position']['top'])
+        )
         graph.node[current_node_id]['node'] = None
     # iterate over steps to create edges (this is done by looking at
     # input_connections, i.e. only by looking at tool nodes)
     for current_node_id, step in steps.iteritems():
         # ensure node id is an integer
         current_node_id = int(current_node_id)
-        for current_node_input_name, input_connection in \
-                step['input_connections'].iteritems():
+        input_connections = step['input_connections'].iteritems()
+        for current_node_input_name, input_connection in input_connections:
             parent_node_id = input_connection["id"]
             # test if parent node is a tool node or an input node to pick the
             # right name for the outgoing edge
@@ -562,16 +566,18 @@ def create_expanded_workflow_graph(dictionary):
                 )
             else:
                 parent_node_output_name = input_connection['output_name']
-
-            edge_output_id = str(
-                parent_node_id) + '_' + parent_node_output_name
-            edge_input_id = str(
-                current_node_id) + '_' + current_node_input_name
-            edge_id = edge_output_id + '___' + edge_input_id
+            edge_output_id = "{}_{}".format(
+                parent_node_id,
+                parent_node_output_name
+            )
+            edge_input_id = "{}_{}".format(
+                current_node_id,
+                current_node_input_name
+            )
+            edge_id = "{}___{}".format(edge_output_id, edge_input_id)
             graph.add_edge(parent_node_id, current_node_id, key=edge_id)
-            graph[parent_node_id][current_node_id]['output_id'] = str(
-                parent_node_id) + '_' + parent_node_output_name
-            graph[parent_node_id][current_node_id]['input_id'] = str(
-                current_node_id) + '_' + current_node_input_name
-
+            graph[parent_node_id][current_node_id]['output_id'] = (
+                edge_output_id
+            )
+            graph[parent_node_id][current_node_id]['input_id'] = edge_input_id
     return graph

--- a/refinery/galaxy_connector/galaxy_workflow.py
+++ b/refinery/galaxy_connector/galaxy_workflow.py
@@ -531,7 +531,7 @@ def create_expanded_workflow_graph(dictionary):
     graph = nx.MultiDiGraph()
     steps = dictionary["steps"]
     galaxy_input_types = [
-        'data_input',
+        tool_manager.models.WorkflowTool.DATA_INPUT,
         tool_manager.models.WorkflowTool.DATA_COLLECTION_INPUT
     ]
 

--- a/refinery/galaxy_connector/galaxy_workflow.py
+++ b/refinery/galaxy_connector/galaxy_workflow.py
@@ -530,10 +530,7 @@ def configure_workflow(workflow_dict, ret_list):
 def create_expanded_workflow_graph(dictionary):
     graph = nx.MultiDiGraph()
     steps = dictionary["steps"]
-    galaxy_input_types = [
-        tool_manager.models.WorkflowTool.DATA_INPUT,
-        tool_manager.models.WorkflowTool.DATA_COLLECTION_INPUT
-    ]
+    galaxy_input_types = tool_manager.models.WorkflowTool.GALAXY_INPUT_TYPES
 
     # iterate over steps to create nodes
     for current_node_id, step in steps.iteritems():

--- a/refinery/galaxy_connector/galaxy_workflow.py
+++ b/refinery/galaxy_connector/galaxy_workflow.py
@@ -5,7 +5,6 @@ Created on Jan 11, 2012
 '''
 
 import ast
-import collections
 import copy
 import json
 import logging
@@ -530,7 +529,7 @@ def configure_workflow(workflow_dict, ret_list):
 
 def create_expanded_workflow_graph(dictionary):
     graph = nx.MultiDiGraph()
-    steps = collections.OrderedDict(sorted(dictionary["steps"].items()))
+    steps = dictionary["steps"]
     galaxy_input_types = tool_manager.models.WorkflowTool.GALAXY_INPUT_TYPES
 
     # iterate over steps to create nodes

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -14,6 +14,7 @@ import bioblend
 from bioblend.galaxy.dataset_collections import (CollectionDescription,
                                                  CollectionElement,
                                                  HistoryDatasetElement)
+from constants import UUID_RE
 from django_docker_engine.docker_utils import (DockerClientWrapper,
                                                DockerContainerSpec)
 from django_extensions.db.fields import UUIDField
@@ -312,10 +313,7 @@ class Tool(OwnableResource):
         )
 
     def get_input_node_uuids(self):
-        node_uuids = re.findall(
-            r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}',
-            self.get_file_relationships()
-        )
+        node_uuids = re.findall(UUID_RE, self.get_file_relationships())
         return node_uuids
 
     def get_relative_container_url(self):

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -587,11 +587,7 @@ class WorkflowTool(Tool):
                 direction=INPUT_CONNECTION,
                 name=file_store_item.datafile.name,
                 step=0,
-                filename=(
-                    self.INPUT_DATASET_COLLECTION
-                    if self._has_dataset_collection_input()
-                    else self.INPUT_DATASET
-                ),
+                filename=self._get_analysis_node_connection_input_filename(),
                 is_refinery_file=file_store_item.is_local()
             )
 
@@ -831,6 +827,13 @@ class WorkflowTool(Tool):
             matching_refinery_to_galaxy_file_mappings[0][self.ANALYSIS_GROUP]
         )
         return analysis_group_number
+
+    def _get_analysis_node_connection_input_filename(self):
+        return (
+            self.INPUT_DATASET_COLLECTION if
+            self._has_dataset_collection_input()
+            else self.INPUT_DATASET
+        )
 
     @staticmethod
     def _get_galaxy_dataset_filename(galaxy_dataset_dict):

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -1126,6 +1126,7 @@ class WorkflowTool(Tool):
 
         for galaxy_to_refinery_dict in galaxy_to_refinery_mapping_list:
             node = Node.objects.get(
+                uuid__in=self.get_input_node_uuids(),
                 file_uuid=galaxy_to_refinery_dict[Tool.REFINERY_FILE_UUID]
             )
             galaxy_dict[self.FILE_RELATIONSHIPS_GALAXY] = (

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -463,6 +463,7 @@ class WorkflowTool(Tool):
     GALAXY_DATA = "galaxy_data"
     GALAXY_DATASET_HISTORY_ID = "galaxy_dataset_history_id"
     GALAXY_IMPORT_HISTORY_DICT = "import_history_dict"
+    GALAXY_INPUT_TYPES = [DATA_INPUT, DATA_COLLECTION_INPUT]
     GALAXY_LIBRARY_DICT = "library_dict"
     GALAXY_WORKFLOW_INVOCATION_DATA = "galaxy_workflow_invocation_data"
     GALAXY_TO_REFINERY_MAPPING_LIST = "galaxy_to_refinery_mapping_list"

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -601,7 +601,7 @@ class WorkflowTool(Tool):
                 name=galaxy_dataset["name"],
                 subanalysis=self._get_analysis_group_number(galaxy_dataset),
                 step=self._get_workflow_step(galaxy_dataset),
-                filename=galaxy_dataset["name"],
+                filename=self._get_galaxy_dataset_filename(galaxy_dataset),
                 filetype=galaxy_dataset["file_ext"],
                 is_refinery_file=True
             )

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -455,6 +455,7 @@ class WorkflowTool(Tool):
     """
     ANALYSIS_GROUP = "analysis_group"
     COLLECTION_INFO = "collection_info"
+    DATA_INPUT = "data_input"
     DATA_COLLECTION_INPUT = "data_collection_input"
     FILE_RELATIONSHIPS_GALAXY = "{}_galaxy".format(Tool.FILE_RELATIONSHIPS)
     FILE_RELATIONSHIPS_NESTING = "file_relationships_nesting"
@@ -466,7 +467,8 @@ class WorkflowTool(Tool):
     GALAXY_WORKFLOW_INVOCATION_DATA = "galaxy_workflow_invocation_data"
     GALAXY_TO_REFINERY_MAPPING_LIST = "galaxy_to_refinery_mapping_list"
     HISTORY_DATASET_COLLECTION_ASSOCIATION = "hdca"
-    INPUT_DATASET_COLLECTION = "Input Dataset Collection"
+    INPUT_DATASET = "Input Dataset"
+    INPUT_DATASET_COLLECTION = "{} Collection".format(INPUT_DATASET)
     LIST = "list"
     PAIRED = "paired"
     REVERSE = "reverse"
@@ -584,7 +586,11 @@ class WorkflowTool(Tool):
                 direction=INPUT_CONNECTION,
                 name=file_store_item.datafile.name,
                 step=0,
-                filename=self.INPUT_DATASET_COLLECTION,
+                filename=(
+                    self.INPUT_DATASET_COLLECTION
+                    if self._has_dataset_collection_input()
+                    else self.INPUT_DATASET
+                ),
                 is_refinery_file=file_store_item.is_local()
             )
 

--- a/refinery/tool_manager/test_data/galaxy_mocks.py
+++ b/refinery/tool_manager/test_data/galaxy_mocks.py
@@ -154,10 +154,44 @@ galaxy_datasets_list = [
     }
 ]
 
-galaxy_datasets_list_same_output_names = []
-for galaxy_dataset in galaxy_datasets_list:
-    galaxy_dataset["name"] = "Output File"
-    galaxy_datasets_list_same_output_names.append(galaxy_dataset)
+galaxy_datasets_list_same_output_names = [
+    {
+        u'creating_job': u'efwefwee75g27398cd',
+        u'file_size': 406,
+        u'dataset_id': u'gergg34g34g44',
+        u'id': u'd32aba4ae7b4124a',
+        u'state': u'ok',
+        u'history_id': u'67ce804af6ec796b',
+        u'name': u'Output file',
+        u'file_ext': u'txt',
+        u'url': u'/api/histories/67ce804af6ec796b/contents/d32aba4ae7b4124a',
+        u'purged': False
+    },
+    {
+        u'creating_job': u'1d1dbe75827398cd',
+        u'file_size': 406,
+        u'dataset_id': u'34g34g34g3g34g3',
+        u'id': u'd22aba4ae7b4124a',
+        u'state': u'ok',
+        u'history_id': u'67ce804af6ec796b',
+        u'name': u'Output file',
+        u'file_ext': u'txt',
+        u'url': u'/api/histories/67ce804af6ec796b/contents/d32aba4ae7b4124a',
+        u'purged': False
+    },
+    {
+        u'creating_job': u'32456789rwjefvtg7',
+        u'file_size': 406,
+        u'dataset_id': u'4gh33gt34g34g',
+        u'id': u'd32aba4ae7b4124a',
+        u'state': u'ok',
+        u'history_id': u'67ce804af6ec796b',
+        u'name': u'Output file',
+        u'file_ext': u'txt',
+        u'url': u'/api/histories/67ce804af6ec796b/contents/d32aba4ae7b4124a',
+        u'purged': True
+    }
+]
 
 galaxy_workflow_invocation = {
     u'inputs': {u'0': {u'src': u'hdca', u'id': u'f0cc9868bc58f90b'}},
@@ -194,10 +228,23 @@ galaxy_history_download_list = [
         u'dataset_id': u'953f3a3e2982a4fa', u'type': u'txt'
     }
 ]
-galaxy_history_download_list_same_names = []
-for galaxy_history_download in galaxy_history_download_list:
-    galaxy_history_download["name"] = "Output File"
-    galaxy_history_download_list_same_names.append(galaxy_history_download)
+galaxy_history_download_list_same_names = [
+    {
+        u'name': u'Output file',
+        u'state': u'ok', u'file_size': 211,
+        u'dataset_id': u'8ee788c99983ff96', u'type': u'txt'
+    },
+    {
+        u'name': u'Output file',
+        u'state': u'ok', u'file_size': 211,
+        u'dataset_id': u'14bb1cdaa43f5769', u'type': u'txt'
+    },
+    {
+        u'name': u'Output file',
+        u'state': u'ok', u'file_size': 714,
+        u'dataset_id': u'953f3a3e2982a4fa', u'type': u'txt'
+    }
+]
 
 galaxy_tool_data = {
     u'inputs': [

--- a/refinery/tool_manager/test_data/galaxy_mocks.py
+++ b/refinery/tool_manager/test_data/galaxy_mocks.py
@@ -53,13 +53,30 @@ galaxy_workflow_dict = {
         u'1': {
             u'tool_id': u'refinery_test_LIST-N',
             u'id': 1,
-            u'name': u'Refinery test tool LIST - N'
+            u'input_connections': {
+                u'input_file': {
+                    u'output_name': u'output',
+                    u'id': 0
+                }
+            },
+            u'name': u'Refinery test tool LIST - N',
+            u'type': u'tool',
+            u'position': {
+                u'top': 513,
+                u'left': 822
+            }
         },
         u'0': {
-            u'tool_id': u'refinery_test_LIST-N',
+            u'tool_id': None,
             u'id': 0,
-            u'name': u'Refinery test tool LIST - N',
-            u'type': u'data_input'
+            u'input_connections': {},
+            u'inputs': [{u'name': u'Input Dataset'}],
+            u'name': u'input',
+            u'type': u'data_input',
+            u'position': {
+                u'top': 908,
+                u'left': 207
+            }
         }
     }
 }
@@ -70,13 +87,30 @@ galaxy_workflow_dict_collection = {
         u'1': {
             u'tool_id': u'refinery_test_LIST-N',
             u'id': 1,
-            u'name': u'Refinery test tool LIST - N'
+            u'input_connections': {
+                u'input_file': {
+                    u'output_name': u'output',
+                    u'id': 0
+                }
+            },
+            u'name': u'Refinery test tool LIST - N',
+            u'type': u'tool',
+            u'position': {
+                u'top': 513,
+                u'left': 822
+            }
         },
         u'0': {
-            u'tool_id': u'refinery_test_LIST-N',
+            u'tool_id': None,
             u'id': 0,
-            u'name': u'Refinery test tool LIST - N',
-            u'type': u'data_collection_input'
+            u'input_connections': {},
+            u'inputs': [{u'name': u'Input Dataset Collection'}],
+            u'name': u'input',
+            u'type': u'data_collection_input',
+            u'position': {
+                u'top': 908,
+                u'left': 207
+            }
         }
     }
 }
@@ -101,7 +135,7 @@ galaxy_datasets_list = [
         u'id': u'd22aba4ae7b4124a',
         u'state': u'ok',
         u'history_id': u'67ce804af6ec796b',
-        u'name': u'Refinery test tool LIST - N on data 2',
+        u'name': u'Refinery test tool LIST - N on data 3',
         u'file_ext': u'txt',
         u'url': u'/api/histories/67ce804af6ec796b/contents/d32aba4ae7b4124a',
         u'purged': False
@@ -113,7 +147,7 @@ galaxy_datasets_list = [
         u'id': u'd32aba4ae7b4124a',
         u'state': u'ok',
         u'history_id': u'67ce804af6ec796b',
-        u'name': u'Refinery test tool LIST - N on data 1',
+        u'name': u'Refinery test tool LIST - N on data 2',
         u'file_ext': u'txt',
         u'url': u'/api/histories/67ce804af6ec796b/contents/d32aba4ae7b4124a',
         u'purged': True
@@ -140,17 +174,17 @@ galaxy_workflow_invocation = {
 
 galaxy_history_download_list = [
     {
-        u'name': u'Refinery test tool LIST - N on data 14',
+        u'name': u'Refinery test tool LIST - N on data 4',
         u'state': u'ok', u'file_size': 211,
         u'dataset_id': u'8ee788c99983ff96', u'type': u'txt'
     },
     {
-        u'name': u'Refinery test tool LIST - N on data 13',
+        u'name': u'Refinery test tool LIST - N on data 3',
         u'state': u'ok', u'file_size': 211,
         u'dataset_id': u'14bb1cdaa43f5769', u'type': u'txt'
     },
     {
-        u'name': u'Refinery test tool LIST - N on data 12',
+        u'name': u'Refinery test tool LIST - N on data 2',
         u'state': u'ok', u'file_size': 714,
         u'dataset_id': u'953f3a3e2982a4fa', u'type': u'txt'
     }

--- a/refinery/tool_manager/test_data/galaxy_mocks.py
+++ b/refinery/tool_manager/test_data/galaxy_mocks.py
@@ -154,6 +154,11 @@ galaxy_datasets_list = [
     }
 ]
 
+galaxy_datasets_list_same_output_names = []
+for galaxy_dataset in galaxy_datasets_list:
+    galaxy_dataset["name"] = "Output File"
+    galaxy_datasets_list_same_output_names.append(galaxy_dataset)
+
 galaxy_workflow_invocation = {
     u'inputs': {u'0': {u'src': u'hdca', u'id': u'f0cc9868bc58f90b'}},
     u'history_id': u'67ce804af6ec796b',
@@ -189,6 +194,10 @@ galaxy_history_download_list = [
         u'dataset_id': u'953f3a3e2982a4fa', u'type': u'txt'
     }
 ]
+galaxy_history_download_list_same_names = []
+for galaxy_history_download in galaxy_history_download_list:
+    galaxy_history_download["name"] = "Output File"
+    galaxy_history_download_list_same_names.append(galaxy_history_download)
 
 galaxy_tool_data = {
     u'inputs': [

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -1672,7 +1672,9 @@ class WorkflowToolTests(ToolManagerTestBase):
             self.assertEqual(output_connection.subanalysis, 0)
             self.assertEqual(
                 output_connection.filename,
-                galaxy_datasets_list[index]["name"]
+                self.tool._get_galaxy_dataset_filename(
+                    galaxy_datasets_list[index]
+                )
             )
             self.assertEqual(
                 output_connection.filetype,

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -78,7 +78,11 @@ class ToolManagerMocks(TestCase):
         self.galaxy_datasets_list_mock = mock.patch.object(
             HistoryClient, "show_matching_datasets",
             return_value=galaxy_datasets_list
-        ).start()
+        )
+        self.galaxy_datasets_list_same_names_mock = mock.patch.object(
+            HistoryClient, "show_matching_datasets",
+            return_value=galaxy_datasets_list_same_output_names
+        )
 
         # Galaxy History mocks
         self.history_upload_mock = mock.patch.object(
@@ -126,10 +130,14 @@ class ToolManagerMocks(TestCase):
         ).start()
 
         # galaxy_connector mocks
-        self.get_history_file_list_mock = mock.patch(
-            "galaxy_connector.models.Instance.get_history_file_list",
+        self.get_history_file_list_mock = mock.patch.object(
+            Instance, "get_history_file_list",
             return_value=galaxy_history_download_list
-        ).start()
+        )
+        self.get_history_file_list_same_names_mock = mock.patch.object(
+            Instance, "get_history_file_list",
+            return_value=galaxy_history_download_list_same_names
+        )
 
         # tool_manager mocks
         self.get_taskset_result_mock = mock.patch(

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -1926,6 +1926,25 @@ class WorkflowToolTests(ToolManagerTestBase):
             _get_galaxy_download_task_ids(self.tool.analysis)
             self.tool.analysis.attach_outputs_dataset()
             self.assertTrue(galaxy_workflow_dict_collection_mock.called)
+
+        input_connection = AnalysisNodeConnection.objects.filter(
+            analysis=self.tool.analysis,
+            direction=INPUT_CONNECTION
+        )[0]
+        assay = input_connection.node.assay
+        study = input_connection.node.study
+        for output_connection in AnalysisNodeConnection.objects.filter(
+                analysis=self.tool.analysis, direction=OUTPUT_CONNECTION):
+            self.assertEqual(output_connection.node.study, study)
+            self.assertEqual(output_connection.node.assay, assay)
+            self.assertEqual(output_connection.node.name,
+                             output_connection.name)
+            self.assertEqual(output_connection.node.analysis_uuid,
+                             self.tool.analysis.uuid)
+            self.assertEqual(output_connection.node.subanalysis,
+                             output_connection.subanalysis)
+            self.assertEqual(output_connection.node.workflow_output,
+                             output_connection.name)
         self.assertEqual(self.show_dataset_provenance_mock.call_count, 8)
 
     def test_attach_outputs_dataset_non_dsc(self):
@@ -1940,7 +1959,24 @@ class WorkflowToolTests(ToolManagerTestBase):
         )
         _get_galaxy_download_task_ids(self.tool.analysis)
         self.tool.analysis.attach_outputs_dataset()
-
+        input_connection = AnalysisNodeConnection.objects.filter(
+            analysis=self.tool.analysis,
+            direction=INPUT_CONNECTION
+        )[0]
+        assay = input_connection.node.assay
+        study = input_connection.node.study
+        for output_connection in AnalysisNodeConnection.objects.filter(
+                analysis=self.tool.analysis, direction=OUTPUT_CONNECTION):
+            self.assertEqual(output_connection.node.study, study)
+            self.assertEqual(output_connection.node.assay, assay)
+            self.assertEqual(output_connection.node.name,
+                             output_connection.name)
+            self.assertEqual(output_connection.node.analysis_uuid,
+                             self.tool.analysis.uuid)
+            self.assertEqual(output_connection.node.subanalysis,
+                             output_connection.subanalysis)
+            self.assertEqual(output_connection.node.workflow_output,
+                             output_connection.name)
         self.assertEqual(self.show_dataset_provenance_mock.call_count, 8)
 
 


### PR DESCRIPTION
When a DataSetCollection is used as input to a workflow which only accepts a `data_input`, said workflow will be run (N x the number of elements in the collection) with the potential to create N derived data nodes with the same name if the workflow doesn't have a dynamically named `label` for it's `outputs`. 

`Analysis.attach_outputs_dataset()` had logic in place to not attach derived data nodes to their AnalysisNodeConnections if this scenario occured, but this is behavior that we would like now.

Reviewed side by side w/ @mccalluc 