### PR TITLE
Sort facet values

### DIFF
--- a/refinery/data_set_manager/search_indexes.py
+++ b/refinery/data_set_manager/search_indexes.py
@@ -124,10 +124,9 @@ class NodeIndex(indexes.SearchIndex, indexes.Indexable):
                 else:
                     data[key].add("N/A")
         # iterate over all keys in data and join sets into strings
-        # TODO: This doesn't feel right: facet each separately?
         for key, value in data.iteritems():
             if type(value) is set:
-                data[key] = " + ".join(value)
+                data[key] = " + ".join(sorted(value))
 
         try:
             file_store_item = FileStoreItem.objects.get(


### PR DESCRIPTION
Fix #2080. data_set_manager.tests.NodeIndexTests.test_prepare seems not to have changed, but it probably should have. Looking into that, at least to improve test coverage... 

Hmm: The only line in setUp that ends up being processed by the code in question:
```
assay = Assay.objects.create(study=study, technology='whizbang')
```
but I don't see a place to insert something multi-valued.