### PR TITLE
Only log WARNING or above in tests

### DIFF
--- a/refinery/config/settings/prod.py
+++ b/refinery/config/settings/prod.py
@@ -1,4 +1,5 @@
 # custom settings for production environment
+import sys
 
 from .base import *  # NOQA
 
@@ -9,3 +10,7 @@ TEMPLATE_DEBUG = DEBUG
 ALLOWED_HOSTS = get_setting("ALLOWED_HOSTS")
 
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+
+# Only log WARNING or greater for tests w/ prod settings
+if "test" in sys.argv:
+    logging.disable(logging.WARNING)


### PR DESCRIPTION
Our CI tests have been getting fairly close to the 10,000 limit set by Travis. Mainly due to `INFO` and `DEBUG` logging.

This approach fixes that, but I'm not immediately sure if there are any negative repercussions.