### PR TITLE
Scottx611x/fix derived node attribute inheritance

### DIFF
--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -1698,10 +1698,8 @@ class Analysis(OwnableResource):
         )
         for input_connection in input_node_connections:
             for edge in graph.edges_iter([input_connection.step]):
-                input_id = "{}_{}".format(
-                    input_connection.step,
-                    input_connection.filename
-                )
+                input_id = input_connection.get_input_connection_id()
+
                 if graph[edge[0]][edge[1]]['output_id'] == input_id:
                     input_node_id = edge[1]
                     data_transformation_node = (
@@ -1757,10 +1755,8 @@ class Analysis(OwnableResource):
             workflow_step = output_connection.step
             if len(graph.edges([workflow_step])) > 0:
                 for edge in graph.edges_iter([workflow_step]):
-                    output_id = "{}_{}".format(
-                        workflow_step,
-                        output_connection.name
-                    )
+                    output_id = output_connection.get_output_connection_id()
+
                     if graph[edge[0]][edge[1]]['output_id'] == output_id:
                         input_node_id = edge[0]
                         output_node_id = edge[1]
@@ -1967,6 +1963,12 @@ class AnalysisNodeConnection(models.Model):
             str(self.step) + "_" +
             self.name + " (" + str(self.is_refinery_file) + ")"
         )
+
+    def get_input_connection_id(self):
+        return "{}_{}".format(self.step, self.filename)
+
+    def get_output_connection_id(self):
+        return "{}_{}".format(self.step, self.name)
 
 
 class Download(TemporaryResource, OwnableResource):

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -1752,9 +1752,8 @@ class Analysis(OwnableResource):
             # a. attach output node to source data transformation node
             # b. attach output node to target data transformation node
             # (if exists)
-            workflow_step = output_connection.step
-            if len(graph.edges([workflow_step])) > 0:
-                for edge in graph.edges_iter([workflow_step]):
+            if len(graph.edges([output_connection.step])) > 0:
+                for edge in graph.edges_iter([output_connection.step]):
                     output_id = output_connection.get_output_connection_id()
 
                     if graph[edge[0]][edge[1]]['output_id'] == output_id:

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -1900,13 +1900,7 @@ class Analysis(OwnableResource):
                     output_connections_to_analysis_results.append(
                         (output_connection, None)
                     )
-
-        # return a sorted list based on the AnalysisNodeConnections step
-        # attribute
-        return sorted(
-            output_connections_to_analysis_results,
-            key=lambda x: x[0].step
-        )
+        return output_connections_to_analysis_results
 
     @property
     def is_tool_based(self):

--- a/refinery/core/tests.py
+++ b/refinery/core/tests.py
@@ -1448,16 +1448,28 @@ class AnalysisTests(TestCase):
                 node=self.node,
                 step=1,
                 filename=self.node_filename,
-                direction=OUTPUT_CONNECTION
+                direction=OUTPUT_CONNECTION,
+                is_refinery_file=True
             )
         )
         self.analysis_node_connection_b = (
             AnalysisNodeConnection.objects.create(
                 analysis=self.analysis,
                 node=self.node,
-                step=1,
+                step=2,
                 filename=self.node_filename,
-                direction=OUTPUT_CONNECTION
+                direction=OUTPUT_CONNECTION,
+                is_refinery_file=False
+            )
+        )
+        self.analysis_node_connection_c = (
+            AnalysisNodeConnection.objects.create(
+                analysis=self.analysis,
+                node=self.node,
+                step=3,
+                filename=self.node_filename,
+                direction=OUTPUT_CONNECTION,
+                is_refinery_file=True
             )
         )
         self.analysis_node_connection_with_node_analyzed_further = (
@@ -1561,26 +1573,25 @@ class AnalysisTests(TestCase):
         )
 
     def test___get_output_connection_to_analysis_result_mapping(self):
-        analysis_result_b = AnalysisResult.objects.create(
-            analysis_uuid=self.analysis.uuid,
-            file_store_uuid=self.node.file_uuid,
-            file_name=self.node_filename,
-            file_type=self.node.get_file_store_item().filetype
-        )
-        analysis_result_a = AnalysisResult.objects.create(
-            analysis_uuid=self.analysis.uuid,
-            file_store_uuid=self.node.file_uuid,
-            file_name=self.node_filename,
-            file_type=self.node.get_file_store_item().filetype
-        )
+        common_params = {
+            "analysis_uuid": self.analysis.uuid,
+            "file_store_uuid": self.node.file_uuid,
+            "file_name": self.node_filename,
+            "file_type": self.node.get_file_store_item().filetype
+        }
+        analysis_result_0 = AnalysisResult.objects.create(**common_params)
+        AnalysisResult.objects.create(**common_params)
+        analysis_result_1 = AnalysisResult.objects.create(**common_params)
+
         output_mapping = (
             self.analysis._get_output_connection_to_analysis_result_mapping()
         )
         self.assertEqual(
             output_mapping,
             [
-                (self.analysis_node_connection_b, analysis_result_b),
-                (self.analysis_node_connection_a, analysis_result_a)
+                (self.analysis_node_connection_a, analysis_result_1),
+                (self.analysis_node_connection_b, None),
+                (self.analysis_node_connection_c, analysis_result_0)
             ]
         )
 

--- a/refinery/core/tests.py
+++ b/refinery/core/tests.py
@@ -1595,6 +1595,20 @@ class AnalysisTests(TestCase):
             ]
         )
 
+    def test_analysis_node_connection_input_id(self):
+        self.assertEqual(
+            self.analysis_node_connection_a.get_input_connection_id(),
+            "{}_{}".format(self.analysis_node_connection_a.step,
+                           self.analysis_node_connection_a.filename)
+        )
+
+    def test_analysis_node_connection_output_id(self):
+        self.assertEqual(
+            self.analysis_node_connection_a.get_output_connection_id(),
+            "{}_{}".format(self.analysis_node_connection_a.step,
+                           self.analysis_node_connection_a.name)
+        )
+
 
 class UtilitiesTest(TestCase):
     def setUp(self):

--- a/refinery/core/tests.py
+++ b/refinery/core/tests.py
@@ -1589,9 +1589,9 @@ class AnalysisTests(TestCase):
         self.assertEqual(
             output_mapping,
             [
-                (self.analysis_node_connection_a, analysis_result_1),
+                (self.analysis_node_connection_c, analysis_result_0),
                 (self.analysis_node_connection_b, None),
-                (self.analysis_node_connection_c, analysis_result_0)
+                (self.analysis_node_connection_a, analysis_result_1)
             ]
         )
 

