### PR TITLE
Mccalluc/misc travis log cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
   # Install geckodriver required for selenium testing
   - GECKODRIVER_VERSION=v0.17.0
   - TAR=geckodriver-$GECKODRIVER_VERSION-linux64.tar
-  - wget https://github.com/mozilla/geckodriver/releases/download/$GECKODRIVER_VERSION/$TAR.gz
+  - wget --no-verbose https://github.com/mozilla/geckodriver/releases/download/$GECKODRIVER_VERSION/$TAR.gz
   - gunzip $TAR.gz
   - tar -xvf $TAR
   - chmod a+x geckodriver

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ script:
   - flake8 --exclude=migrations,ui ..
 
   - echo 'travis_fold:start:grunt'
-  - pushd ui && grunt test | grep -v SUCCESS && popd
+  - pushd ui && grunt test && popd # TODO: 600 mostly useless lines of output
   - echo 'travis_fold:end:grunt'
 
   - echo 'travis_fold:start:django-tests'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: required
 
 language: python
 addons:
-  firefox: "53.0.3"
   apt:
     packages:
       - xvfb
@@ -31,6 +30,13 @@ install:
   - npm --version
 
   - pip install -r requirements.txt --quiet
+
+  # Firefox could be downloaded more simply as a Travis addon...
+  # but the progress meter adds 1000 lines to the log.
+  - FIREFOX_SOURCE_URL='https://download.mozilla.org/?product=firefox-53.0.3&lang=en-US&os=linux64'
+  - wget --no-verbose -O /tmp/firefox-53.0.3.tar.bz2 $FIREFOX_SOURCE_URL
+  - export PATH=$HOME/firefox-53.0.3/firefox:$PATH
+  - firefox --version
 
   # Install geckodriver required for selenium testing
   - GECKODRIVER_VERSION=v0.17.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ before_script:
   - npm install -g grunt-cli@0.1.13 bower@1.8.2 --progress false --quiet || ( cat npm-debug.log && false )
   - cd ui
   - npm install --progress false --quiet || ( cat npm-debug.log && false )
-  - bower install --config.interactive=false --quiet | grep -v PhantomJS
+  - bower install --config.interactive=false --quiet
   - cd ../
 
   # Required for cypress tests; TODO: Move to puppet.
@@ -88,7 +88,7 @@ script:
   - flake8 --exclude=migrations,ui ..
 
   - echo 'travis_fold:start:grunt'
-  - pushd ui && grunt test && popd
+  - pushd ui && grunt test | grep -v SUCCESS && popd
   - echo 'travis_fold:end:grunt'
 
   - echo 'travis_fold:start:django-tests'

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ before_script:
   - npm install -g grunt-cli@0.1.13 bower@1.8.2 --progress false --quiet || ( cat npm-debug.log && false )
   - cd ui
   - npm install --progress false --quiet || ( cat npm-debug.log && false )
-  - bower install --config.interactive=false --quiet
+  - bower install --config.interactive=false --quiet | grep -v PhantomJS
   - cd ../
 
   # Required for cypress tests; TODO: Move to puppet.


### PR DESCRIPTION
I think this much is good: It just gets rid of the download progress for ff and geckodriver, which together consume ~2000 lines. I'll try to clean up the PhantomJS in a separate branch.