### PR TITLE
Use the latest django-docker

### DIFF
--- a/refinery/config/settings/base.py
+++ b/refinery/config/settings/base.py
@@ -658,7 +658,8 @@ DJANGO_DOCKER_ENGINE_BASE_URL = "visualizations"
 # Time in seconds to wait before killing unused visualization
 DJANGO_DOCKER_ENGINE_SECONDS_INACTIVE = 60 * 60
 # Location of DjangoDockerEngine proxy logging
-PROXY_LOG = '/tmp/django_docker_engine.log'
+DJANGO_DOCKER_ENGINE_DATA_DIR = '/data/django-docker-engine-data'
+PROXY_LOG = '/data/django-docker-engine.log'
 
 REFINERY_DEPLOYMENT_PLATFORM = "vagrant"
 

--- a/refinery/tool_manager/urls.py
+++ b/refinery/tool_manager/urls.py
@@ -18,6 +18,7 @@ with open(please_wait_path, 'r') as f:
     please_wait_content = f.read()
 
 url_patterns = Proxy(
+    settings.DJANGO_DOCKER_ENGINE_DATA_DIR,
     logger=FileLogger(settings.PROXY_LOG),
     please_wait_content=please_wait_content
 ).url_patterns()

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,4 +79,4 @@ watchdog==0.6.0
 xmltodict==0.9.2
 yolk==0.4.1
 
-git+https://github.com/refinery-platform/django_docker_engine.git@v0.0.20
+git+https://github.com/refinery-platform/django_docker_engine.git@v0.0.21


### PR DESCRIPTION
Use https://github.com/refinery-platform/django_docker_engine/pull/79: django-docker temp dirs should be cleaned up, and we can configure them to be stored under `/data`.