### PR TITLE
Remove data_set_manager test data zip files from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 *.rar
 *.tar
 *.zip
+!/refinery/data_set_manager/test-data/*.zip
 
 # Logs and databases #
 ######################


### PR DESCRIPTION
Zip files added to the repo were matching a pattern in `.gitignore`.

