### PR TITLE
Scottx611x/expose vis tool status

### DIFF
--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -422,6 +422,15 @@ class Tool(OwnableResource):
         except NotFound:
             return False
 
+    def get_relative_container_url(self):
+        """
+        Construct & return the relative url of our Tool's container
+        """
+        return "/{}/{}".format(
+            settings.DJANGO_DOCKER_ENGINE_BASE_URL,
+            self.container_name
+        )
+
 
 class VisualizationToolError(StandardError):
     pass
@@ -478,15 +487,6 @@ class VisualizationTool(Tool):
             for node in solr_response_json["nodes"]
         }
         return node_info
-
-    def get_relative_container_url(self):
-        """
-        Construct & return the relative url of our Tool's container
-        """
-        return "/{}/{}".format(
-            settings.DJANGO_DOCKER_ENGINE_BASE_URL,
-            self.container_name
-        )
 
     def _get_visualization_parameters(self):
         tool_parameters = []

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -308,8 +308,10 @@ class Tool(OwnableResource):
     def _django_docker_client(self):
         return DockerClientWrapper(settings.DJANGO_DOCKER_ENGINE_DATA_DIR)
 
-    def _get_owner_as_json(self):
-        return serializers.serialize("json", [self.get_owner()])[0]
+    def _get_owner_as_dict(self):
+        return json.loads(
+            serializers.serialize("json", [self.get_owner()])
+        )[0]["fields"]
 
     def get_input_file_uuid_list(self):
         # Tools can't be created without the `file_uuid_list` existing so no

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -5,7 +5,6 @@ import re
 import uuid
 
 from django.conf import settings
-from django.core import serializers
 from django.db import models
 from django.db.models.signals import post_delete, pre_delete
 from django.dispatch import receiver
@@ -308,10 +307,17 @@ class Tool(OwnableResource):
     def _django_docker_client(self):
         return DockerClientWrapper(settings.DJANGO_DOCKER_ENGINE_DATA_DIR)
 
-    def _get_owner_as_dict(self):
-        return json.loads(
-            serializers.serialize("json", [self.get_owner()])
-        )[0]["fields"]
+    @property
+    def relaunch_url(self):
+        return "/api/v2/tools/{}/relaunch/".format(self.uuid)
+
+    def _get_owner_info_as_dict(self):
+        user = self.get_owner()
+        return {
+            "username": user.username,
+            "full_name": "{} {}".format(user.first_name, user.last_name),
+            "user_profile_uuid": user.profile.uuid
+        }
 
     def get_input_file_uuid_list(self):
         # Tools can't be created without the `file_uuid_list` existing so no

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -5,6 +5,7 @@ import re
 import uuid
 
 from django.conf import settings
+from django.core import serializers
 from django.db import models
 from django.db.models.signals import post_delete, pre_delete
 from django.dispatch import receiver
@@ -306,6 +307,9 @@ class Tool(OwnableResource):
     @property
     def _django_docker_client(self):
         return DockerClientWrapper(settings.DJANGO_DOCKER_ENGINE_DATA_DIR)
+
+    def _get_owner_as_json(self):
+        return serializers.serialize("json", [self.get_owner()])[0]
 
     def get_input_file_uuid_list(self):
         # Tools can't be created without the `file_uuid_list` existing so no

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -406,18 +406,16 @@ class Tool(OwnableResource):
 
     def is_running(self):
         if self.get_tool_type() == ToolDefinition.WORKFLOW:
-            return (
-                True if self.analysis.get_status() == Analysis.RUNNING_STATUS
-                else False
-            )
+            return True if self.analysis.running() else False
         else:
             try:
                 self._django_docker_client.lookup_container_url(
                     self.container_name
                 )
-                return True
             except NotFound:
                 return False
+            else:
+                return True
 
 
 class VisualizationToolError(StandardError):

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -411,7 +411,7 @@ class Tool(OwnableResource):
         self.set_tool_launch_config(tool_launch_config)
 
     def is_running(self):
-        if self.get_tool_type() == ToolDefinition.WORKFLOW:
+        if self.is_workflow():
             return True if self.analysis.running() else False
 
         try:
@@ -421,6 +421,12 @@ class Tool(OwnableResource):
             return True
         except NotFound:
             return False