--- a/refinery/data_set_manager/models.py
+++ b/refinery/data_set_manager/models.py
@@ -478,6 +478,9 @@ class Node(models.Model):
         """
         return self.type in self._get_derived_node_types()
 
+    def is_orphan(self):
+        return self.parents.count() == 0
+
     def get_analysis_node_connections(self):
         return core.models.AnalysisNodeConnection.objects.filter(node=self)
 

--- a/refinery/data_set_manager/tests.py
+++ b/refinery/data_set_manager/tests.py
@@ -1446,6 +1446,11 @@ class NodeClassMethodTests(TestCase):
         # Check inverse relationship:
         self.assertEqual(self.another_node.uuid, self.node.get_children()[0])
 
+    def test_is_orphan(self):
+        self.assertTrue(self.another_node.is_orphan())
+        self.node.add_child(self.another_node)
+        self.assertFalse(self.another_node.is_orphan())
+
     # Auxiliary nodes:
 
     def test_create_and_associate_auxiliary_node(self):

--- a/refinery/data_set_manager/utils.py
+++ b/refinery/data_set_manager/utils.py
@@ -563,7 +563,6 @@ def _add_annotated_nodes(
 
     if len(bulk_list) > 0:
         AnnotatedNode.objects.bulk_create(bulk_list)
-        bulk_list = []
 
     end = time.time()
 

--- a/refinery/galaxy_connector/galaxy_workflow.py
+++ b/refinery/galaxy_connector/galaxy_workflow.py
@@ -527,9 +527,9 @@ def configure_workflow(workflow_dict, ret_list):
     return new_workflow, history_download, analysis_node_connections
 
 
-def create_expanded_workflow_graph(dictionary):
+def create_expanded_workflow_graph(galaxy_workflow_dict):
     graph = nx.MultiDiGraph()
-    steps = dictionary["steps"]
+    steps = galaxy_workflow_dict["steps"]
     galaxy_input_types = tool_manager.models.WorkflowTool.GALAXY_INPUT_TYPES
 
     # iterate over steps to create nodes

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -461,6 +461,7 @@ class WorkflowTool(Tool):
     """
     ANALYSIS_GROUP = "analysis_group"
     COLLECTION_INFO = "collection_info"
+    CREATING_JOB = "creating_job"
     DATA_INPUT = "data_input"
     DATA_COLLECTION_INPUT = "data_collection_input"
     FILE_RELATIONSHIPS_GALAXY = "{}_galaxy".format(Tool.FILE_RELATIONSHIPS)
@@ -842,7 +843,7 @@ class WorkflowTool(Tool):
     @handle_bioblend_exceptions
     def _get_galaxy_dataset_job(self, galaxy_dataset_dict):
         return self.galaxy_connection.jobs.show_job(
-            galaxy_dataset_dict["creating_job"]
+            galaxy_dataset_dict[self.CREATING_JOB]
         )
 
     @staticmethod
@@ -1050,7 +1051,7 @@ class WorkflowTool(Tool):
     def _get_workflow_step(self, galaxy_dataset_dict):
         workflow_steps = []
         for step in self._get_galaxy_workflow_invocation()["steps"]:
-            if step["job_id"] == galaxy_dataset_dict["creating_job"]:
+            if step["job_id"] == galaxy_dataset_dict[self.CREATING_JOB]:
                     workflow_steps.append(step["order_index"])
 
         if not workflow_steps:

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -477,6 +477,7 @@ class WorkflowTool(Tool):
     HISTORY_DATASET_COLLECTION_ASSOCIATION = "hdca"
     INPUT_DATASET = "Input Dataset"
     INPUT_DATASET_COLLECTION = "{} Collection".format(INPUT_DATASET)
+    INPUT_STEP_NUMBER = 0
     LIST = "list"
     PAIRED = "paired"
     REVERSE = "reverse"
@@ -593,7 +594,7 @@ class WorkflowTool(Tool):
                 node=node,
                 direction=INPUT_CONNECTION,
                 name=file_store_item.datafile.name,
-                step=0,
+                step=self.INPUT_STEP_NUMBER,
                 filename=self._get_analysis_node_connection_input_filename(),
                 is_refinery_file=file_store_item.is_local()
             )
@@ -1057,18 +1058,14 @@ class WorkflowTool(Tool):
         return self.get_tool_launch_config()[ToolDefinition.PARAMETERS]
 
     def _get_workflow_step(self, galaxy_dataset_dict):
-        workflow_steps = []
         for step in self._get_galaxy_workflow_invocation()["steps"]:
             if step["job_id"] == galaxy_dataset_dict[self.CREATING_JOB]:
-                    workflow_steps.append(step["order_index"])
+                    return step["order_index"]
 
         # If we reach this point and have no workflow_steps, this means that
         #  the galaxy dataset in question corresponds to an `upload` or
         # `input` step i.e. `0`
