### PR TITLE
Allow deletion of the empty user data S3 buckets

### DIFF
--- a/deployment/terraform/modules/s3/main.tf
+++ b/deployment/terraform/modules/s3/main.tf
@@ -26,8 +26,4 @@ resource "aws_s3_bucket" "uploaded_files" {
 resource "aws_s3_bucket" "media_files" {
   acl    = "public-read"
   bucket = "${var.bucket_name_base}-media"
-
-  lifecycle {
-    prevent_destroy = true
-  }
 }


### PR DESCRIPTION
`aws_s3_bucket` resource cannot be deleted if bucket is not empty, so extra protection provided by the `lifecycle` meta-parameter is unnecessary. Also, this makes removal of temporary infrastructures easier.
