### PR TITLE
Scottx611x/fix node meta info query

### DIFF
--- a/refinery/data_set_manager/tests.py
+++ b/refinery/data_set_manager/tests.py
@@ -1398,7 +1398,7 @@ class UtilitiesTest(TestCase):
             {
                 "q": "django_ct:data_set_manager.node",
                 "wt": "json",
-                "fq": "uuid:'{}'".format(" OR ".join(fake_node_uuids))
+                "fq": "uuid:({})".format(" OR ".join(fake_node_uuids))
             }
         )
 

--- a/refinery/data_set_manager/utils.py
+++ b/refinery/data_set_manager/utils.py
@@ -1159,7 +1159,7 @@ def _create_solr_params_from_node_uuids(node_uuids):
     return {
         "q": "django_ct:data_set_manager.node",
         "wt": "json",
-        "fq": "uuid:'{}'".format(" OR ".join(node_uuids))
+        "fq": "uuid:({})".format(" OR ".join(node_uuids))
     }
 
 


### PR DESCRIPTION
Just noticed that the actual query to Solr would only retrieve the first `Node` specified.

This PR updates the query syntax to properly utilize the `OR` and retrieve all `Nodes` that are asked for.