### PR TITLE
Bump codecov req

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ boto3==1.4.4
 celery==3.1.20
 certifi==2015.4.28
 cffi==1.9.1
-codecov==1.6.3
+codecov==2.0.10
 coverage==4.0.3
 cryptography==1.7.1
 Django==1.7.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ boto3==1.4.4
 celery==3.1.20
 certifi==2015.4.28
 cffi==1.9.1
-codecov==2.0.10
+codecov==2.0.11
 coverage==4.0.3
 cryptography==1.7.1
 Django==1.7.11


### PR DESCRIPTION
Steve from codecov suggested that we update our `codecov-python` version to avoid this error:
`"Direct to s3 failed. Using backup v2 endpoint."`