### PR TITLE
Scottx611x/galaxy rename dataset action

### DIFF
--- a/refinery/core/migrations/0009_analysisnodeconnection_galaxy_dataset_name.py
+++ b/refinery/core/migrations/0009_analysisnodeconnection_galaxy_dataset_name.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0008_auto_20170824_1339'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='analysisnodeconnection',
+            name='galaxy_dataset_name',
+            field=models.CharField(max_length=250, null=True, blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -1721,7 +1721,7 @@ class Analysis(OwnableResource):
                     study=study,
                     assay=assay,
                     type=Node.DERIVED_DATA_FILE,
-                    name=output_connection.name,
+                    name=output_connection.galaxy_dataset_name,
                     analysis_uuid=self.uuid,
                     subanalysis=output_connection.subanalysis,
                     workflow_output=output_connection.name
@@ -1950,6 +1950,8 @@ class AnalysisNodeConnection(models.Model):
     # inputs) exist in Refinery
     is_refinery_file = models.BooleanField(null=False, blank=False,
                                            default=False)
+    galaxy_dataset_name = models.CharField(null=True, blank=True,
+                                           max_length=250)
 
     def __unicode__(self):
         return (

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -1716,16 +1716,8 @@ class Analysis(OwnableResource):
 
         for output_connection, analysis_result in output_mappings:
             # create derived data file node
-            derived_data_file_node = (
-                Node.objects.create(
-                    study=study,
-                    assay=assay,
-                    type=Node.DERIVED_DATA_FILE,
-                    name=output_connection.galaxy_dataset_name,
-                    analysis_uuid=self.uuid,
-                    subanalysis=output_connection.subanalysis,
-                    workflow_output=output_connection.name
-                )
+            derived_data_file_node = self._create_derived_data_file_node(
+                study, assay, output_connection
             )
             if output_connection.is_refinery_file:
                 # retrieve uuid of corresponding output file if exists
@@ -1911,6 +1903,18 @@ class Analysis(OwnableResource):
         except (tool_manager.models.Tool.DoesNotExist,
                 tool_manager.models.Tool.MultipleObjectsReturned):
             return False
+
+    def _create_derived_data_file_node(self, study,
+                                       assay, analysis_node_connection):
+        return Node.objects.create(
+            study=study,
+            assay=assay,
+            type=Node.DERIVED_DATA_FILE,
+            name=analysis_node_connection.galaxy_dataset_name,
+            analysis_uuid=self.uuid,
+            subanalysis=analysis_node_connection.subanalysis,
+            workflow_output=analysis_node_connection.name
+        )
 
 
 #: Defining available relationship types

--- a/refinery/core/tests.py
+++ b/refinery/core/tests.py
@@ -1460,7 +1460,8 @@ class AnalysisTests(TestCase):
                 step=1,
                 filename=self.node_filename,
                 direction=OUTPUT_CONNECTION,
-                is_refinery_file=True
+                is_refinery_file=True,
+                galaxy_dataset_name="Galaxy File Name"
             )
         )
         self.analysis_node_connection_b = (
@@ -1619,6 +1620,23 @@ class AnalysisTests(TestCase):
             "{}_{}".format(self.analysis_node_connection_a.step,
                            self.analysis_node_connection_a.name)
         )
+
+    def test__create_derived_data_file_node(self):
+        derived_data_file_node = self.analysis._create_derived_data_file_node(
+            self.study,
+            self.assay,
+            self.analysis_node_connection_a
+        )
+        self.assertEqual(derived_data_file_node.name, "Galaxy File Name")
+        self.assertEqual(derived_data_file_node.study, self.study)
+        self.assertEqual(derived_data_file_node.assay, self.assay)
+        self.assertEqual(derived_data_file_node.type, Node.DERIVED_DATA_FILE)
+        self.assertEqual(derived_data_file_node.analysis_uuid,
+                         self.analysis.uuid)
+        self.assertEqual(derived_data_file_node.subanalysis,
+                         self.analysis_node_connection_a.subanalysis)
+        self.assertEqual(derived_data_file_node.workflow_output,
+                         self.analysis_node_connection_a.name)
 
 
 class UtilitiesTest(TestCase):

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -658,7 +658,8 @@ class WorkflowTool(Tool):
                 step=self._get_workflow_step(galaxy_dataset),
                 filename=self._get_galaxy_dataset_filename(galaxy_dataset),
                 filetype=galaxy_dataset["file_ext"],
-                is_refinery_file=galaxy_dataset in exposed_workflow_outputs
+                is_refinery_file=galaxy_dataset in exposed_workflow_outputs,
+                galaxy_dataset_name=galaxy_dataset["name"]
             )
 
     def _create_collection_description(self):

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -920,7 +920,8 @@ class WorkflowTool(Tool):
             )
         )
         retained_datasets = [
-            galaxy_dataset for galaxy_dataset in galaxy_dataset_list
+            self._update_galaxy_dataset_name(galaxy_dataset)
+            for galaxy_dataset in galaxy_dataset_list
             if not galaxy_dataset["purged"] and
             self._get_workflow_step(galaxy_dataset) > 0
         ]
