### PR TITLE
Replace bit.ly links with their targets

### DIFF
--- a/refinery/config/settings/base.py
+++ b/refinery/config/settings/base.py
@@ -644,13 +644,15 @@ AUTO_LOGIN = get_setting("AUTO_LOGIN", local_settings, [])
 TEST_RUNNER = "django.test.runner.DiscoverRunner"
 
 # Required for pre-Django 1.9 TransactionTestCases utilizing
-# `serialized_rollback` to function properly http://bit.ly/2l5gR30
+# `serialized_rollback` to function properly.
+# https://code.djangoproject.com/ticket/23727#comment:13
 TEST_NON_SERIALIZED_APPS = ['core', 'django.contrib.contenttypes',
                             'django.contrib.auth']
 
 VISUALIZATION_ANNOTATION_BASE_PATH = "tool_manager/visualization_annotations"
 
-# To avoid Port conflicts between LiveServerTestCases http://bit.ly/2pb64KN
+# To avoid Port conflicts between LiveServerTestCases
+# https://docs.djangoproject.com/en/1.7/topics/testing/tools/#liveservertestcase
 os.environ["DJANGO_LIVE_TEST_SERVER_ADDRESS"] = "localhost:10000-12000"
 
 DJANGO_DOCKER_ENGINE_MAX_CONTAINERS = 10

--- a/refinery/core/search_indexes.py
+++ b/refinery/core/search_indexes.py
@@ -90,7 +90,8 @@ class DataSetIndex(indexes.SearchIndex, indexes.Indexable):
                 )
 
         # Cast to `list` looks redundant, but MultiValueField stores sets
-        # improperly, introducing a search bug. See: http://bit.ly/2pZLE5c
+        # improperly, introducing a search bug.
+        # https://github.com/refinery-platform/refinery-platform/pull/1716#discussion_r115339987
         return list(set(submitters))
 
     def prepare_measurement(self, object):
@@ -107,7 +108,8 @@ class DataSetIndex(indexes.SearchIndex, indexes.Indexable):
                 measurements.append(assay.measurement)
 
         # Cast to `list` looks redundant, but MultiValueField stores sets
-        # improperly, introducing a search bug. See: http://bit.ly/2pZLE5c
+        # improperly, introducing a search bug.
+        # https://github.com/refinery-platform/refinery-platform/pull/1716#discussion_r115339987
         return list(set(measurements))
 
     def prepare_technology(self, object):
@@ -124,7 +126,8 @@ class DataSetIndex(indexes.SearchIndex, indexes.Indexable):
                 technologies.append(assay.technology)
 
         # Cast to `list` looks redundant, but MultiValueField stores sets
-        # improperly, introducing a search bug. See: http://bit.ly/2pZLE5c
+        # improperly, introducing a search bug.
+        # https://github.com/refinery-platform/refinery-platform/pull/1716#discussion_r115339987
         return list(set(technologies))
 
     # from:

--- a/refinery/data_set_manager/models.py
+++ b/refinery/data_set_manager/models.py
@@ -514,7 +514,7 @@ class Node(models.Model):
             # (<Node_object>, Boolean: <created>)
             # So, if this Node is newly created, we will associate it as a
             # child to its parent, otherwise nothing happens
-            # See here for reference: http://bit.ly/2bL0PH5
+            # https://docs.djangoproject.com/en/1.10/ref/models/querysets/#get-or-create
             node_object = node[0]
             is_newly_created_node = node[1]
 

--- a/refinery/data_set_manager/tasks.py
+++ b/refinery/data_set_manager/tasks.py
@@ -539,7 +539,7 @@ def generate_bam_index(auxiliary_file_store_item_uuid, datafile_path):
     # Try and fetch the bam_index FileExtension
     # NOTE: that we are not handling the normal errors for an orm.get()s below
     # because we want the task from which this function is called within to
-    # fail if we can't get what we want http://bit.ly/1KSbazM
+    # fail if we can't get what we want.
     bam_index_file_extension = FileExtension.objects.get(name="bai").name
     auxiliary_file_store_item = FileStoreItem.objects.get(
         uuid=auxiliary_file_store_item_uuid)

--- a/refinery/file_store/migrations/0003_filetypes_and_fileextensions.py
+++ b/refinery/file_store/migrations/0003_filetypes_and_fileextensions.py
@@ -9,7 +9,8 @@ def forwards(apps, schema_editor):
 
     if FileType.objects.count():
         # Workaround for old-fixture based FileType data messing up
