### PR TITLE
Scottx611x/better load tools error message

### DIFF
--- a/refinery/config/settings/base.py
+++ b/refinery/config/settings/base.py
@@ -615,3 +615,6 @@ TASTYPIE_DEFAULT_FORMATS = ['json']
 
 # temporary feature toggle for using S3 as user data file storage backend
 REFINERY_S3_USER_DATA = get_setting('REFINERY_S3_USER_DATA', default=False)
+
+REFINERY_VISUALIZATION_TOOL_REGISTRY_URL = \
+    "https://github.com/refinery-platform/visualization-tools/"

--- a/refinery/config/settings/base.py
+++ b/refinery/config/settings/base.py
@@ -616,5 +616,5 @@ TASTYPIE_DEFAULT_FORMATS = ['json']
 # temporary feature toggle for using S3 as user data file storage backend
 REFINERY_S3_USER_DATA = get_setting('REFINERY_S3_USER_DATA', default=False)
 
-REFINERY_VISUALIZATION_TOOL_REGISTRY_URL = \
+REFINERY_VISUALIZATION_REGISTRY = \
     "https://github.com/refinery-platform/visualization-tools/"

--- a/refinery/tool_manager/management/commands/load_tools.py
+++ b/refinery/tool_manager/management/commands/load_tools.py
@@ -48,6 +48,7 @@ class Command(BaseCommand):
     def __init__(self):
         super(Command, self).__init__()
         self.force = False