@@ -1272,6 +1273,35 @@ class WorkflowTool(Tool):
             self.GALAXY_TO_REFINERY_MAPPING_LIST,
             galaxy_to_refinery_mapping_list
         )
+
+    def _update_galaxy_dataset_name(self, galaxy_dataset_dict):
+        """
+        Update the name of a Galaxy Dataset if any Galaxy
+        RenameDatasetActions are detected for it
+        :param galaxy_dataset_dict: dict containing information about a
+        Galaxy Dataset
+        :return: galaxy_dataset_dict with an updated 'name' if a
+        RenameDatasetAction was detected, otherwise the original galaxy
+        dataset is returned
+        """
+        workflow_steps = self._get_workflow_dict()["steps"]
+        workflow_step_number = str(
+            self._get_workflow_step(galaxy_dataset_dict)
+        )
+        post_job_actions = workflow_steps[workflow_step_number].get(
+            "post_job_actions"
+        )
+        if post_job_actions:
+            rename_dataset_key = (
+                "RenameDatasetAction{}".format(galaxy_dataset_dict["name"])
+            )
+            if rename_dataset_key in post_job_actions.keys():
+                galaxy_dataset_dict["name"] = (
+                    post_job_actions[
+                        rename_dataset_key
+                    ]["action_arguments"]["newname"]
+                )
+        return galaxy_dataset_dict
 
     @handle_bioblend_exceptions
     def upload_datafile_to_library_from_url(self, library_id, datafile_url):

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -2110,8 +2110,9 @@ class WorkflowToolTests(ToolManagerTestBase):
 
     def test_that_galaxy_renamedatasetactions_are_handled(self):
         new_dataset_name = "COFFEE"
+        workflow_step = 1
         workflow_dict = galaxy_workflow_dict
