### PR TITLE
Hackdna/fix isa tab parser bug

### DIFF
--- a/refinery/data_set_manager/isa_tab_parser.py
+++ b/refinery/data_set_manager/isa_tab_parser.py
@@ -1010,12 +1010,10 @@ class IsaTabParser:
                 "file \"" + investigation_file_name + "\""
             )
         # 5. assign ISA-Tab archive and pre-ISA-Tab archive if present
-        try:
+        if isa_archive:
             self._current_investigation.isarchive_file = create(isa_archive)
             import_file(self._current_investigation.isarchive_file,
                         refresh=True)
-        except:
-            pass
 
         if preisa_archive:
             self._current_investigation.pre_isarchive_file = \

--- a/refinery/data_set_manager/tests.py
+++ b/refinery/data_set_manager/tests.py
@@ -2167,11 +2167,7 @@ class IsaTabTestBase(TestCase):
         self.user.set_password(test_user)
         self.user.save()
         self.isa_tab_import_url = "/data_set_manager/import/isa-tab-form/"
-        is_logged_in = self.client.login(
-            username=self.user.username,
-            password=test_user
-        )
-        self.assertTrue(is_logged_in)
+        self.client.login(username=self.user.username, password=test_user)
 
     def tearDown(self):
         mock.patch.stopall()


### PR DESCRIPTION
To prevent unnecessary errors when trying to create FileStoreItem instances when source is None and avoid silencing exceptions which can lead to TransactionManagementError when running tests.
