### PR TITLE
Scottx611x/expose extra directories

### DIFF
--- a/refinery/file_store/tasks.py
+++ b/refinery/file_store/tasks.py
@@ -109,12 +109,10 @@ def import_file(uuid, refresh=False, file_size=0):
             logger.debug("Downloading file from '%s'", item.source)
             try:
                 uploaded_object.download_fileobj(download)
-            except botocore.exceptions.ClientError:
-                logger.error("Failed to download '%s'", item.source)
-                import_file.update_state(
-                    state=celery.states.FAILURE,
-                    meta='Failed to import uploaded file'
-                )
+            except botocore.exceptions.ClientError as exc:
+                logger.error("Failed to download '%s': %s", item.source, exc)
+                import_file.update_state(state=celery.states.FAILURE,
+                                         meta='Failed to import uploaded file')
                 return None
             logger.debug("Saving downloaded file '%s'", download.name)
             item.datafile.save(os.path.basename(key), File(download))

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -431,10 +431,8 @@ class VisualizationTool(Tool):
             self.FILE_RELATIONSHIPS: self.get_file_relationships_urls(),
             ToolDefinition.PARAMETERS: self._get_visualization_parameters(),
             self.NODE_INFORMATION: self._get_detailed_input_nodes_dict(),
-            ToolDefinition.EXTRA_DIRECTORIES: (
+            ToolDefinition.EXTRA_DIRECTORIES:
                 self.tool_definition.get_extra_directories()
-            )
-
         }
 
     def _get_detailed_input_nodes_dict(self):

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -159,7 +159,7 @@ class ToolDefinition(models.Model):
     Visualizations, Other) will need to know about their expected inputs,
     outputs, and input file structuring.
     """
-
+    EXTRA_DIRECTORIES = "extra_directories"
     PARAMETERS = "parameters"
     WORKFLOW = 'WORKFLOW'
     VISUALIZATION = 'VISUALIZATION'
@@ -204,14 +204,16 @@ class ToolDefinition(models.Model):
         """
         if self.tool_type == ToolDefinition.VISUALIZATION:
             try:
-                return self.get_annotation()["extra_directories"]
+                return self.get_annotation()[self.EXTRA_DIRECTORIES]
             except KeyError:
                 logger.error("ToolDefinition: %s's annotation is missing its "
-                             "`extra_directories` key.", self.name)
+                             "`%s` key.", self.name, self.EXTRA_DIRECTORIES)
                 raise
         else:
             raise NotImplementedError(
-                "Workflow-based tools don't utilize `extra_directories`"
+                "Workflow-based tools don't utilize `{}`".format(
+                    self.EXTRA_DIRECTORIES
+                )
             )
 
     def get_parameters(self):
@@ -428,7 +430,11 @@ class VisualizationTool(Tool):
         return {
             self.FILE_RELATIONSHIPS: self.get_file_relationships_urls(),
             ToolDefinition.PARAMETERS: self._get_visualization_parameters(),
-            self.NODE_INFORMATION: self._get_detailed_input_nodes_dict()
+            self.NODE_INFORMATION: self._get_detailed_input_nodes_dict(),
+            ToolDefinition.EXTRA_DIRECTORIES: (
+                self.tool_definition.get_extra_directories()
+            )
+
         }
 
     def _get_detailed_input_nodes_dict(self):

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -87,7 +87,7 @@ class Parameter(models.Model):
         if self.value_type in self.STRING_TYPES:
             return str(parameter_value)
         elif self.value_type == self.BOOLEAN:
-            return bool(parameter_value)
+            return True if parameter_value.lower() == "true" else False
         elif self.value_type == self.INTEGER:
             return int(parameter_value)
         elif self.value_type == self.FLOAT:
@@ -469,9 +469,13 @@ class VisualizationTool(Tool):
                 {
                     "uuid": parameter.uuid,
                     "description": parameter.description,
-                    "default_value": parameter.default_value,
+                    "default_value": parameter.cast_param_value_to_proper_type(
+                        parameter.default_value
+                    ),
                     "name": parameter.name,
-                    "value": self._get_edited_parameter_value(parameter),
+                    "value": parameter.cast_param_value_to_proper_type(
+                        self._get_edited_parameter_value(parameter)
+                    ),
                     "value_type": parameter.value_type
                 }
             )

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -3473,3 +3473,75 @@ class ToolManagerUtilitiesTests(ToolManagerTestBase):
                 ),
                 context.exception.message
             )
