### PR TITLE
Mccalluc/use new django docker

### DIFF
--- a/refinery/tool_manager/please-wait.html
+++ b/refinery/tool_manager/please-wait.html
@@ -1,10 +1,25 @@
 <html>
 <head>
     <title>Please wait</title>
-    <meta http-equiv="refresh" content="5">
+    <meta http-equiv="refresh" content="10">
 </head>
 <body>
     <h1>Please wait</h1>
     <p>Please wait while your visualization loads.</p>
+    <script>
+        // Hi-frequency meta-refreshes are bad, but we can keep the 10 second
+        // meta-refresh as a fall-back, in case something goes wrong here:
+        setInterval(function() {
+            var request = new XMLHttpRequest();
+            request.addEventListener("load", function() {
+                if(request.status === 200){
+					window.location.reload(true);
+                    // "true": reload from server, ignore cache.
+				};
+            }, false);
+            request.open('GET', window.location.href);
+            request.send()
+        }, 1000);
+    </script>
 </body>
 </html>

--- a/refinery/tool_manager/please-wait.html
+++ b/refinery/tool_manager/please-wait.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+    <title>Please wait</title>
+    <meta http-equiv="refresh" content="5">
+</head>
+<body>
+    <h1>Please wait</h1>
+    <p>Please wait while your visualization loads.</p>
+</body>
+</html>

--- a/refinery/tool_manager/urls.py
+++ b/refinery/tool_manager/urls.py
@@ -1,3 +1,5 @@
+from os.path import dirname, join
+
 from django.conf import settings
 from django.conf.urls import include, url
 
@@ -11,9 +13,13 @@ tool_manager_router = DefaultRouter()
 tool_manager_router.register(r'tools', ToolsViewSet)
 tool_manager_router.register(r'tool_definitions', ToolDefinitionsViewSet)
 
+please_wait_path = join(dirname(__file__), 'please-wait.html')
+with open(please_wait_path, 'r') as f:
+    please_wait_content = f.read()
+
 url_patterns = Proxy(
     logger=FileLogger(settings.PROXY_LOG),
-    please_wait_content='TODO: Please wait'
+    please_wait_content=please_wait_content
 ).url_patterns()
 django_docker_engine_url = url(
     r'^{}/'.format(settings.DJANGO_DOCKER_ENGINE_BASE_URL),

--- a/refinery/tool_manager/urls.py
+++ b/refinery/tool_manager/urls.py
@@ -11,7 +11,10 @@ tool_manager_router = DefaultRouter()
 tool_manager_router.register(r'tools', ToolsViewSet)
 tool_manager_router.register(r'tool_definitions', ToolDefinitionsViewSet)
 
-url_patterns = Proxy(FileLogger(settings.PROXY_LOG)).url_patterns()
+url_patterns = Proxy(
+    logger=FileLogger(settings.PROXY_LOG),
+    please_wait_content='TODO: Please wait'
+).url_patterns()
 django_docker_engine_url = url(
     r'^{}/'.format(settings.DJANGO_DOCKER_ENGINE_BASE_URL),
     include(url_patterns)

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,4 +79,4 @@ watchdog==0.6.0
 xmltodict==0.9.2
 yolk==0.4.1
 
-git+https://github.com/refinery-platform/django_docker_engine.git@v0.0.10
+git+https://github.com/refinery-platform/django_docker_engine.git@v0.0.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,4 +79,4 @@ watchdog==0.6.0
 xmltodict==0.9.2
 yolk==0.4.1
 
-git+https://github.com/refinery-platform/django_docker_engine.git@v0.0.19
+git+https://github.com/refinery-platform/django_docker_engine.git@v0.0.20


### PR DESCRIPTION
This depends on https://github.com/refinery-platform/django_docker_engine/pull/75 being released and tagged, but even apart from that, I suspect things could be done differently here.