### PR TITLE
In AWS deployment, check for None tags

### DIFF
--- a/deployment/utils.py
+++ b/deployment/utils.py
@@ -43,6 +43,11 @@ def load_tags():
     if 'owner' not in tags:
         tags['owner'] = os.popen("git config --get user.email").read().rstrip()
 
+    for k, v in tags.items():
+        if v is None:
+            raise RuntimeError(
+                "None is not legal, in tag {!r}".format(k))
+
     return [{'Key': k, 'Value': v} for k, v in tags.items()]
 
 


### PR DESCRIPTION
This is useful, because the default template for tags has
(the YAML for) `None` as the values.