### PR TITLE
Mount a new volume for docker parallel to /data

### DIFF
--- a/deployment/aws-config/config.yaml.template
+++ b/deployment/aws-config/config.yaml.template
@@ -50,6 +50,9 @@ DATA_VOLUME_SIZE: 500
 # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html
 DATA_VOLUME_TYPE: "st1"
 
+DOCKER_VOLUME_SIZE: 5 # HiGlass image is 2.5G, and containers are also kept here.
+DOCKER_VOLUME_TYPE: "st1"
+
 # The name of the EC2 key pair to use for SSH (must already exist in the AWS account)
 KEY_NAME: "id_rsa"
 

--- a/deployment/refinery-modules/refinery/manifests/aws.pp
+++ b/deployment/refinery-modules/refinery/manifests/aws.pp
@@ -6,11 +6,32 @@ class refinery::aws {
 
 $fstype = 'ext3'
 
+# This is the block device for the docker image cache.
+# It must match the attachment point for the EC2 EBS volume.
+$docker_block_device = '/dev/xvds'
+
+filesystem { $docker_block_device:
+  ensure => present,
+  fs_type => $fstype,
+}
+->
+# Mountpoint
+file { '/var/lib/docker':
+  ensure => directory,
+}
+->
+mount { '/var/lib/docker':
+  ensure => mounted,
+  device => $docker_block_device,
+  fstype => $fstype,
+  options => 'defaults',
+}
+
 # This is the block device for the external data.
 # It must match the attachment point for the EC2 EBS volume.
-$block_device = '/dev/xvdr'
+$data_block_device = '/dev/xvdr'
 
-filesystem { $block_device:
+filesystem { $data_block_device:
   ensure => present,
   fs_type => $fstype,
 }
@@ -22,7 +43,7 @@ file { '/data':
 ->
 mount { '/data':
   ensure => mounted,
-  device => $block_device,
+  device => $data_block_device,
   fstype => $fstype,
   options => 'defaults',
 }


### PR DESCRIPTION
Towards #2095. Began by looking at adding more space to the root volume, but it seems like it would be a good think for now to explicitly limit the space that can be consumed by Docker, and if it exceeds those bounds we'll notice immediately.

I have not tried to run this yet. Thoughts?