### PR TITLE
Remove call to a deprecated method commit_unless_managed()

### DIFF
--- a/refinery/core/management/commands/create_public_group.py
+++ b/refinery/core/management/commands/create_public_group.py
@@ -3,7 +3,7 @@ import sys
 from django.conf import settings
 from django.contrib.auth.models import Group
 from django.core.management.base import BaseCommand
-from django.db import connection, transaction
+from django.db import connection
 
 from core.models import ExtendedGroup
 
@@ -23,8 +23,7 @@ class Command(BaseCommand):
 
 
 def create_public_group():
-    """Create public group
-    """
+    """Create public group"""
     sys.stdout.write(
         "Creating public group '{}' for Refinery. Edit "
         "'REFINERY_PUBLIC_GROUP_NAME' in your settings to choose another "
@@ -63,10 +62,9 @@ def create_public_group():
         # creation of the public group we need to set the sequence for the
         # group ids to the public group id (this is not updated automatically
         # when the id is set explicitly)
-        cursor = connection.cursor()
-        cursor.execute("SELECT setval(\'auth_group_id_seq\', %s )",
-                       (settings.REFINERY_PUBLIC_GROUP_ID,))
-        transaction.commit_unless_managed()
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT setval(\'auth_group_id_seq\', %s )",
+                           (settings.REFINERY_PUBLIC_GROUP_ID,))
         sys.stdout.write("Successfully created group '{}'.".format(
             settings.REFINERY_PUBLIC_GROUP_NAME)
         )


### PR DESCRIPTION
Toward #449 