+        self.visualization_registry_branch = "master"
 
     def warn(self, message):
         self.stderr.write(
@@ -115,27 +116,30 @@ class Command(BaseCommand):
         if result[0].lower() == "n":
             sys.exit(0)
 
-    def _load_visualization_definitions(self, names, branch='master'):
+    def _load_visualization_definitions(self, names):
         visualization_annotations = []
-        availible_registry_tool_names = \
-            self._get_available_visualization_tool_registry_names()
 
         for name in names:
             if os.path.exists(name):
                 with open(name) as f:
                     annotation = json.loads(f.read())
             else:
-                url = 'https://raw.githubusercontent.com/' + \
-                    'refinery-platform/visualization-tools/' + \
-                    branch + '/tool-annotations/' + name + '.json'
-                response = requests.get(url)
+                raw_asset_url = (
+                    'https://raw.githubusercontent.com/'
+                    'refinery-platform/visualization-tools/' +
+                    self.visualization_registry_branch +
+                    '/tool-annotations/' + name + '.json'
+                )
+                response = requests.get(raw_asset_url)
                 if response.status_code != 200:
+                    availible_registry_tool_names = \
+                        self._get_available_visualization_tool_registry_names()
                     raise CommandError(
-                        '"{}" not a local file and "{}" does not point to'
+                        '"{}" not a local file path and "{}" does not point to'
                         ' a valid Visualization Tool Registry URL.\n '
                         'Available Visualization Tools from the '
                         'Registry ({}) are: {}'.format(
-                            name, url,
+                            name, raw_asset_url,
                             settings.REFINERY_VISUALIZATION_TOOL_REGISTRY_URL,
                             availible_registry_tool_names
                         )

--- a/refinery/tool_manager/management/commands/load_tools.py
+++ b/refinery/tool_manager/management/commands/load_tools.py
@@ -226,22 +226,11 @@ class Command(BaseCommand):
         except requests.exceptions.RequestException as e:
             raise CommandError(
                 "Unable to fetch Visualization Tools from the Registry "
-                "({}): {}".format(
-                    settings.REFINERY_VISUALIZATION_TOOL_REGISTRY_URL,
-                    e
-                )
+                "({}): {}".format(settings.REFINERY_VISUALIZATION_REGISTRY, e)
             )
-        else:
-            return ", ".join(
-                [
-                    tool_name.split("/")[1].replace(".json", "")
-                    for tool_name in re.findall(
-                        r"tool-annotations/.+?\.json",
-                        response.content
-                    )
-                ]
-
-            )
+        return ', '.join(
+            re.findall(r"tool-annotations/(.+?)\.json",  response.content)
+        )
 
     @staticmethod
     def _has_workflow_outputs(workflow):

--- a/refinery/tool_manager/management/commands/load_tools.py
+++ b/refinery/tool_manager/management/commands/load_tools.py
@@ -140,7 +140,7 @@ class Command(BaseCommand):
                         'Available Visualization Tools from the '
                         'Registry ({}) are: {}'.format(
                             name, raw_asset_url,
-                            settings.REFINERY_VISUALIZATION_TOOL_REGISTRY_URL,
+                            settings.REFINERY_VISUALIZATION_REGISTRY,
                             availible_registry_tool_names
                         )
                     )
@@ -217,7 +217,7 @@ class Command(BaseCommand):
         try:
             response = requests.get(
                 urljoin(
-                    settings.REFINERY_VISUALIZATION_TOOL_REGISTRY_URL,
+                    settings.REFINERY_VISUALIZATION_REGISTRY,
                     "tree/{}/tool-annotations".format(
                         self.visualization_registry_branch
                     )

--- a/refinery/tool_manager/management/commands/load_tools.py
+++ b/refinery/tool_manager/management/commands/load_tools.py
@@ -49,6 +49,11 @@ class Command(BaseCommand):
         super(Command, self).__init__()
         self.force = False
         self.visualization_registry_branch = "master"
+        self.raw_registry_url = \
+            settings.REFINERY_VISUALIZATION_REGISTRY.replace(
+                "github",
+                "raw.githubusercontent"
+            )
 
     def warn(self, message):
         self.stderr.write(
@@ -124,9 +129,8 @@ class Command(BaseCommand):
                 with open(name) as f:
                     annotation = json.loads(f.read())
             else:
-                raw_asset_url = (
-                    'https://raw.githubusercontent.com/'
-                    'refinery-platform/visualization-tools/' +
+                raw_asset_url = urljoin(
+                    self.raw_registry_url,
                     self.visualization_registry_branch +
                     '/tool-annotations/' + name + '.json'
                 )

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -3444,6 +3444,10 @@ class VisualizationToolLaunchTests(ToolManagerTestBase,  # TODO: Cypress
             self.live_server_url,
             "/tool_manager/test_data/sample.seg"
         )
+        mock.patch.object(
+            LoadToolsCommand,
+            "_get_available_visualization_tool_registry_names",
+        ).start()
 
     def tearDown(self):
         # super() will only ever resolve a single class type for a given method

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -267,12 +267,11 @@ class ToolManagerTestBase(ToolManagerMocks):
             self.django_docker_cleanup_wait_time
         )
 
-    def load_visualizations(self, visualizations=None):
+    def load_visualizations(
+        self,
+        visualizations=["{}/visualizations/igv.json".format(TEST_DATA_PATH)]
+    ):
         # TODO: More mocking, so Docker image is not downloaded
-        if visualizations is None:
-            visualizations = [
-                "{}/visualizations/igv.json".format(TEST_DATA_PATH)
-            ]
         call_command("load_tools", visualizations=visualizations)
         return visualizations
 

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -3580,18 +3580,17 @@ class VisualizationToolLaunchTests(ToolManagerTestBase,  # TODO: Cypress
         )
 
     def test_max_containers(self):
-        for i in xrange(settings.DJANGO_DOCKER_ENGINE_MAX_CONTAINERS):
+        with self.settings(DJANGO_DOCKER_ENGINE_MAX_CONTAINERS=1):
             self._start_visualization(
                 'hello_world.json',
                 "https://www.example.com/file.txt",
-                count=i+1
+                count=settings.DJANGO_DOCKER_ENGINE_MAX_CONTAINERS
             )
-
-        with self.assertRaises(VisualizationToolError) as context:
-            self._start_visualization(
-                'hello_world.json',
-                "https://www.example.com/file.txt"
-            )
+            with self.assertRaises(VisualizationToolError) as context:
+                self._start_visualization(
+                    'hello_world.json',
+                    "https://www.example.com/file.txt",
+                )
         self.assertIn("Max containers", context.exception.message)
 
     def test__get_launch_parameters(self):

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -1262,7 +1262,9 @@ class ToolDefinitionGenerationTests(ToolManagerTestBase):
             fake_registry_tool_names
         )
 
-        with self.settings(REFINERY_VISUALIZATION_REGISTRY="blah"):
+        with self.settings(
+                REFINERY_VISUALIZATION_REGISTRY="http://www.example.com"
+        ):
             with self.assertRaises(CommandError) as context:
                 self.load_visualizations(visualizations=[fake_vis_tool_name])
                 self.assertTrue(get_available_vis_tool_names_mock.called)

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -1263,14 +1263,14 @@ class ToolDefinitionGenerationTests(ToolManagerTestBase):
             fake_registry_tool_names
         )
 
-        with self.settings(REFINERY_VISUALIZATION_TOOL_REGISTRY_URL="blah"):
+        with self.settings(REFINERY_VISUALIZATION_REGISTRY="blah"):
             with self.assertRaises(CommandError) as context:
                 self.load_visualizations(visualizations=[fake_vis_tool_name])
                 self.assertTrue(get_available_vis_tool_names_mock.called)
             self.assertIn(
                 "Available Visualization Tools from the Registry ({}) are: {}"
                 .format(
-                    settings.REFINERY_VISUALIZATION_TOOL_REGISTRY_URL,
+                    settings.REFINERY_VISUALIZATION_REGISTRY,
                     fake_registry_tool_names
                 ),
                 context.exception.message


### PR DESCRIPTION
Fixes: #2529 

Error message displayed is now:
```
CommandError: "blah" not a local file path and "https://raw.githubusercontent.com/refinery-platform/visualization-tools/master/tool-annotations/blah.json" does not point to a valid Visualization Tool Registry URL.
 Available Visualization Tools from the Registry (https://github.com/refinery-platform/visualization-tools/) are: heatmap-scatterplot, higlass, igv, refinery-developer-tool
```