### PR TITLE
Clean up display of FB buttons

### DIFF
--- a/refinery/ui/source/js/file-browser/views/files-tab.html
+++ b/refinery/ui/source/js/file-browser/views/files-tab.html
@@ -10,23 +10,25 @@
       <div class="row"
         ng-if="FBCtrl.isOwner || FBCtrl.canEdit"
         id="tool-panel-show-button">
+
         <button
           class="btn btn-primary btn-sm"
           data-target="#tool-launch-panel"
           ng-click="FBCtrl.toggleToolPanel()">
-        <span ng-if="FBCtrl.collapsedToolPanel">
-          <i class="fa fa-angle-double-right" aria-hidden="true"></i>
-           Show Tool Panel
-        </span>
-        <span ng-if="!FBCtrl.collapsedToolPanel">
-          <i class="fa fa-angle-double-left" aria-hidden="true"></i>
-           Hide Tool Panel
-        </span>
+          <span ng-if="FBCtrl.collapsedToolPanel">
+            <i class="fa fa-angle-double-left" aria-hidden="true"></i>
+             Show Tool Panel
+          </span>
+          <span ng-if="!FBCtrl.collapsedToolPanel">
+            <i class="fa fa-angle-double-right" aria-hidden="true"></i>
+             Hide Tool Panel
+          </span>
         </button>
-        <span ng-if="FBCtrl.isOwner" class="float-right">
-          <i class="fa fa-wrench fa-border" rp-assay-files-util-modal>
-           <span class="font-awesome-text">Config</span>
-          </i>
+
+        <span class="float-right">
+          <span ng-if="FBCtrl.isOwner" class="btn btn-sm">
+            <i class="fa fa-wrench" rp-assay-files-util-modal></i>
+          </span>
           <a
             id="help-view-selector"
             popover-placement="right"
@@ -40,6 +42,7 @@
               id="config-question-icon"></i>
           </a>
         </span>
+
       </div>
       <div class="row" id="table-filter">
         <div id="filter-panel-body">

--- a/refinery/ui/source/styles/file-browser.less
+++ b/refinery/ui/source/styles/file-browser.less
@@ -114,22 +114,6 @@
       background-color: @gray-lighter;
     }
 
-    .fa-wrench {
-      background-color: #f5f5f5;
-      box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.25);;
-      background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#fff), to(#e6e6e6));
-      vertical-align: middle;
-      font-size: 80%;
-
-      // Overrides the font awesome font for text
-      .font-awesome-text {
-        font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-      }
-    }
-    .fa-border {
-      border-color: #f5f5f5;
-    }
-
     .fa-question {
       vertical-align: top;
     }


### PR DESCRIPTION
This is subjective, but... before:
![screen shot 2017-09-12 at 1 54 56 pm](https://user-images.githubusercontent.com/730388/30340878-f8f6380e-97c1-11e7-8382-8fa9f0c877f0.png)

after:
![screen shot 2017-09-12 at 1 52 10 pm](https://user-images.githubusercontent.com/730388/30340882-008a7184-97c2-11e7-8cfc-40be4bfb8360.png)

- arrow points in the direction the panel will expand
- button size consistency
- Remove "Config" text to avoid wrap

Other thoughts:
- Maybe just "Tool Panel"?
- The popover is really not that useful. Maybe just get rid of it, and think about whether the modal itself is as clear as it can be?
> **Select File Display Mode**
> The collection of files in this data set can be displayed using different representations.