-        workflow_dict["steps"]["1"]["post_job_actions"] = {
+        workflow_dict["steps"][str(workflow_step)]["post_job_actions"] = {
             "RenameDatasetActionRefinery test tool LIST - N on data 4": {
                 "action_arguments": {
                     "newname": new_dataset_name
@@ -2120,16 +2121,19 @@ class WorkflowToolTests(ToolManagerTestBase):
                 "output_name": "Refinery test tool LIST - N on data 4"
             }
         }
-        self.galaxy_datasets_list_mock.return_value = workflow_dict
+        self.get_workflow_dict_mock.return_value = workflow_dict
         self.galaxy_datasets_list_mock.start()
 
         self.create_tool(ToolDefinition.WORKFLOW)
         galaxy_datasets = self.tool._get_galaxy_history_dataset_list()
-        for galaxy_dataset in galaxy_datasets:
-            if self.tool._get_workflow_step(galaxy_dataset) == 1:
-                # Assert that the Output file w/ a
-                # RenamedDatasetAction in Galaxy was edited
-                self.assertEqual(galaxy_dataset["name"], new_dataset_name)
+        edited_galaxy_dataset = next(
+            (galaxy_dataset for galaxy_dataset in galaxy_datasets if
+             self.tool._get_workflow_step(galaxy_dataset) == workflow_step),
+            None
+        )
+        # Assert that the Output file w/ a
+        # RenamedDatasetAction in Galaxy was edited
+        self.assertEqual(edited_galaxy_dataset["name"], new_dataset_name)
 
 
 class ToolAPITests(APITestCase, ToolManagerTestBase):

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -2127,9 +2127,8 @@ class WorkflowToolTests(ToolManagerTestBase):
         self.create_tool(ToolDefinition.WORKFLOW)
         galaxy_datasets = self.tool._get_galaxy_history_dataset_list()
         edited_galaxy_dataset = next(
-            (galaxy_dataset for galaxy_dataset in galaxy_datasets if
-             self.tool._get_workflow_step(galaxy_dataset) == workflow_step),
-            None
+            galaxy_dataset for galaxy_dataset in galaxy_datasets if
+            self.tool._get_workflow_step(galaxy_dataset) == workflow_step
         )
         # Assert that the Output file w/ a
         # RenamedDatasetAction in Galaxy was edited

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -2108,7 +2108,7 @@ class WorkflowToolTests(ToolManagerTestBase):
 
         self._assert_analysis_node_connection_outputs_validity()
 
-    def test_that_galaxy_renamedatasetactions_are_handled(self):
+    def test_galaxy_renamedatasetaction_handling(self):
         new_dataset_name = "COFFEE"
         workflow_step = 1
         workflow_dict = galaxy_workflow_dict

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -2108,6 +2108,29 @@ class WorkflowToolTests(ToolManagerTestBase):
 
         self._assert_analysis_node_connection_outputs_validity()
 
+    def test_that_galaxy_renamedatasetactions_are_handled(self):
+        new_dataset_name = "COFFEE"
+        workflow_dict = galaxy_workflow_dict
+        workflow_dict["steps"]["1"]["post_job_actions"] = {
+            "RenameDatasetActionRefinery test tool LIST - N on data 4": {
+                "action_arguments": {
+                    "newname": new_dataset_name
+                },
+                "action_type": "RenameDatasetAction",
+                "output_name": "Refinery test tool LIST - N on data 4"
+            }
+        }
+        self.galaxy_datasets_list_mock.return_value = workflow_dict
+        self.galaxy_datasets_list_mock.start()
+
+        self.create_tool(ToolDefinition.WORKFLOW)
+        galaxy_datasets = self.tool._get_galaxy_history_dataset_list()
+        for galaxy_dataset in galaxy_datasets:
+            if self.tool._get_workflow_step(galaxy_dataset) == 1:
+                # Assert that the Output file w/ a
+                # RenamedDatasetAction in Galaxy was edited
+                self.assertEqual(galaxy_dataset["name"], new_dataset_name)
+
 
 class ToolAPITests(APITestCase, ToolManagerTestBase):
     def test_tools_exist(self):

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -2126,13 +2126,15 @@ class WorkflowToolTests(ToolManagerTestBase):
 
         self.create_tool(ToolDefinition.WORKFLOW)
         galaxy_datasets = self.tool._get_galaxy_history_dataset_list()
-        edited_galaxy_dataset = next(
+        edited_galaxy_datasets = [
             galaxy_dataset for galaxy_dataset in galaxy_datasets if
             self.tool._get_workflow_step(galaxy_dataset) == workflow_step
-        )
+        ]
+        assert len(edited_galaxy_datasets) == 1
+
         # Assert that the Output file w/ a
         # RenamedDatasetAction in Galaxy was edited
-        self.assertEqual(edited_galaxy_dataset["name"], new_dataset_name)
+        self.assertEqual(edited_galaxy_datasets[0]["name"], new_dataset_name)
 
 
 class ToolAPITests(APITestCase, ToolManagerTestBase):


### PR DESCRIPTION
Add support for Galaxy tool outputs that utilize [`RenameDatasetActions`](https://galaxyproject.org/learn/advanced-workflow/variables/#rename-output-based-on-specified-content)

Fix #2193 