### PR TITLE
Command-line multi-file download

### DIFF
--- a/refinery/ui/source/js/user-file-browser/ctrls/user-file-browser-files-ctrl.js
+++ b/refinery/ui/source/js/user-file-browser/ctrls/user-file-browser-files-ctrl.js
@@ -69,11 +69,19 @@
     };
 
     gridOptionsService.appScopeProvider = vm;
-    vm.downloadFilterQuery = function () {
+    vm.downloadCsvQuery = function () {
       return $httpParamSerializer({
         fq: userFileParamsService.fq(),
         sort: userFileParamsService.sort()
       });
+    };
+    vm.downloadCsvPath = function () {
+      return '/files_download?' + vm.downloadCsvQuery();
+    };
+    vm.downloadCsvUrl = function () {
+      return $location.protocol() + '://'
+          + $location.host() + ':' + $location.port()
+          + vm.downloadCsvPath();
     };
     vm.gridOptions = gridOptionsService;
     vm.gridOptions.onRegisterApi = function (api) {

--- a/refinery/ui/source/js/user-file-browser/partials/user-file-browser-files.html
+++ b/refinery/ui/source/js/user-file-browser/partials/user-file-browser-files.html
@@ -1,6 +1,37 @@
 <div class="col-lg-10 col-md-10 col-sm-9" id="main-area">
     <div>
-        <a href="/files_download?{{ $ctrl.downloadFilterQuery() }}"><i class="fa fa-arrow-circle-o-down"></i> Download as CSV</a>
+        <a class="refinery-base btn btn-default btn-sm"
+           href="{{ $ctrl.downloadCsvPath() }}">
+            <i class="fa fa-arrow-circle-o-down"></i> Download as CSV
+        </a>
+        <span class="refinery-base btn btn-default btn-sm"
+              data-toggle="modal" data-target="#multi-file-download-modal">
+            <i class="fa fa-arrow-circle-o-down"></i> Download all files
+        </span>
+
+        <div class="modal fade" id="multi-file-download-modal" tabindex="-1" role="dialog">
+          <div class="modal-dialog" role="document">
+            <div class="modal-content">
+              <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Download selected files</h4>
+              </div>
+              <div class="modal-body">
+                <p>
+                  To download all of the currently selected files, copy and paste this to your command line:
+                </p>
+                <pre>$ curl '{{ $ctrl.downloadCsvUrl() }}' | cut -f 1 -d ',' | tail -n +2 | xargs -n 1 curl -O -L</pre>
+                <p>
+                  This downloads the CSV, gets the column with urls, and downloads each listed URL in turn.
+                </p>
+              </div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-primary" data-dismiss="modal" >Ok</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
     </div>
     <div class="m-r-1">
         <!-- Bootstrap col classes are using the window width, not our inner div.

--- a/refinery/ui/source/js/user-file-browser/partials/user-file-browser-files.html
+++ b/refinery/ui/source/js/user-file-browser/partials/user-file-browser-files.html
@@ -1,5 +1,27 @@
 <div class="col-lg-10 col-md-10 col-sm-9" id="main-area">
-    <div>
+    <div class="modal fade" id="multi-file-download-modal" tabindex="-1" role="dialog">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <h4 class="modal-title">Download selected files</h4>
+          </div>
+          <div class="modal-body">
+            <p>
+              To download all of the currently selected files, copy and paste this to your command line:
+            </p>
+            <pre>$ curl '{{ $ctrl.downloadCsvUrl() }}' | cut -f 1 -d ',' | tail -n +2 | xargs -n 1 curl -O -L</pre>
+            <p>
+              This downloads the CSV, gets the column with urls, and downloads each listed URL in turn.
+            </p>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-primary" data-dismiss="modal" >Ok</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="btn-toolbar p-b-1">
         <a class="refinery-base btn btn-default btn-sm"
            href="{{ $ctrl.downloadCsvPath() }}">
             <i class="fa fa-arrow-circle-o-down"></i> Download as CSV
@@ -8,30 +30,6 @@
               data-toggle="modal" data-target="#multi-file-download-modal">
             <i class="fa fa-arrow-circle-o-down"></i> Download all files
         </span>
-
-        <div class="modal fade" id="multi-file-download-modal" tabindex="-1" role="dialog">
-          <div class="modal-dialog" role="document">
-            <div class="modal-content">
-              <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                <h4 class="modal-title">Download selected files</h4>
-              </div>
-              <div class="modal-body">
-                <p>
-                  To download all of the currently selected files, copy and paste this to your command line:
-                </p>
-                <pre>$ curl '{{ $ctrl.downloadCsvUrl() }}' | cut -f 1 -d ',' | tail -n +2 | xargs -n 1 curl -O -L</pre>
-                <p>
-                  This downloads the CSV, gets the column with urls, and downloads each listed URL in turn.
-                </p>
-              </div>
-              <div class="modal-footer">
-                <button type="button" class="btn btn-primary" data-dismiss="modal" >Ok</button>
-              </div>
-            </div>
-          </div>
-        </div>
-
     </div>
     <div class="m-r-1">
         <!-- Bootstrap col classes are using the window width, not our inner div.

--- a/refinery/ui/source/js/user-file-browser/partials/user-file-browser-files.html
+++ b/refinery/ui/source/js/user-file-browser/partials/user-file-browser-files.html
@@ -10,9 +10,14 @@
             <p>
               To download all of the currently selected files, copy and paste this to your command line:
             </p>
-            <pre>$ curl '{{ $ctrl.downloadCsvUrl() }}' | cut -f 1 -d ',' | tail -n +2 | xargs -n 1 curl -O -L</pre>
+            <textarea
+                style="width: 100%; font-family: monospace; overflow-wrap: break-word;"
+                rows="6" cols="80"
+                onclick="this.focus(); this.select();"
+                readonly="readonly"
+            >curl '{{ $ctrl.downloadCsvUrl() }}' | cut -f 1 -d ',' | tail -n +2 | xargs -n 1 curl -O -L</textarea>
             <p>
-              This downloads the CSV, gets the column with urls, and downloads each listed URL in turn.
+              This downloads the CSV, gets the URLs, and downloads each URL in turn.
             </p>
           </div>
           <div class="modal-footer">


### PR DESCRIPTION
Fix  #2029
![screen shot 2017-11-13 at 3 08 52 pm](https://user-images.githubusercontent.com/730388/32746750-97a836a8-c884-11e7-83dd-bc5d7f5d4ea7.png)

- Buttons seemed more idiomatic than links, but I could be swayed.
- Probably want more space around buttons, but didn't want to invest more time there unless we're pretty sure it's what we want.
- The commandline is really long, because the query arguments reflect the internal solr names. Alternatively, we could have folks download the CSV, and then give them a command line assuming that they have the csv: Prettier, but more space for things to go wrong?
- Text ok?