-        if not workflow_steps:
-            workflow_steps.append(0)
-
-        return workflow_steps[0]
+        return self.INPUT_STEP_NUMBER
 
     def _get_creating_job_output_name(self, galaxy_dataset_dict):
         """

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -830,8 +830,8 @@ class WorkflowTool(Tool):
         assert len(list(set(analysis_groups))) == 1, (
             "`analysis_groups` should only contain a single element."
         )
-        analysis_group_number = analysis_groups[0]
-        return analysis_group_number
+        analysis_group = analysis_groups[0]
+        return analysis_group
 
     def _get_analysis_node_connection_input_filename(self):
         return (

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -1062,13 +1062,12 @@ class WorkflowTool(Tool):
             if step["job_id"] == galaxy_dataset_dict[self.CREATING_JOB]:
                     workflow_steps.append(step["order_index"])
 
+        # If we reach this point and have no workflow_steps, this means that
+        #  the galaxy dataset in question corresponds to an `upload` or
+        # `input` step i.e. `0`
         if not workflow_steps:
             workflow_steps.append(0)
 
-        assert len(workflow_steps) == 1, (
-            "There should always be one corresponding workflow step, "
-            "but there are {}".format(len(workflow_steps))
-        )
         return workflow_steps[0]
 
     def _get_creating_job_output_name(self, galaxy_dataset_dict):

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -819,16 +819,17 @@ class WorkflowTool(Tool):
         )
         refinery_to_galaxy_file_mappings = self._get_galaxy_file_mapping_list()
 
-        analysis_group_number = None
-        for refinery_to_galaxy_file_map in refinery_to_galaxy_file_mappings:
-            if (refinery_input_file_id == refinery_to_galaxy_file_map[
-                    self.GALAXY_DATASET_HISTORY_ID]):
-                analysis_group_number = (
-                    refinery_to_galaxy_file_map[self.ANALYSIS_GROUP]
-                )
-        assert analysis_group_number is not None, (
-            "`analysis_group_number` shouldn't be `None`"
+        analysis_groups = [
+            refinery_to_galaxy_file_map[self.ANALYSIS_GROUP]
+            for refinery_to_galaxy_file_map in refinery_to_galaxy_file_mappings
+            if refinery_input_file_id == refinery_to_galaxy_file_map[
+                self.GALAXY_DATASET_HISTORY_ID
+            ]
+        ]
+        assert len(list(set(analysis_groups))) == 1, (
+            "`analysis_groups` should only contain a single element."
         )
+        analysis_group_number = analysis_groups[0]
         return analysis_group_number
 
     def _get_analysis_node_connection_input_filename(self):
@@ -1047,16 +1048,19 @@ class WorkflowTool(Tool):
         return self.get_tool_launch_config()[ToolDefinition.PARAMETERS]
 
     def _get_workflow_step(self, galaxy_dataset_dict):
-        workflow_step = None
+        workflow_steps = []
         for step in self._get_galaxy_workflow_invocation()["steps"]:
-            if step["job_id"] is not None:
-                if step["job_id"] == galaxy_dataset_dict["creating_job"]:
-                    workflow_step = step["order_index"]
-            else:
-                # Workflow steps that don't have a `job_id` correspond to an
-                #  input/upload step i.e. `0`
-                workflow_step = 0
-        return workflow_step
+            if step["job_id"] == galaxy_dataset_dict["creating_job"]:
+                    workflow_steps.append(step["order_index"])
+
+        if not workflow_steps:
+            workflow_steps.append(0)
+
+        assert len(workflow_steps) == 1, (
+            "There should always be one corresponding workflow step, "
+            "but there are {}".format(len(workflow_steps))
+        )
+        return workflow_steps[0]
 
     def _get_creating_job_output_name(self, galaxy_dataset_dict):
         """
@@ -1072,17 +1076,20 @@ class WorkflowTool(Tool):
         """
         creating_job = self._get_galaxy_dataset_job(galaxy_dataset_dict)
         creating_job_outputs = creating_job["outputs"]
-
-        workflow_step_output_name = None
-        for output_name in creating_job_outputs.keys():
-            if (creating_job_outputs[output_name]["uuid"] ==
-                    galaxy_dataset_dict["uuid"]):
-                workflow_step_output_name = output_name
-
-        assert workflow_step_output_name is not None, (
-            "There should be a creating job output name for a Galaxy Dataset"
+        logger.debug("Dataset: %s", galaxy_dataset_dict)
+        logger.debug("Creating job outputs: %s", creating_job_outputs)
+        workflow_step_output_name = [
+            output_name for output_name in creating_job_outputs.keys()
+            if creating_job_outputs[output_name]["uuid"] ==
+            galaxy_dataset_dict["uuid"]
+        ]
+        assert len(workflow_step_output_name) == 1, (
+            "There should only be one creating job output name for a "
+            "Galaxy dataset. There were: {}".format(
+                len(workflow_step_output_name)
+            )
         )
-        return workflow_step_output_name
+        return workflow_step_output_name[0]
 
     def _has_dataset_collection_input(self):
         """

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -869,14 +869,17 @@ class WorkflowTool(Tool):
         Galaxy Workflow invocation all tool outputs in the Galaxy Workflow
         editor.
         """
-        dataset_list = self.galaxy_connection.histories.show_matching_datasets(
-            self.galaxy_workflow_history_id
+        galaxy_dataset_list = (
+            self.galaxy_connection.histories.show_matching_datasets(
+                self.galaxy_workflow_history_id
+            )
         )
-        non_purged_datasets = [
-            dataset for dataset in dataset_list
-            if not dataset["purged"] and self._get_workflow_step(dataset) > 0
+        retained_datasets = [
+            galaxy_dataset for galaxy_dataset in galaxy_dataset_list
+            if not galaxy_dataset["purged"] and
+            self._get_workflow_step(galaxy_dataset) > 0
         ]
-        return non_purged_datasets
+        return retained_datasets
 
     def _get_exposed_workflow_outputs(self):
         """

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -1081,8 +1081,6 @@ class WorkflowTool(Tool):
         """
         creating_job = self._get_galaxy_dataset_job(galaxy_dataset_dict)
         creating_job_outputs = creating_job["outputs"]
-        logger.debug("Dataset: %s", galaxy_dataset_dict)
-        logger.debug("Creating job outputs: %s", creating_job_outputs)
         workflow_step_output_name = [
             output_name for output_name in creating_job_outputs.keys()
             if creating_job_outputs[output_name]["uuid"] ==

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -893,22 +893,25 @@ class WorkflowTool(Tool):
         outputs of the WorkflowTool's Galaxy Workflow that have been
         explicitly exposed
         """
-        visible_datasets = []
-        for dataset in self._get_galaxy_history_dataset_list():
-            creating_job = self._get_galaxy_dataset_job(dataset)
+        exposed_galaxy_datasets = []
+        for galaxy_dataset in self._get_galaxy_history_dataset_list():
+            creating_job = self._get_galaxy_dataset_job(galaxy_dataset)
+
+            # `tool_id` corresponds to the descriptive name of a galaxy
+            # tool. Not a UUID-like string like one may think
             if "upload" not in creating_job["tool_id"]:
-                workflow_step = self._get_workflow_step(dataset)
+                workflow_step = self._get_workflow_step(galaxy_dataset)
                 workflow_steps = self._get_workflow_dict()["steps"]
                 creating_job_output_name = (
-                    self._get_creating_job_output_name(dataset)
+                    self._get_creating_job_output_name(galaxy_dataset)
                 )
                 workflow_output_names = [
                     output["output_name"] for output in
                     workflow_steps[str(workflow_step)]["workflow_outputs"]
                 ]
                 if creating_job_output_name in workflow_output_names:
