### PR TITLE
 Fix visual bug with tool tip.

### DIFF
--- a/refinery/ui/source/js/commons/ctrls/SharingHelpPopoverDetailsCtrl.js
+++ b/refinery/ui/source/js/commons/ctrls/SharingHelpPopoverDetailsCtrl.js
@@ -1,0 +1,34 @@
+/**
+ * Sharing Help Popover Details Ctrl
+ * @namespace SharingHelpPopoverDetailsCtrl
+ * @desc Controller for the sharing help popover details
+ * @memberOf refineryApp
+ */
+(function () {
+  'use strict';
+
+  angular
+    .module('refineryApp')
+    .controller('SharingHelpPopoverDetailsCtrl', SharingHelpPopoverDetailsCtrl);
+
+  SharingHelpPopoverDetailsCtrl.$inject = [
+    '$location'
+  ];
+
+
+  function SharingHelpPopoverDetailsCtrl (
+    $location
+  ) {
+    var vm = this;
+
+   /*
+   * ---------------------------------------------------------
+   * LifeCycle Hooks
+   * ---------------------------------------------------------
+   */
+    vm.$onInit = function () {
+      vm.isCollaborationPage = $location.search('collaboration').$$search.collaboration;
+      console.log(vm.isCollaborationPage);
+    };
+  }
+})();

--- a/refinery/ui/source/js/commons/ctrls/sharing-help-popover-details-ctrl.js
+++ b/refinery/ui/source/js/commons/ctrls/sharing-help-popover-details-ctrl.js
@@ -20,6 +20,7 @@
     $location
   ) {
     var vm = this;
+    vm.isCollaborationPage = false;
 
    /*
    * ---------------------------------------------------------
@@ -27,8 +28,8 @@
    * ---------------------------------------------------------
    */
     vm.$onInit = function () {
+      // check if the user is on the collaboration page
       vm.isCollaborationPage = $location.search('collaboration').$$search.collaboration;
-      console.log(vm.isCollaborationPage);
     };
   }
 })();

--- a/refinery/ui/source/js/commons/ctrls/sharing-help-popover-details-ctrl.js
+++ b/refinery/ui/source/js/commons/ctrls/sharing-help-popover-details-ctrl.js
@@ -29,7 +29,7 @@
    */
     vm.$onInit = function () {
       // check if the user is on the collaboration page
-      vm.isCollaborationPage = $location.absUrl().indexOf('collaboration') > -1;
+      vm.isCollaborationPage = $location.absUrl().indexOf('/collaboration/') > -1;
     };
   }
 })();

--- a/refinery/ui/source/js/commons/ctrls/sharing-help-popover-details-ctrl.js
+++ b/refinery/ui/source/js/commons/ctrls/sharing-help-popover-details-ctrl.js
@@ -29,7 +29,7 @@
    */
     vm.$onInit = function () {
       // check if the user is on the collaboration page
-      vm.isCollaborationPage = $location.search('collaboration').$$search.collaboration;
+      vm.isCollaborationPage = $location.absUrl().indexOf('collaboration') > -1;
     };
   }
 })();

--- a/refinery/ui/source/js/commons/ctrls/sharing-help-popover-details-ctrl.spec.js
+++ b/refinery/ui/source/js/commons/ctrls/sharing-help-popover-details-ctrl.spec.js
@@ -1,0 +1,27 @@
+(function () {
+  'use strict';
+
+  describe('Controller: Sharing Helop Popover Details Ctrl', function () {
+    var ctrl;
+    var scope;
+
+    beforeEach(module('refineryApp'));
+    beforeEach(inject(function (
+      $rootScope,
+      $controller
+    ) {
+      scope = $rootScope.$new();
+      ctrl = $controller('SharingHelpPopoverDetailsCtrl', {
+        $scope: scope
+      });
+    }));
+
+    it('Sharing Help Popover Details ctrl should exist', function () {
+      expect(ctrl).toBeDefined();
+    });
+
+    it('Data & UI displays variables should exist for views', function () {
+      expect(ctrl.isCollaborationPage).toEqual(false);
+    });
+  });
+})();

