### PR TITLE
bump django-docker-engine

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ django-auth-ldap==1.2.6
 django-celery==3.1.17
 django-chunked-upload==1.0.5
 django-debug-toolbar==1.4
-django-docker-engine==0.0.34
+django-docker-engine==0.0.35
 django-extensions==1.6.7
 django-flatblocks==0.7.1
 django-guardian==1.4.1


### PR DESCRIPTION
This provides a default 50% CPU quota per container: enough for now, because I think we really want to go in a different direction eventually.