### PR TITLE
Mccalluc/bring back get assays

### DIFF
--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -702,6 +702,19 @@ class DataSet(SharableResource):
         else:
             return None
 
+    def get_studies(self, version=None):
+        return Study.objects.filter(
+            investigation=self.get_investigation(version)
+        )
+
+    def get_assays(self, version=None):
+        return Assay.objects.filter(
+            # TODO: filter returns a list, so I doubt this works?
+            study=Study.objects.filter(
+                investigation=self.get_investigation()
+            )
+        )
+
     def get_file_count(self):
         """Returns the number of files in the data set"""
         investigation = self.get_investigation()

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -709,10 +709,7 @@ class DataSet(SharableResource):
 
     def get_assays(self, version=None):
         return Assay.objects.filter(
-            # TODO: filter returns a list, so I doubt this works?
-            study=Study.objects.filter(
-                investigation=self.get_investigation()
-            )
+            study=self.get_studies(version)
         )
 
     def get_file_count(self):

--- a/refinery/core/tests.py
+++ b/refinery/core/tests.py
@@ -2019,6 +2019,14 @@ class DataSetTests(TestCase):
         self.node4 = Node.objects.create(
             name="n4", assay=self.assay, study=self.study)
 
+    def test_get_studies(self):
+        studies = self.dataset.get_studies()
+        self.assertEqual(len(studies), 1)
+
+    def test_get_assays(self):
+        assays = self.dataset.get_assays()
+        self.assertEqual(len(assays), 1)
+
     def test_get_file_store_items(self):
         file_store_items = self.dataset.get_file_store_items()
         self.assertEqual(len(file_store_items), 3)


### PR DESCRIPTION
Fix #2078 by reverting my earlier commit and adding tests... but I'm still confused about why `__in` isn't necessary here: Maybe the difference is that the query behind the scenes is just a plain `JOIN`, because what we're looking for are matching objects, instead of matching values?