+
+    def is_visualization(self):
+        return self.get_tool_type() == ToolDefinition.VISUALIZATION
+
+    def is_workflow(self):
+        return self.get_tool_type() == ToolDefinition.WORKFLOW
 
     def get_relative_container_url(self):
         """

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -413,15 +413,14 @@ class Tool(OwnableResource):
     def is_running(self):
         if self.get_tool_type() == ToolDefinition.WORKFLOW:
             return True if self.analysis.running() else False
-        else:
-            try:
-                self._django_docker_client.lookup_container_url(
-                    self.container_name
-                )
-            except NotFound:
-                return False
-            else:
-                return True
+
+        try:
+            self._django_docker_client.lookup_container_url(
+                self.container_name
+            )
+            return True
+        except NotFound:
+            return False
 
 
 class VisualizationToolError(StandardError):

--- a/refinery/tool_manager/serializers.py
+++ b/refinery/tool_manager/serializers.py
@@ -75,7 +75,7 @@ class ToolDefinitionSerializer(serializers.ModelSerializer):
 
 class ToolSerializer(serializers.ModelSerializer):
     is_running = BooleanField()  # this maps to Tool.is_running()
-    owner = JSONField(source="_get_owner_as_json")
+    owner = JSONField(source="_get_owner_as_dict")
 
     class Meta:
         model = Tool

--- a/refinery/tool_manager/serializers.py
+++ b/refinery/tool_manager/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from rest_framework.fields import BooleanField
+from rest_framework.fields import BooleanField, JSONField
 from rest_framework_recursive.fields import RecursiveField
 
 from file_store.models import FileType
@@ -75,6 +75,7 @@ class ToolDefinitionSerializer(serializers.ModelSerializer):
 
 class ToolSerializer(serializers.ModelSerializer):
     is_running = BooleanField()  # this maps to Tool.is_running()
+    owner = JSONField(source="_get_owner_as_json")
 
     class Meta:
         model = Tool

--- a/refinery/tool_manager/serializers.py
+++ b/refinery/tool_manager/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from rest_framework.fields import BooleanField
 from rest_framework_recursive.fields import RecursiveField
 
 from file_store.models import FileType
@@ -73,6 +74,8 @@ class ToolDefinitionSerializer(serializers.ModelSerializer):
 
 
 class ToolSerializer(serializers.ModelSerializer):
+    is_running = BooleanField()  # this maps to Tool.is_running()
+
     class Meta:
         model = Tool
         exclude = ["id"]

--- a/refinery/tool_manager/serializers.py
+++ b/refinery/tool_manager/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from rest_framework.fields import BooleanField, JSONField
+from rest_framework.fields import BooleanField, CharField, JSONField
 from rest_framework_recursive.fields import RecursiveField
 
 from file_store.models import FileType
@@ -75,7 +75,9 @@ class ToolDefinitionSerializer(serializers.ModelSerializer):
 
 class ToolSerializer(serializers.ModelSerializer):
     is_running = BooleanField()  # this maps to Tool.is_running()
-    owner = JSONField(source="_get_owner_as_dict")
+    owner = JSONField(source="_get_owner_info_as_dict")
+    container_url = CharField(source="get_relative_container_url")
+    relaunch_url = CharField()  # this maps to Tool.relaunch_url
 
     class Meta:
         model = Tool

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -2671,7 +2671,7 @@ class ToolAPITests(APITestCase, ToolManagerTestBase):
         for tool in self.get_response.data:
             self.assertEqual(
                 tool["owner"],
-                self.tool._get_owner_as_json()
+                self.tool._get_owner_as_dict()
             )
 
 

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -276,6 +276,9 @@ class ToolManagerTestBase(ToolManagerMocks):
     def tearDown(self):
         # Trigger the pre_delete signal so that datafiles are purged
         FileStoreItem.objects.all().delete()
+        # Remove any running containers
+        with self.settings(DJANGO_DOCKER_ENGINE_SECONDS_INACTIVE=0):
+            django_docker_cleanup()
         super(ToolManagerTestBase, self).tearDown()
 
     def create_solr_mock_response(self, tool):

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -2761,6 +2761,12 @@ class ToolAPITests(APITestCase, ToolManagerTestBase):
         )
         self.assertTrue(self.tool.is_running())
 
+    def test_relaunch_failure_no_auth(self):
+        self.create_tool(ToolDefinition.VISUALIZATION)
+        get_request = self.factory.get(self.tool.relaunch_url)
+        get_response = self.tool_relaunch_view(get_request)
+        self.assertEqual(get_response.status_code, 403)
+
     def test_relaunch_failure_no_uuid_present(self):
         self.create_tool(ToolDefinition.VISUALIZATION)
         get_request = self.factory.get(self.tool.relaunch_url)

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -2661,6 +2661,19 @@ class ToolAPITests(APITestCase, ToolManagerTestBase):
 
         self.assertFalse(self.get_response.data[0]["is_running"])
 
+    def test_owner_info_is_returned(self):
+        self.create_tool(ToolDefinition.WORKFLOW)
+        self.create_tool(ToolDefinition.VISUALIZATION)
+
+        self._make_tools_get_request()
+        self.assertEqual(len(self.get_response.data), 2)
+
+        for tool in self.get_response.data:
+            self.assertEqual(
+                tool["owner"],
+                self.tool._get_owner_as_json()
+            )
+
 
 class WorkflowToolLaunchTests(ToolManagerTestBase):
     tasks_mock = "analysis_manager.tasks"

--- a/refinery/tool_manager/utils.py
+++ b/refinery/tool_manager/utils.py
@@ -183,7 +183,7 @@ def create_tool(tool_launch_configuration, user_instance):
     )
 
     tool_type = tool_definition.tool_type
-    tool_name = "{}-launch".format(tool_definition.name)
+    tool_name = tool_definition.name
 
     common_tool_params = {
         "name": tool_name,


### PR DESCRIPTION
- Adds fields `is_running`,  `owner`, `container_url`, `relaunch_url`,  to the `/tools` api response

TODO:
- [x] Test
- [x] Get Jennifer requested `owner` fields
- [x] Make sure requesting users have at least `read` perm to relaunch