### PR TITLE
Mccalluc/remove old check from provvis 2190

### DIFF
--- a/refinery/static/source/js/refinery/contents.js
+++ b/refinery/static/source/js/refinery/contents.js
@@ -237,7 +237,7 @@
           }
 
           /* Set face attributes for nodes in Provenance Visualization.*/
-          if (arguments.query == provVisQuery && provvis.get() instanceof provvisDecl.ProvVis === false) {
+          if (arguments.query == provVisQuery && ! provvis.get() instanceof provvisDecl.ProvVis && dataSetMonitor.analyses) {
             provvis.run(currentStudyUuid, dataSetMonitor.analyses.objects, arguments.response);
           }
 
@@ -246,7 +246,7 @@
           }
 
           /* Update Provenance Visualization by filtered nodeset. */
-          if (($('.nav-pills li.active a').attr('href').split("#")[1] === 'provenance-view-tab') && arguments.query == provVisQuery && provvis.get() instanceof provvisDecl.ProvVis) {
+          if (arguments.query == provVisQuery && provvis.get() instanceof provvisDecl.ProvVis) {
             provvisRender.update(provvis.get(), arguments.response);
           }
         });

--- a/refinery/static/source/js/refinery/contents.js
+++ b/refinery/static/source/js/refinery/contents.js
@@ -236,18 +236,18 @@
             pivotMatrixView.updateMatrix(arguments.response);
           }
 
-          /* Set face attributes for nodes in Provenance Visualization.*/
-          if (arguments.query == provVisQuery && ! provvis.get() instanceof provvisDecl.ProvVis && dataSetMonitor.analyses) {
-            provvis.run(currentStudyUuid, dataSetMonitor.analyses.objects, arguments.response);
-          }
-
           if (arguments.query == provVisQuery) {
-            lastProvVisSolrResponse = arguments.response;
-          }
+            /* Set face attributes for nodes in Provenance Visualization.*/
+            if (! provvis.get() instanceof provvisDecl.ProvVis && dataSetMonitor.analyses) {
+              provvis.run(currentStudyUuid, dataSetMonitor.analyses.objects, arguments.response);
+            }
 
-          /* Update Provenance Visualization by filtered nodeset. */
-          if (arguments.query == provVisQuery && provvis.get() instanceof provvisDecl.ProvVis) {
-            provvisRender.update(provvis.get(), arguments.response);
+            lastProvVisSolrResponse = arguments.response;
+
+            /* Update Provenance Visualization by filtered nodeset. */
+            if (provvis.get() instanceof provvisDecl.ProvVis) {
+              provvisRender.update(provvis.get(), arguments.response);
+            }
           }
         });
 


### PR DESCRIPTION
This might fix #2190, but right now, even without the change, my local environment is not loading the visualization, but not with the same error we see on production. Tried `grunt build` (though I don't think that hits this js?) and `supervisorctl restart all`, and I guess the next step is to re-provision with vagrant?