### PR TITLE
Mccalluc/sort filter facets on file browser

### DIFF
--- a/refinery/ui/source/js/file-browser/directives/assay-filters.js
+++ b/refinery/ui/source/js/file-browser/directives/assay-filters.js
@@ -28,6 +28,14 @@
       controller: 'AssayFiltersCtrl',
       controllerAs: 'ASCtrl',
       link: function (scope, element, attrs, ctrl) {
+        scope.isDropped = function (attributeName) {
+          var escapeAttributeName = attributeName.replace(/ /g, '-');
+          var attributeTitle = angular.element(
+            document.querySelector('#attribute-panel-' + escapeAttributeName)
+          );
+          return attributeTitle.hasClass('fa-caret-right');
+        };
+
         // ng-click event for attribute filter panels
         // Event is custom because when a filter is selected, it continues to
         // show even though the panel is collapsed

--- a/refinery/ui/source/js/file-browser/partials/assay-filters.html
+++ b/refinery/ui/source/js/file-browser/partials/assay-filters.html
@@ -9,22 +9,39 @@
     </div>
     <div
       ng-repeat="(attribute, attributeObj) in ASCtrl.attributeFilter track by $index"
-      ng-init="attributeIndex = $index">
+      ng-init="attributeIndex = $index; order = '-count'">
       <div class="panel panel-default">
         <div class="panel-heading" role="tab">
           <h4 class="panel-title">
-          <div
-            role="button"
-            data-toggle="collapse"
-            data-parent="#attribute-filter"
-            ng-click="dropAttributePanel($event, attribute, attributeObj)"
-            aria-expanded="true"
-            aria-controls="{{ attribute }}">
-             <i class="fa fa-caret-right fa-pull-left"
-              id="attribute-panel-{{attribute | replaceWhiteSpaceWithHyphen}}"
-              aria-hidden="true"></i>
-             {{ attribute }} &nbsp; ({{ attributeObj.facetObj.length }})
-          </div>
+
+            <div
+              role="button"
+              data-toggle="collapse"
+              data-parent="#attribute-filter"
+              ng-click="dropAttributePanel($event, attribute, attributeObj)"
+              aria-expanded="true"
+              aria-controls="{{ attribute }}">
+               <i class="fa fa-caret-right fa-pull-left"
+                id="attribute-panel-{{attribute | replaceWhiteSpaceWithHyphen}}"
+                aria-hidden="true"></i>
+               {{ attribute }} &nbsp; ({{ attributeObj.facetObj.length }})
+            </div>
+
+            <span ng-hide="isDropped(attribute, search)">
+              <button
+                ng-click="order = 'name'"
+                ng-hide="order == 'name'"
+                class="btn btn-xs">
+                <i class="fa fa-sort-alpha-asc" aria-hidden="true"></i>
+              </button>
+              <button
+                ng-click="order = '-count'"
+                ng-hide="order == '-count'"
+                class="btn btn-xs">
+                <i class="fa fa-sort-numeric-desc" aria-hidden="true"></i>
+              </button>
+            </span>
+
           </h4>
         </div>
       <div id="{{attribute | replaceWhiteSpaceWithHyphen}}"
@@ -32,7 +49,7 @@
         role="tabpanel"
         aria-labelledby="{{ attribute }}">
         <div class="panel-body">
-          <div ng-repeat="field in attributeObj.facetObj track by $index">
+          <div ng-repeat="field in attributeObj.facetObj | orderBy: order track by $index">
             <div class="checkbox container"
                 ng-show="showField(field.name, attributeObj.internal_name, attribute)">
                 <div class="row">

--- a/refinery/ui/source/js/file-browser/partials/assay-filters.html
+++ b/refinery/ui/source/js/file-browser/partials/assay-filters.html
@@ -7,6 +7,9 @@
         Attribute Filter
       </h2>
     </div>
+    <div class="refinery-subheader m-t-1">
+      <input ng-model="search" ng-init="search = ''" style="width: 100%;" placeholder="search...">
+    </div>
     <div
       ng-repeat="(attribute, attributeObj) in ASCtrl.attributeFilter track by $index"
       ng-init="attributeIndex = $index; order = '-count'">
@@ -64,9 +67,7 @@
                   <div class="col-xs-8">
                     <label for="{{ field.name | replaceWhiteSpaceWithHyphen
                       }}-{{ $index }}">
-                      <span>
-                        {{ field.name }}
-                      </span>
+                      <span ng-bind-html="field.name | highlight:search"></span>
                     </label>
                   </div>
                   <div class="col-xs-3">

--- a/refinery/ui/source/js/file-browser/partials/assay-filters.html
+++ b/refinery/ui/source/js/file-browser/partials/assay-filters.html
@@ -14,7 +14,7 @@
         <div class="panel-heading" role="tab">
           <h4 class="panel-title">
 
-            <div
+            <span
               role="button"
               data-toggle="collapse"
               data-parent="#attribute-filter"
@@ -25,7 +25,7 @@
                 id="attribute-panel-{{attribute | replaceWhiteSpaceWithHyphen}}"
                 aria-hidden="true"></i>
                {{ attribute }} &nbsp; ({{ attributeObj.facetObj.length }})
-            </div>
+            </span>
 
             <span ng-hide="isDropped(attribute, search)">
               <button

--- a/refinery/ui/source/js/file-browser/partials/assay-filters.html
+++ b/refinery/ui/source/js/file-browser/partials/assay-filters.html
@@ -54,7 +54,7 @@
         <div class="panel-body">
           <div ng-repeat="field in attributeObj.facetObj | orderBy: order track by $index">
             <div class="checkbox container"
-                ng-show="showField(field.name, attributeObj.internal_name, attribute)">
+                ng-show="field.name.toLowerCase().includes(search.toLowerCase()) || showField(field.name, attributeObj.internal_name, attribute)">
                 <div class="row">
                   <div class="col-xs-1">
                     <input


### PR DESCRIPTION
Fix #337. Fix #336.

- alphabetic sorting is normal out of the box sorting: "A9" is after "A10". Doing it the right way (zero padding any numbers in strings) would get a lot harder: We'd have to find a place to keep those padded strings, and I'm not sure right now how that would fit in the DOM.
- With fold/unfold - check/uncheck - match/no-match - search/no-search there are a lot of possible states, and it's not unfolding for searches the way I'd like... but I'm also not so sure that searching facet values is even as important when we're just looking at one dataset?
- I'm also noticing that the behavior to show selected facets, even when folded up, is not what I've done in the cross-dataset browser.