-        # Postgres' id sequence. See article here: http://bit.ly/2qsevm2 for similar issue
+        # Postgres' id sequence. See article here for similar issue:
+        # https://www.vlent.nl/weblog/2011/05/06/integrityerror-duplicate-key-value-violates-unique-constraint/
         highest_id = FileType.objects.all().aggregate(Max('id'))["id__max"]
         with connection.cursor() as cursor:
             cursor.execute('alter sequence file_store_filetype_id_seq restart with {};'.format(highest_id + 1))
@@ -166,7 +167,8 @@ def forwards(apps, schema_editor):
 
     if FileExtension.objects.count():
         # Workaround for old-fixture based FileExtension data messing up Postgres' id sequence.
-        # See article here: http://bit.ly/2qsevm2 for similar issue
+        # See article here for similar issue:
+        # https://www.vlent.nl/weblog/2011/05/06/integrityerror-duplicate-key-value-violates-unique-constraint/
         highest_id = FileExtension.objects.all().aggregate(Max('id'))["id__max"]
         with connection.cursor() as cursor:
             cursor.execute('alter sequence file_store_fileextension_id_seq restart with {};'.format(highest_id + 1))

--- a/refinery/file_store/models.py
+++ b/refinery/file_store/models.py
@@ -525,7 +525,7 @@ class FileStoreItem(models.Model):
         NOTE: That if you simply revoke() a task without the `terminate` ==
         True, said task will try to restart upon a Worker restart.
 
-        See: http://bit.ly/2di038U or http://bit.ly/1qb8763
+        http://docs.celeryproject.org/en/latest/userguide/workers.html#revoke-revoking-tasks
         """
         try:
             revoke(self.import_task_id, terminate=True)

--- a/refinery/selenium_testing/utils.py
+++ b/refinery/selenium_testing/utils.py
@@ -15,7 +15,8 @@ MAX_WAIT = 60
 class SeleniumTestBaseGeneric(StaticLiveServerTestCase):
     """Base class to be used for all selenium-based tests"""
 
-    # Don't delete data migration data after test runs: http://bit.ly/2lAYqVJ
+    # Don't delete data migration data after test runs:
+    # https://docs.djangoproject.com/en/1.7/topics/testing/tools/#transactiontestcase
     serialized_rollback = True
 
     def setUp(self):

--- a/refinery/tool_manager/utils.py
+++ b/refinery/tool_manager/utils.py
@@ -31,8 +31,10 @@ from .models import Tool, ToolDefinition, WorkflowTool
 
 logger = logging.getLogger(__name__)
 ANNOTATION_ERROR_MESSAGE = (
-    "Tool not properly annotated. Please read: http://bit.ly/2nalk6w for "
-    "examples and more information on how to properly annotate your tools."
+    "Tool not properly annotated. For examples and more information "
+    "on how to properly annotate your tools, please read "
+    "https://github.com/refinery-platform/refinery-platform/wiki/"
+    "Annotating-&-Importing-Refinery-Tools#importing-refinery-tools"
 )
 # Allow JSON Schema to find the JSON pointers we define in our schemas
 JSON_SCHEMA_FILE_RESOLVER = RefResolver(
@@ -296,7 +298,7 @@ def create_file_relationship_nesting(workflow_annotation,
     # One may think: "why not just have `file_relationships=[]` in the
     # method signature?" But this [utilizing mutable arguments] is a
     # common Python "gotcha". Especially in the context of recursive methods.
-    # It's illustrated well here: http://bit.ly/21b5Axg
+    # http://docs.python-guide.org/en/latest/writing/gotchas/#mutable-default-arguments
     if not file_relationships:
         file_relationships = []
 

--- a/refinery/ui/source/js/dashboard/controllers/dashboard.js
+++ b/refinery/ui/source/js/dashboard/controllers/dashboard.js
@@ -1213,7 +1213,8 @@ DashboardCtrl.prototype.readableDate = function (dataObj, property) {
 
   if (property === 'modification_date') {
     // Analyses' modification_date field is not a date string that Safari
-    // can handle so we need to convert it. See: http://bit.ly/2dXs5Ho
+    // can handle so we need to convert it.
+    // https://stackoverflow.com/a/6427318
     var dateParts = dataObj[property].toString().split(/[^0-9]/);
     dataObj[property] = new Date(dateParts[0], dateParts[1] - 1, dateParts[2]);
   }


### PR DESCRIPTION
- Bytes are cheap!
- Link shorteners may be fragile.
- The content of the link itself may tell me something about how useful it is: canonical docs? wisdom of SO? gif of Schwarzenagger?

(There were 3 in migrations that could probably be changed, too, but this is everything else.)