### PR TITLE
Hide any users without profiles or a full_name.

### DIFF
--- a/refinery/templates/core/group.html
+++ b/refinery/templates/core/group.html
@@ -25,12 +25,13 @@
     </div>
     <p>
     {% for member in group.user_set.all %}
-      {% if member.profile %}
+      {% if member.profile and member.get_full_name  %}
         <a href="{% url 'user' member.profile.uuid %}">{{ member.get_full_name }}</a>
-      {% else %}
+        &nbsp;(Last login: {{ member.last_login|naturaltime }})<br/>
+      {% elif member.get_full_name %}
         {{ member.get_full_name }}
+        &nbsp;(Last login: {{ member.last_login|naturaltime }})<br/>
       {% endif %}
-      &nbsp;(Last login: {{ member.last_login|naturaltime }})<br/>
     {% endfor %}
     </p>
 


### PR DESCRIPTION
Ref #2121 
Unsure why users want this page, since group info is provided on the collaboration page. The collaboration page is getting an overhaul next year, so this pull request addresses the bug.