-                    visible_datasets.append(dataset)
-        return visible_datasets
+                    exposed_galaxy_datasets.append(galaxy_dataset)
+        return exposed_galaxy_datasets
 
     def get_galaxy_dict(self):
         """

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -1234,7 +1234,7 @@ class WorkflowTool(Tool):
     @handle_bioblend_exceptions
     def upload_datafile_to_library_from_url(self, library_id, datafile_url):
         """
-        Upload file from Refinery into a Galaxy Data Library form a
+        Upload file from Refinery into a Galaxy Data Library from a
         specified url
         :param library_id: UUID string of the Galaxy Library to interact with
         :param datafile_url: <String> Full url pointing to a Refinery

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -900,16 +900,18 @@ class WorkflowTool(Tool):
             # `tool_id` corresponds to the descriptive name of a galaxy
             # tool. Not a UUID-like string like one may think
             if "upload" not in creating_job["tool_id"]:
-                workflow_step = self._get_workflow_step(galaxy_dataset)
-                workflow_steps = self._get_workflow_dict()["steps"]
+                workflow_step_key = str(
+                    self._get_workflow_step(galaxy_dataset)
+                )
+                workflow_steps_dict = self._get_workflow_dict()["steps"]
                 creating_job_output_name = (
                     self._get_creating_job_output_name(galaxy_dataset)
                 )
-                workflow_output_names = [
-                    output["output_name"] for output in
-                    workflow_steps[str(workflow_step)]["workflow_outputs"]
+                workflow_step_output_names = [
+                    workflow_output["output_name"] for workflow_output in
+                    workflow_steps_dict[workflow_step_key]["workflow_outputs"]
                 ]
-                if creating_job_output_name in workflow_output_names:
+                if creating_job_output_name in workflow_step_output_names:
                     exposed_galaxy_datasets.append(galaxy_dataset)
         return exposed_galaxy_datasets
 

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -866,8 +866,8 @@ class WorkflowTool(Tool):
     def _get_galaxy_history_dataset_list(self):
         """
         Retrieve a list of Galaxy Datasets from the Galaxy History of our
-        Galaxy Workflow invocation That correspond to the selected tool
-        outputs in the Galaxy Workflow editor.
+        Galaxy Workflow invocation all tool outputs in the Galaxy Workflow
+        editor.
         """
         dataset_list = self.galaxy_connection.histories.show_matching_datasets(
             self.galaxy_workflow_history_id

--- a/refinery/tool_manager/test_data/galaxy_mocks.py
+++ b/refinery/tool_manager/test_data/galaxy_mocks.py
@@ -59,6 +59,28 @@ galaxy_workflow_dict = {
                     u'id': 0
                 }
             },
+            u'workflow_outputs': [
+                {
+                    u'output_name': u'Refinery test tool LIST - N on data 2',
+                    u'uuid': u'db331eb4-313a-47e0-9998-0e4aa03786d4',
+                },
+                {
+                    u'output_name': u'Refinery test tool LIST - N on data 4',
+                    u'uuid': u'8adc43a1-e075-4ad5-be6a-b9791532b801',
+                },
+                {
+                    u'output_name': u'Output file',
+                    u'uuid': u'adc43a1-e075-4ad5-be6a-b9791532b8018',
+                },
+                {
+                    u'output_name': u'Output file',
+                    u'uuid': u'adc43a1-e075-4ad5-be6a-b9791532b8018',
+                },
+                {
+                    u'output_name': u'Output file',
+                    u'uuid': u'adc43a1-e075-4ad5-be6a-b9791532b8018',
+                }
+            ],
             u'name': u'Refinery test tool LIST - N',
             u'type': u'tool',
             u'position': {
@@ -80,7 +102,6 @@ galaxy_workflow_dict = {
         }
     }
 }
