### PR TITLE
Scottx611x/set workflow tool analysis library_id

### DIFF
--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -798,9 +798,12 @@ class WorkflowTool(Tool):
 
     @handle_bioblend_exceptions
     def create_galaxy_library(self):
-        return self.galaxy_connection.libraries.create_library(
+        galaxy_library_dict = self.galaxy_connection.libraries.create_library(
             name="Library for: {}".format(self)
         )
+        self.analysis.library_id = galaxy_library_dict["id"]
+        self.analysis.save()
+        return galaxy_library_dict
 
     def _create_workflow_inputs_dict(self):
         """

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -106,6 +106,11 @@ class ToolManagerMocks(TestCase):
         ).start()
 
         # Galaxy Library mocks
+        self.create_library_mock = mock.patch.object(
+            LibraryClient,
+            "create_library",
+            return_value=library_dict
+        ).start()
         self.delete_library_mock = mock.patch.object(
             LibraryClient, "delete_library"
         ).start()
@@ -150,9 +155,6 @@ class ToolManagerMocks(TestCase):
         ).start()
         self.create_history_mock = mock.patch.object(
             WorkflowTool, "create_galaxy_history", return_value=history_dict
-        ).start()
-        self.create_library_mock = mock.patch.object(
-            WorkflowTool, "create_galaxy_library", return_value=library_dict
         ).start()
         self.tool_data_mock = mock.patch.object(
             WorkflowTool, "_get_tool_data",
@@ -2372,6 +2374,12 @@ class WorkflowToolTests(ToolManagerTestBase):
         # Assert that the Output file w/ a
         # RenamedDatasetAction in Galaxy was edited
         self.assertEqual(edited_galaxy_datasets[0]["name"], new_dataset_name)
+
+    def test_create_galaxy_library_sets_analysis_library_id(self):
+        self.create_tool(ToolDefinition.WORKFLOW)
+        self.assertIsNone(self.tool.analysis.library_id)
+        self.tool.create_galaxy_library()
+        self.assertEqual(self.tool.analysis.library_id, library_dict["id"])
 
 
 class ToolAPITests(APITestCase, ToolManagerTestBase):


### PR DESCRIPTION
@hackdna Resolves the issue you brought up [here](https://refinery-platform.slack.com/archives/C1ZRZBVJA/p1509039006000339)

Was testing that [`bioblend.galaxy.libraries.LibraryClient.delete_library()`  was being called if an `Analysis` had a `library_id`](https://github.com/refinery-platform/refinery-platform/blob/v1.6.0/refinery/tool_manager/tests.py#L2657), but was never setting the library_id in our application code. 