--- a/refinery/ui/source/js/commons/directives/sharing-help-popover-details.js
+++ b/refinery/ui/source/js/commons/directives/sharing-help-popover-details.js
@@ -1,3 +1,10 @@
+/**
+ * Sharing Help Popover Details
+ * @namespace rpSharingHelpPopoverDetails
+ * @desc Common tooltip component template used between the collaboration
+ * page and sharing/edit page
+ * @memberOf refineryApp
+ */
 (function () {
   angular
     .module('refineryApp')

--- a/refinery/ui/source/js/commons/directives/sharing-help-popover-details.js
+++ b/refinery/ui/source/js/commons/directives/sharing-help-popover-details.js
@@ -1,7 +1,7 @@
 /**
  * Sharing Help Popover Details
  * @namespace rpSharingHelpPopoverDetails
- * @desc Common tooltip component template used between the collaboration
+ * @desc Common popover component template used between the collaboration
  * page and sharing/edit page
  * @memberOf refineryApp
  */

--- a/refinery/ui/source/js/commons/directives/sharing-help-popover-details.js
+++ b/refinery/ui/source/js/commons/directives/sharing-help-popover-details.js
@@ -1,0 +1,10 @@
+(function () {
+  angular
+    .module('refineryApp')
+    .component('rpSharingHelpPopoverDetails', {
+      templateUrl: ['$window', function ($window) {
+        return $window.getStaticUrl('partials/commons/partials/sharing-help-popover-details.html');
+      }],
+      controller: 'SharingHelpPopoverDetailsCtrl'
+    });
+})();

--- a/refinery/ui/source/js/commons/directives/sharing-help-popover-details.spec.js
+++ b/refinery/ui/source/js/commons/directives/sharing-help-popover-details.spec.js
@@ -1,0 +1,30 @@
+(function () {
+  'use strict';
+
+  describe('rpSharingHelpPopoverDetails component unit test', function () {
+    beforeEach(module('refineryApp'));
+
+    var directiveElement;
+
+    beforeEach(inject(function (
+      $compile,
+      $rootScope,
+      $templateCache,
+      $window
+    ) {
+      $templateCache.put(
+        $window.getStaticUrl('partials/commons/partials/sharing-help-popover-details.html'),
+        '<div id="sharing-help-popover-details"></div>'
+      );
+      var scope = $rootScope.$new();
+      var template = '<rp-sharing-help-popover-details></rp-sharing-help-popover-details>';
+      directiveElement = $compile(template)(scope);
+      scope.$digest();
+    }));
+
+    it('generates the appropriate HTML', function () {
+      expect(directiveElement.html()).toContain('sharing-help-popover-details');
+      expect(directiveElement.html()).toContain('</div>');
+    });
+  });
+})();

--- a/refinery/ui/source/js/commons/directives/sharing-help-popover.js
+++ b/refinery/ui/source/js/commons/directives/sharing-help-popover.js
@@ -1,3 +1,10 @@
+/**
+ * Sharing Help Popover  Ctrl
+ * @namespace rpSharingHelpPopover
+ * @desc Common tooltip component used between the collaboration page and
+ * sharing/edit page
+ * @memberOf refineryApp
+ */
 (function () {
   'use strict';
   angular

--- a/refinery/ui/source/js/commons/directives/sharing-help-popover.js
+++ b/refinery/ui/source/js/commons/directives/sharing-help-popover.js
@@ -1,7 +1,7 @@
 /**
  * Sharing Help Popover Ctrl
  * @namespace rpSharingHelpPopover
- * @desc Common tooltip component used between the collaboration page and
+ * @desc Common popover component used between the collaboration page and
  * sharing/edit page
  * @memberOf refineryApp
  */

--- a/refinery/ui/source/js/commons/directives/sharing-help-popover.js
+++ b/refinery/ui/source/js/commons/directives/sharing-help-popover.js
@@ -1,5 +1,5 @@
 /**
- * Sharing Help Popover  Ctrl
+ * Sharing Help Popover Ctrl
  * @namespace rpSharingHelpPopover
  * @desc Common tooltip component used between the collaboration page and
  * sharing/edit page

--- a/refinery/ui/source/js/commons/partials/sharing-help-popover-details.html
+++ b/refinery/ui/source/js/commons/partials/sharing-help-popover-details.html
@@ -2,14 +2,14 @@
   Only data set owners can change sharing options. To share
   with an authenticated user, create a new group or invite the user to an
   existing group
-  <span ng-if="vm.isCollaborationPage">
+  <span ng-if="!$ctrl.isCollaborationPage">
     <a href='/collaboration'> on the collaboration page. </a> Owners can
     update data set permissions (including making it public) on the data set
     preview by clicking the “sharing” button.
   </span>
-  <span ng-if="!vm.isCollaborationPage">
+  <span ng-if="$ctrl.isCollaborationPage">
     on the collaboration page. Owners can update data set permissions
-    (including making it public) on the<a href='/#'> data set preview </a> by
+    (including making it public) on the <a href='/#'> data set preview </a> by
     clicking the “sharing” button.
   </span>
 </p>

--- a/refinery/ui/source/js/commons/partials/sharing-help-popover-details.html
+++ b/refinery/ui/source/js/commons/partials/sharing-help-popover-details.html
@@ -1,0 +1,15 @@
+<p>
+  Only data set owners can change sharing options. To share
+  with an authenticated user, create a new group or invite the user to an
+  existing group
+  <span ng-if="vm.isCollaborationPage">
+    <a href='/collaboration'> on the collaboration page. </a> Owners can
+    update data set permissions (including making it public) on the data set
+    preview by clicking the “sharing” button.
+  </span>
+  <span ng-if="!vm.isCollaborationPage">
+    on the collaboration page. Owners can update data set permissions
+    (including making it public) on the<a href='/#'> data set preview </a> by
+    clicking the “sharing” button.
+  </span>
+</p>

--- a/refinery/ui/source/js/commons/partials/sharing-help-popover-details.html
+++ b/refinery/ui/source/js/commons/partials/sharing-help-popover-details.html
@@ -4,12 +4,14 @@
   existing group
   <span ng-if="!$ctrl.isCollaborationPage">
     <a href='/collaboration'> on the collaboration page. </a> Owners can
-    update data set permissions (including making it public) on the data set
-    preview by clicking the “sharing” button.
+    update data set permissions (including making it public) on the dashboard by
+    by opening a data set preview (click a data set link) and then clicking
+    the “sharing” button."
   </span>
   <span ng-if="$ctrl.isCollaborationPage">
     on the collaboration page. Owners can update data set permissions
-    (including making it public) on the <a href='/#'> data set preview </a> by
-    clicking the “sharing” button.
+    (including making it public) on the <a href='/#'> dashboard </a> by
+    by opening a data set preview (click a data set link) and then clicking
+    the “sharing” button."
   </span>
 </p>

--- a/refinery/ui/source/js/commons/partials/sharing-help-popover.html
+++ b/refinery/ui/source/js/commons/partials/sharing-help-popover.html
@@ -1,10 +1,6 @@
  <a
   popover-placement="bottom"
-  uib-popover-html="'Only data set owners can change sharing options. To share
-  with an authenticated user, create a new group or invite the user to an
-  existing group  <a href=/collaboration> on the collaboration page. </a>
-  Owners can update data set permissions (including making it public)
-  on the <a href=/#> data set preview </a> by clicking the “sharing” button.'"
+  uib-popover-template="'sharinghelppopoverdetails.html'"
   popover-title="Share a Data Set"
   popover-trigger="focus"
   popover-append-to-body="true"
@@ -12,3 +8,7 @@
   class="popover-top">
     <i class="fa fa-question-circle info-icon icon-only"></i>
 </a>
+
+ <script type="text/ng-template" id="sharinghelppopoverdetails.html">
+   <rp-sharing-help-popover-details></rp-sharing-help-popover-details>
+ </script>


### PR DESCRIPTION
Ref #1886 
Resolves #1884 
When on the data set share -- ? tooltip, clicking the link 'data_set_preview' doesn't visually do anything since the user is already on the data set preview page.
Update html by adding a component and template for the new logic.

![to-collab-page](https://user-images.githubusercontent.com/9956764/31580662-de32e6d0-b124-11e7-8f87-864c2914d537.gif)
![to-dashboard](https://user-images.githubusercontent.com/9956764/31580663-de41dd8e-b124-11e7-8657-8fc290add473.gif)