-
 galaxy_workflow_dict_collection = {
     u'name': u'list test wf',
     u'steps': {
@@ -93,6 +114,16 @@ galaxy_workflow_dict_collection = {
                     u'id': 0
                 }
             },
+            u'workflow_outputs': [
+                {
+                    u'output_name': u'Refinery test tool LIST - N on data 2',
+                    u'uuid': u'db331eb4-313a-47e0-9998-0e4aa03786d4',
+                },
+                {
+                    u'output_name': u'Refinery test tool LIST - N on data 4',
+                    u'uuid': u'8adc43a1-e075-4ad5-be6a-b9791532b801',
+                }
+            ],
             u'name': u'Refinery test tool LIST - N',
             u'type': u'tool',
             u'position': {
@@ -126,10 +157,11 @@ galaxy_datasets_list = [
         u'name': u'Refinery test tool LIST - N on data 4',
         u'file_ext': u'txt',
         u'url': u'/api/histories/67ce804af6ec796b/contents/d32aba4ae7b4124a',
-        u'purged': False
+        u'purged': False,
+        u'uuid': u'8adc43a1-e075-4ad5-be6a-b9791532b801'
     },
     {
-        u'creating_job': u'1d1dbe75827398cd',
+        u'creating_job': u'efwefwee75g27398cd',
         u'file_size': 406,
         u'dataset_id': u'34g34g34g3g34g3',
         u'id': u'd22aba4ae7b4124a',
@@ -138,10 +170,11 @@ galaxy_datasets_list = [
         u'name': u'Refinery test tool LIST - N on data 3',
         u'file_ext': u'txt',
         u'url': u'/api/histories/67ce804af6ec796b/contents/d32aba4ae7b4124a',
-        u'purged': False
+        u'purged': False,
+        u'uuid': u'5b5625c7-3c28-4542-b9c5-2ca9cee301b0'
     },
     {
-        u'creating_job': u'32456789rwjefvtg7',
+        u'creating_job': u'efwefwee75g27398cd',
         u'file_size': 406,
         u'dataset_id': u'4gh33gt34g34g',
         u'id': u'd32aba4ae7b4124a',
@@ -150,7 +183,8 @@ galaxy_datasets_list = [
         u'name': u'Refinery test tool LIST - N on data 2',
         u'file_ext': u'txt',
         u'url': u'/api/histories/67ce804af6ec796b/contents/d32aba4ae7b4124a',
-        u'purged': True
+        u'purged': True,
+        u'uuid': u'db331eb4-313a-47e0-9998-0e4aa03786d4'
     }
 ]
 
@@ -165,10 +199,11 @@ galaxy_datasets_list_same_output_names = [
         u'name': u'Output file',
         u'file_ext': u'txt',
         u'url': u'/api/histories/67ce804af6ec796b/contents/d32aba4ae7b4124a',
-        u'purged': False
+        u'purged': False,
+        u'uuid': u'adc43a1-e075-4ad5-be6a-b9791532b8018'
     },
     {
-        u'creating_job': u'1d1dbe75827398cd',
+        u'creating_job': u'efwefwee75g27398cd',
         u'file_size': 406,
         u'dataset_id': u'34g34g34g3g34g3',
         u'id': u'd22aba4ae7b4124a',
@@ -177,10 +212,11 @@ galaxy_datasets_list_same_output_names = [
         u'name': u'Output file',
         u'file_ext': u'txt',
         u'url': u'/api/histories/67ce804af6ec796b/contents/d32aba4ae7b4124a',
-        u'purged': False
+        u'purged': False,
+        u'uuid': u'adc43a1-e075-4ad5-be6a-b9791532b8018'
     },
     {
-        u'creating_job': u'32456789rwjefvtg7',
+        u'creating_job': u'efwefwee75g27398cd',
         u'file_size': 406,
         u'dataset_id': u'4gh33gt34g34g',
         u'id': u'd32aba4ae7b4124a',
@@ -189,7 +225,8 @@ galaxy_datasets_list_same_output_names = [
         u'name': u'Output file',
         u'file_ext': u'txt',
         u'url': u'/api/histories/67ce804af6ec796b/contents/d32aba4ae7b4124a',
-        u'purged': True
+        u'purged': True,
+        u'uuid': u'adc43a1-e075-4ad5-be6a-b9791532b8018'
     }
 ]
 
@@ -215,34 +252,49 @@ galaxy_history_download_list = [
     {
         u'name': u'Refinery test tool LIST - N on data 4',
         u'state': u'ok', u'file_size': 211,
-        u'dataset_id': u'8ee788c99983ff96', u'type': u'txt'
+        u'dataset_id': u'8ee788c99983ff96', u'type': u'txt',
+        u'uuid': u'8adc43a1-e075-4ad5-be6a-b9791532b801'
     },
     {
         u'name': u'Refinery test tool LIST - N on data 3',
         u'state': u'ok', u'file_size': 211,
-        u'dataset_id': u'14bb1cdaa43f5769', u'type': u'txt'
+        u'dataset_id': u'14bb1cdaa43f5769', u'type': u'txt',
+        u'uuid': u'5b5625c7-3c28-4542-b9c5-2ca9cee301b0'
+
     },
     {
         u'name': u'Refinery test tool LIST - N on data 2',
         u'state': u'ok', u'file_size': 714,
-        u'dataset_id': u'953f3a3e2982a4fa', u'type': u'txt'
+        u'dataset_id': u'953f3a3e2982a4fa', u'type': u'txt',
+        u'uuid': u'db331eb4-313a-47e0-9998-0e4aa03786d4'
+
     }
 ]
 galaxy_history_download_list_same_names = [
     {
         u'name': u'Output file',
         u'state': u'ok', u'file_size': 211,
-        u'dataset_id': u'8ee788c99983ff96', u'type': u'txt'
+        u'dataset_id': u'8ee788c99983ff96', u'type': u'txt',
+        u'uuid': u'adc43a1-e075-4ad5-be6a-b9791532b8018'
+
     },
     {
         u'name': u'Output file',
-        u'state': u'ok', u'file_size': 211,
-        u'dataset_id': u'14bb1cdaa43f5769', u'type': u'txt'
+        u'state': u'ok',
+        u'file_size': 211,
+        u'dataset_id': u'14bb1cdaa43f5769',
+        u'type': u'txt',
+        u'uuid': u'adc43a1-e075-4ad5-be6a-b9791532b8018'
+
     },
     {
         u'name': u'Output file',
-        u'state': u'ok', u'file_size': 714,
-        u'dataset_id': u'953f3a3e2982a4fa', u'type': u'txt'
+        u'state': u'ok',
+        u'file_size': 714,
+        u'dataset_id': u'953f3a3e2982a4fa',
+        u'type': u'txt',
+        u'uuid': u'adc43a1-e075-4ad5-be6a-b9791532b8018'
+
     }
 ]
 
@@ -269,8 +321,21 @@ galaxy_job = {
         }
     },
     u'outputs': {
-        u'output_file': {
-            u'src': u'hda', u'id': u'6189d907339532bf'
+        u'Refinery test tool LIST - N on data 4': {
+            u'src': u'hda',
+            u'uuid': u'8adc43a1-e075-4ad5-be6a-b9791532b801'
+        },
+        u'Refinery test tool LIST - N on data 3': {
+            u'src': u'hda',
+            u'uuid': u'5b5625c7-3c28-4542-b9c5-2ca9cee301b0'
+        },
+        u'Refinery test tool LIST - N on data 2': {
+            u'src': u'hda',
+            u'uuid': u'db331eb4-313a-47e0-9998-0e4aa03786d4'
+        },
+        u'Output file': {
+            u'src': u'hda',
+            u'uuid': u'adc43a1-e075-4ad5-be6a-b9791532b8018'
         }
     },
     u'exit_code': 0,
@@ -287,7 +352,7 @@ galaxy_job = {
     },
     u'model_class': u'Job',
     u'external_id': u'16585',
-    u'id': u'38fe481bc1c2ecc0'
+    u'id': u'efwefwee75g27398cd'
 }
 
 galaxy_dataset_provenance_0 = {

--- a/refinery/tool_manager/test_data/galaxy_mocks.py
+++ b/refinery/tool_manager/test_data/galaxy_mocks.py
@@ -51,7 +51,7 @@ galaxy_workflow_dict = {
     u'name': u'list test wf',
     u'steps': {
         u'1': {
-            u'tool_id': u'refinery_test_LIST-N-2',
+            u'tool_id': u'refinery_test_LIST-N-1',
             u'id': 1,
             u'input_connections': {
                 u'input_file': {
@@ -69,7 +69,17 @@ galaxy_workflow_dict = {
                     u'uuid': u'adc43a1-e075-4ad5-be6a-b9791532b8018',
                 }
             ],
-            u'name': u'Refinery test tool LIST - N',
+            u'outputs': [
+                {
+                    u'type': u'txt',
+                    u'name': u'Refinery test tool LIST - N on data 4'
+                },
+                {
+                    u'type': u'txt',
+                    u'name': u'Output file'
+                }
+            ],
+            u'name': u'Refinery test tool LIST - N - 1',
             u'type': u'tool',
             u'position': {
                 u'top': 513,
@@ -77,12 +87,12 @@ galaxy_workflow_dict = {
             }
         },
         u'2': {
-            u'tool_id': u'refinery_test_LIST-N-1',
+            u'tool_id': u'refinery_test_LIST-N-2',
             u'id': 2,
             u'input_connections': {
-                u'input_file': {
-                    u'output_name': u'output',
-                    u'id': 0
+                u'input_name': {
+                    u'output_name': u'Refinery test tool LIST - N on data 4',
+                    u'id': 1
                 }
             },
             u'workflow_outputs': [
@@ -95,7 +105,17 @@ galaxy_workflow_dict = {
                     u'uuid': u'adc43a1-4ad5-e075-be6a-b9791532b8018',
                 }
             ],
-            u'name': u'Refinery test tool LIST - N',
+            u'outputs': [
+                {
+                    u'type': u'txt',
+                    u'name': u'Refinery test tool LIST - N on data 3'
+                },
+                {
+                    u'type': u'txt',
+                    u'name': u'Output file'
+                }
+            ],
+            u'name': u'Refinery test tool LIST - N - 2',
             u'type': u'tool',
             u'position': {
                 u'top': 513,
@@ -120,7 +140,7 @@ galaxy_workflow_dict_collection = {
     u'name': u'list test wf',
     u'steps': {
         u'1': {
-            u'tool_id': u'refinery_test_LIST-N-2',
+            u'tool_id': u'refinery_test_LIST-N-1',
             u'id': 1,
             u'input_connections': {
                 u'input_file': {
@@ -138,7 +158,17 @@ galaxy_workflow_dict_collection = {
                     u'uuid': u'adc43a1-e075-4ad5-be6a-b9791532b8018',
                 }
             ],
-            u'name': u'Refinery test tool LIST - N',
+            u'outputs': [
+                {
+                    u'type': u'txt',
+                    u'name': u'Refinery test tool LIST - N on data 4'
+                },
+                {
+                    u'type': u'txt',
+                    u'name': u'Output file'
+                }
+            ],
+            u'name': u'Refinery test tool LIST - N - 1',
             u'type': u'tool',
             u'position': {
                 u'top': 513,
@@ -146,12 +176,12 @@ galaxy_workflow_dict_collection = {
             }
         },
         u'2': {
-            u'tool_id': u'refinery_test_LIST-N-1',
+            u'tool_id': u'refinery_test_LIST-N-2',
             u'id': 2,
             u'input_connections': {
-                u'input_file': {
-                    u'output_name': u'output',
-                    u'id': 0
+                u'input_name': {
+                    u'output_name': u'Refinery test tool LIST - N on data 4',
+                    u'id': 1
                 }
             },
             u'workflow_outputs': [
@@ -164,7 +194,17 @@ galaxy_workflow_dict_collection = {
                     u'uuid': u'adc43a1-4ad5-e075-be6a-b9791532b8018',
                 }
             ],
-            u'name': u'Refinery test tool LIST - N',
+            u'outputs': [
+                {
+                    u'type': u'txt',
+                    u'name': u'Refinery test tool LIST - N on data 3'
+                },
+                {
+                    u'type': u'txt',
+                    u'name': u'Output file'
+                }
+            ],
+            u'name': u'Refinery test tool LIST - N - 2',
             u'type': u'tool',
             u'position': {
                 u'top': 513,

--- a/refinery/tool_manager/test_data/galaxy_mocks.py
+++ b/refinery/tool_manager/test_data/galaxy_mocks.py
@@ -51,7 +51,7 @@ galaxy_workflow_dict = {
     u'name': u'list test wf',
     u'steps': {
         u'1': {
-            u'tool_id': u'refinery_test_LIST-N',
+            u'tool_id': u'refinery_test_LIST-N-2',
             u'id': 1,
             u'input_connections': {
                 u'input_file': {
@@ -61,24 +61,38 @@ galaxy_workflow_dict = {
             },
             u'workflow_outputs': [
                 {
-                    u'output_name': u'Refinery test tool LIST - N on data 2',
-                    u'uuid': u'db331eb4-313a-47e0-9998-0e4aa03786d4',
-                },
-                {
                     u'output_name': u'Refinery test tool LIST - N on data 4',
                     u'uuid': u'8adc43a1-e075-4ad5-be6a-b9791532b801',
                 },
                 {
                     u'output_name': u'Output file',
                     u'uuid': u'adc43a1-e075-4ad5-be6a-b9791532b8018',
+                }
+            ],
+            u'name': u'Refinery test tool LIST - N',
+            u'type': u'tool',
+            u'position': {
+                u'top': 513,
+                u'left': 822
+            }
+        },
+        u'2': {
+            u'tool_id': u'refinery_test_LIST-N-1',
+            u'id': 2,
+            u'input_connections': {
+                u'input_file': {
+                    u'output_name': u'output',
+                    u'id': 0
+                }
+            },
+            u'workflow_outputs': [
+                {
+                    u'output_name': u'Refinery test tool LIST - N on data 3',
+                    u'uuid': u'5b5625c7-3c28-4542-b9c5-2ca9cee301b0',
                 },
                 {
                     u'output_name': u'Output file',
-                    u'uuid': u'adc43a1-e075-4ad5-be6a-b9791532b8018',
-                },
-                {
-                    u'output_name': u'Output file',
-                    u'uuid': u'adc43a1-e075-4ad5-be6a-b9791532b8018',
+                    u'uuid': u'adc43a1-4ad5-e075-be6a-b9791532b8018',
                 }
             ],
             u'name': u'Refinery test tool LIST - N',
@@ -106,7 +120,7 @@ galaxy_workflow_dict_collection = {
     u'name': u'list test wf',
     u'steps': {
         u'1': {
-            u'tool_id': u'refinery_test_LIST-N',
+            u'tool_id': u'refinery_test_LIST-N-2',
             u'id': 1,
             u'input_connections': {
                 u'input_file': {
@@ -116,12 +130,38 @@ galaxy_workflow_dict_collection = {
             },
             u'workflow_outputs': [
                 {
-                    u'output_name': u'Refinery test tool LIST - N on data 2',
-                    u'uuid': u'db331eb4-313a-47e0-9998-0e4aa03786d4',
-                },
-                {
                     u'output_name': u'Refinery test tool LIST - N on data 4',
                     u'uuid': u'8adc43a1-e075-4ad5-be6a-b9791532b801',
+                },
+                {
+                    u'output_name': u'Output file',
+                    u'uuid': u'adc43a1-e075-4ad5-be6a-b9791532b8018',
+                }
+            ],
+            u'name': u'Refinery test tool LIST - N',
+            u'type': u'tool',
+            u'position': {
+                u'top': 513,
+                u'left': 822
+            }
+        },
+        u'2': {
+            u'tool_id': u'refinery_test_LIST-N-1',
+            u'id': 2,
+            u'input_connections': {
+                u'input_file': {
+                    u'output_name': u'output',
+                    u'id': 0
+                }
+            },
+            u'workflow_outputs': [
+                {
+                    u'output_name': u'Refinery test tool LIST - N on data 3',
+                    u'uuid': u'5b5625c7-3c28-4542-b9c5-2ca9cee301b0',
+                },
+                {
+                    u'output_name': u'Output file',
+                    u'uuid': u'adc43a1-4ad5-e075-be6a-b9791532b8018',
                 }
             ],
             u'name': u'Refinery test tool LIST - N',
@@ -148,7 +188,7 @@ galaxy_workflow_dict_collection = {
 
 galaxy_datasets_list = [
     {
-        u'creating_job': u'efwefwee75g27398cd',
+        u'creating_job': u'JOB_A_ID',
         u'file_size': 406,
         u'dataset_id': u'gergg34g34g44',
         u'id': u'd32aba4ae7b4124a',
@@ -161,7 +201,7 @@ galaxy_datasets_list = [
         u'uuid': u'8adc43a1-e075-4ad5-be6a-b9791532b801'
     },
     {
-        u'creating_job': u'efwefwee75g27398cd',
+        u'creating_job': u'JOB_B_ID',
         u'file_size': 406,
         u'dataset_id': u'34g34g34g3g34g3',
         u'id': u'd22aba4ae7b4124a',
@@ -174,7 +214,7 @@ galaxy_datasets_list = [
         u'uuid': u'5b5625c7-3c28-4542-b9c5-2ca9cee301b0'
     },
     {
-        u'creating_job': u'efwefwee75g27398cd',
+        u'creating_job': u'JOB_A_ID',
         u'file_size': 406,
         u'dataset_id': u'4gh33gt34g34g',
         u'id': u'd32aba4ae7b4124a',
@@ -190,7 +230,7 @@ galaxy_datasets_list = [
 
 galaxy_datasets_list_same_output_names = [
     {
-        u'creating_job': u'efwefwee75g27398cd',
+        u'creating_job': u'JOB_A_ID',
         u'file_size': 406,
         u'dataset_id': u'gergg34g34g44',
         u'id': u'd32aba4ae7b4124a',
@@ -200,10 +240,10 @@ galaxy_datasets_list_same_output_names = [
         u'file_ext': u'txt',
         u'url': u'/api/histories/67ce804af6ec796b/contents/d32aba4ae7b4124a',
         u'purged': False,
-        u'uuid': u'adc43a1-e075-4ad5-be6a-b9791532b8018'
+        u'uuid': u'adc43a1-4ad5-e075-be6a-b9791532b8018'
     },
     {
-        u'creating_job': u'efwefwee75g27398cd',
+        u'creating_job': u'JOB_B_ID',
         u'file_size': 406,
         u'dataset_id': u'34g34g34g3g34g3',
         u'id': u'd22aba4ae7b4124a',
@@ -216,7 +256,7 @@ galaxy_datasets_list_same_output_names = [
         u'uuid': u'adc43a1-e075-4ad5-be6a-b9791532b8018'
     },
     {
-        u'creating_job': u'efwefwee75g27398cd',
+        u'creating_job': u'JOB_A_ID',
         u'file_size': 406,
         u'dataset_id': u'4gh33gt34g34g',
         u'id': u'd32aba4ae7b4124a',
@@ -226,7 +266,7 @@ galaxy_datasets_list_same_output_names = [
         u'file_ext': u'txt',
         u'url': u'/api/histories/67ce804af6ec796b/contents/d32aba4ae7b4124a',
         u'purged': True,
-        u'uuid': u'adc43a1-e075-4ad5-be6a-b9791532b8018'
+        u'uuid': u'adc43a1-4ad5-e075-be6a-b9791532b8018'
     }
 ]
 
@@ -235,14 +275,11 @@ galaxy_workflow_invocation = {
     u'history_id': u'67ce804af6ec796b',
     u'workflow_id': u'4a56addbcc836c23',
     u'steps': [
-        {u'job_id': u'1d1dbe75827398cd', u'order_index': 1,
+        {u'job_id': u'JOB_A_ID', u'order_index': 1,
          u'workflow_step_id': u'507bf06c009b95ec',
          u'id': u'ae7005de11c97062'},
-        {u'job_id': u'efwefwee75g27398cd', u'order_index': 1,
-         u'workflow_step_id': u'507bg06c009b95ec',
-         u'id': u'ae7005de11c97062'},
-        {u'job_id': u'32456789rwjefvtg7', u'order_index': 1,
-         u'workflow_step_id': u'507bg06c009b95ec',
+        {u'job_id': u'JOB_B_ID', u'order_index': 2,
+         u'workflow_step_id': u'0g09e6c0c50b957b',
          u'id': u'45765uytrerd2t4'}
     ],
     u'id': u'ddaca2bad6847b13'
@@ -275,7 +312,7 @@ galaxy_history_download_list_same_names = [
         u'name': u'Output file',
         u'state': u'ok', u'file_size': 211,
         u'dataset_id': u'8ee788c99983ff96', u'type': u'txt',
-        u'uuid': u'adc43a1-e075-4ad5-be6a-b9791532b8018'
+        u'uuid': u'adc43a1-4ad5-e075-be6a-b9791532b8018'
 
     },
     {
@@ -293,7 +330,7 @@ galaxy_history_download_list_same_names = [
         u'file_size': 714,
         u'dataset_id': u'953f3a3e2982a4fa',
         u'type': u'txt',
-        u'uuid': u'adc43a1-e075-4ad5-be6a-b9791532b8018'
+        u'uuid': u'adc43a1-4ad5-e075-be6a-b9791532b8018'
 
     }
 ]
@@ -311,7 +348,7 @@ galaxy_tool_data = {
     u'id': u'refinery_test_LIST-N',
     u'name': u'Refinery test tool LIST - N'}
 
-galaxy_job = {
+galaxy_job_a = {
     u'tool_id': u'refinery_test_1-1/0.1',
     u'update_time': u'2017-08-29T14:53:07.283924',
     u'inputs': {
@@ -325,13 +362,40 @@ galaxy_job = {
             u'src': u'hda',
             u'uuid': u'8adc43a1-e075-4ad5-be6a-b9791532b801'
         },
+        u'Output file': {
+            u'src': u'hda',
+            u'uuid': u'adc43a1-4ad5-e075-be6a-b9791532b8018'
+        }
+    },
+    u'exit_code': 0,
+    u'state': u'ok',
+    u'create_time': u'2017-08-29T14:53:02.518515',
+    u'params': {
+        u'__workflow_invocation_uuid__': u'"c11aecf08cc911e786c3a0999b05d96b"',
+        u'stdout': u'"False"',
+        u'exit_code': u'"0"',
+        u'p_fail': u'"0.0"',
+        u'empty_outfile': u'"False"',
+        u'stderr': u'"False"',
+        u'sleep_time': u'"0"'
+    },
+    u'model_class': u'Job',
+    u'external_id': u'16585',
+    u'id': u'JOB_A_ID'
+}
+galaxy_job_b = {
+    u'tool_id': u'refinery_test_1-2/0.1',
+    u'update_time': u'2017-08-29T14:53:07.283924',
+    u'inputs': {
+        u'input_file': {
+            u'src': u'hda', u'id': u'0dd7fa018f646963',
+            u'uuid': u'e26b0ec5-7b74-451d-a0a0-63dac713ecf8'
+        }
+    },
+    u'outputs': {
         u'Refinery test tool LIST - N on data 3': {
             u'src': u'hda',
             u'uuid': u'5b5625c7-3c28-4542-b9c5-2ca9cee301b0'
-        },
-        u'Refinery test tool LIST - N on data 2': {
-            u'src': u'hda',
-            u'uuid': u'db331eb4-313a-47e0-9998-0e4aa03786d4'
         },
         u'Output file': {
             u'src': u'hda',
@@ -352,12 +416,12 @@ galaxy_job = {
     },
     u'model_class': u'Job',
     u'external_id': u'16585',
-    u'id': u'efwefwee75g27398cd'
+    u'id': u'JOB_B_ID'
 }
 
 galaxy_dataset_provenance_0 = {
     u'tool_id': u'refinery_test_1-1/0.1',
-    u'job_id': u'79623814bfa3e11b',
+    u'job_id': u'JOB_B_ID',
     u'parameters': {
         u'input_file': {
             u'id': u'3490b582fa824276',
@@ -378,7 +442,7 @@ galaxy_dataset_provenance_0 = {
 
 galaxy_dataset_provenance_1 = {
     u'tool_id': u'upload1',
-    u'job_id': u'7fc964d8785be9fd',
+    u'job_id': u'JOB_A_ID',
     u'parameters': {
         u'uuid': u'null',
         u'file_type': u'"auto"',

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -55,7 +55,9 @@ from core.models import (INPUT_CONNECTION, OUTPUT_CONNECTION, Analysis,
                          AnalysisNodeConnection, AnalysisResult, ExtendedGroup,
                          Project, Workflow, WorkflowEngine, WorkflowFilesDL)
 from data_set_manager.models import AnnotatedNode, Assay, Attribute, Node
-from factory_boy.django_model_factories import ToolFactory
+from factory_boy.django_model_factories import (AnnotatedNodeFactory,
+                                                AttributeFactory, NodeFactory,
+                                                ToolFactory)
 from factory_boy.utils import create_dataset_with_necessary_models
 from file_store.models import FileStoreItem
 from galaxy_connector.models import Instance
@@ -1259,20 +1261,20 @@ class WorkflowToolTests(ToolManagerTestBase):
         study = self.dataset.get_latest_study()
         assay = Assay.objects.get(study=study)
 
-        node = Node.objects.create(
+        node = NodeFactory(
             name="Node {}".format(uuid.uuid4()),
             assay=assay,
             study=study,
             type=Node.RAW_DATA_FILE,
             file_uuid=self.file_store_item.uuid
         )
-        attribute = Attribute.objects.create(
+        attribute = AttributeFactory(
             node=node,
             type=Attribute.CHARACTERISTICS,
             subtype='coffee',
             value='coffee'
         )
-        AnnotatedNode.objects.create(
+        AnnotatedNodeFactory(
             node_id=node.id,
             attribute_id=attribute.id,
             study=study,

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -1651,9 +1651,8 @@ class WorkflowToolTests(ToolManagerTestBase):
 
         self.assertEqual(AnalysisResult.objects.count(), 3)
 
-        # There will be two less WorkflowFilesDL because one of our mock
-        # datasets has been "purged", and one of them isn't a specified
-        # workflow_output
+        # There will be one less WorkflowFilesDL because one of our mock
+        # datasets has been "purged"
         self.assertEqual(WorkflowFilesDL.objects.count(), 2)
         self.assertEqual(
             AnalysisResult.objects.count(),


### PR DESCRIPTION
- Fix bug where Derived Data `Nodes` did not inherit their parent's `Attributes`
- Constrain `WorkflowFilesDL` creation to asterisked outputs of a Galaxy Workflow (This is way easier than having an end-user specify outputs they want returned to Refinery by name. They simply have to [check the asterisk next to the output files in their Workflow Editor](https://galaxyproject.org/learn/advanced-workflow/basic-editing/#hidden_datasets))
---
Tests to write:
- [x] `is_orphan`
- [x] `_get_exposed_workflow_outputs`
- [x] `_get_creating_job_output_name`
- [x] tests for the [data transformation node & derived data node association](https://github.com/refinery-platform/refinery-platform/blob/develop/refinery/core/models.py#L1732-L1752) (this was particularly tricky to debug over the past couple of days)
--- 
- [x] Document asterisking of outputs: https://github.com/refinery-platform/refinery-platform/wiki/Annotating-&-Importing-Refinery-Tools#exposing-galaxy-workflow-outputs-to-refinery
- [x] Make sure test coverage is up to par