+
+
+class ParameterTests(ToolManagerTestBase):
+    def test_cast_param_value_to_proper_type_bool(self):
+        parameter = ParameterFactory(
+            name="Bool Param",
+            description="Boolean Parameter",
+            value_type=Parameter.BOOLEAN,
+            default_value="False"
+        )
+        self.assertFalse(
+            parameter.cast_param_value_to_proper_type(parameter.default_value)
+        )
+
+        parameter = ParameterFactory(
+            name="Bool Param",
+            description="Boolean Parameter",
+            value_type=Parameter.BOOLEAN,
+            default_value="True"
+        )
+        self.assertTrue(
+            parameter.cast_param_value_to_proper_type(parameter.default_value)
+        )
+
+    def test_cast_param_value_to_proper_type_string(self):
+        for string_type in Parameter.STRING_TYPES:
+            parameter = ParameterFactory(
+                name="String Param",
+                description="String Parameter",
+                value_type=string_type,
+                default_value="Coffee"
+            )
+            self.assertEqual(
+                str,
+                type(
+                    parameter.cast_param_value_to_proper_type(
+                        parameter.default_value
+                    )
+                )
+            )
+
+    def test_cast_param_value_to_proper_type_int(self):
+        parameter = ParameterFactory(
+            name="Int Param",
+            description="Integer Parameter",
+            value_type=Parameter.INTEGER,
+            default_value="1"
+        )
+        self.assertEqual(
+            int,
+            type(
+                parameter.cast_param_value_to_proper_type(
+                    parameter.default_value
+                )
+            )
+        )
+
+    def test_cast_param_value_to_proper_type_float(self):
+        parameter = ParameterFactory(
+            name="Float Param",
+            description="Float Parameter",
+            value_type=Parameter.FLOAT,
+            default_value="1.0"
+        )
+        self.assertEqual(
+            float,
+            type(
+                parameter.cast_param_value_to_proper_type(
+                    parameter.default_value
+                )
+            )
+        )

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -1522,7 +1522,7 @@ class VisualizationToolTests(ToolManagerTestBase):
         )
         self.assertTrue(self.search_solr_mock.called)
 
-    def test__create_input_dict(self):
+    def test__create_container_input_dict(self):
         tool_input_dict = self.tool._create_container_input_dict()
         file_relationships = self.tool.get_file_relationships_urls()
 
@@ -1533,7 +1533,9 @@ class VisualizationToolTests(ToolManagerTestBase):
                 VisualizationTool.NODE_INFORMATION:
                     self.tool._get_detailed_input_nodes_dict(),
                 ToolDefinition.PARAMETERS:
-                    self.tool._get_visualization_parameters()
+                    self.tool._get_visualization_parameters(),
+                ToolDefinition.EXTRA_DIRECTORIES:
+                    self.tool.tool_definition.get_extra_directories()
             }
         )
 

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -3508,11 +3508,9 @@ class ParameterTests(ToolManagerTestBase):
                 default_value="Coffee"
             )
             self.assertEqual(
-                str,
-                type(
-                    parameter.cast_param_value_to_proper_type(
-                        parameter.default_value
-                    )
+                parameter.default_value,
+                parameter.cast_param_value_to_proper_type(
+                    parameter.default_value
                 )
             )
 
@@ -3524,11 +3522,9 @@ class ParameterTests(ToolManagerTestBase):
             default_value="1"
         )
         self.assertEqual(
-            int,
-            type(
-                parameter.cast_param_value_to_proper_type(
-                    parameter.default_value
-                )
+            1,
+            parameter.cast_param_value_to_proper_type(
+                parameter.default_value
             )
         )
 
@@ -3540,10 +3536,8 @@ class ParameterTests(ToolManagerTestBase):
             default_value="1.0"
         )
         self.assertEqual(
-            float,
-            type(
-                parameter.cast_param_value_to_proper_type(
-                    parameter.default_value
-                )
+            1.0,
+            parameter.cast_param_value_to_proper_type(
+                parameter.default_value
             )
         )


### PR DESCRIPTION
@mccalluc Please review/merge #2446 Before this one

- Add `extra_directories` information to `input.json`

Note: [`Heatmap Scatterplot`](https://github.com/mccalluc/heatmap-scatter-dash/) Tool launches properly with these changes, but we run into the relative paths issue again (when specifying a relative path in a VisTool things get routed through Refinery instead of the proxy) . We should really begin looking into using[ subdomain based routing for Vis Tools ](https://github.com/refinery-platform/django_docker_engine/issues/71)