### PR TITLE
Bump django_docker_engine version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ django-auth-ldap==1.2.6
 django-celery==3.1.17
 django-chunked-upload==1.0.5
 django-debug-toolbar==1.4
-django-docker-engine==0.0.31
+django-docker-engine==0.0.34
 django-extensions==1.6.7
 django-flatblocks==0.7.1
 django-guardian==1.4.1


### PR DESCRIPTION
  Re: https://github.com/refinery-platform/django_docker_engine/pull/99