### PR TITLE
Update django-docker to 0.0.31

### DIFF
--- a/refinery/config/settings/base.py
+++ b/refinery/config/settings/base.py
@@ -659,12 +659,7 @@ DJANGO_DOCKER_ENGINE_MAX_CONTAINERS = 10
 DJANGO_DOCKER_ENGINE_BASE_URL = "visualizations"
 # Time in seconds to wait before killing unused visualization
 DJANGO_DOCKER_ENGINE_SECONDS_INACTIVE = 60 * 60
-# Location of DjangoDockerEngine proxy logging
 DJANGO_DOCKER_ENGINE_DATA_DIR = get_setting("DJANGO_DOCKER_ENGINE_DATA_DIR")
-PROXY_LOG = os.path.join(
-    DJANGO_DOCKER_ENGINE_DATA_DIR,
-    'django-docker-engine.log'
-)
 
 REFINERY_DEPLOYMENT_PLATFORM = "vagrant"
 

--- a/refinery/tool_manager/urls.py
+++ b/refinery/tool_manager/urls.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.conf.urls import include, url
 
-from django_docker_engine.proxy import FileLogger, Proxy
+from django_docker_engine.proxy import Proxy
 from rest_framework.routers import DefaultRouter
 
 from .views import ToolDefinitionsViewSet, ToolsViewSet
@@ -12,8 +12,7 @@ tool_manager_router.register(r'tools', ToolsViewSet)
 tool_manager_router.register(r'tool_definitions', ToolDefinitionsViewSet)
 
 url_patterns = Proxy(
-    settings.DJANGO_DOCKER_ENGINE_DATA_DIR,
-    logger=FileLogger(settings.PROXY_LOG)
+    settings.DJANGO_DOCKER_ENGINE_DATA_DIR
     # please_wait_title='optional title'
     # please_wait_body='optional html body'
 ).url_patterns()

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ django-auth-ldap==1.2.6
 django-celery==3.1.17
 django-chunked-upload==1.0.5
 django-debug-toolbar==1.4
-django-docker-engine==0.0.27
+django-docker-engine==0.0.31
 django-extensions==1.3.3
 django-flatblocks==0.7.1
 django-guardian==1.4.1


### PR DESCRIPTION
The proxy log was proof of concept: it did not need to be deployed. No other changes in interface? The other changes (port as part of container spec, hostname-based dispatch) aren't things we're using right now.