### PR TITLE
Scottx611x/send over all dataset node info

### DIFF
--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -833,12 +833,14 @@ class DataSet(SharableResource):
         else:
             return False
 
-    def get_nodes(self, uuids_only=False):
-        nodes = Node.objects.filter(
+    def get_nodes(self):
+        return Node.objects.filter(
             assay=self.get_latest_assay(),
             study=self.get_latest_study()
         )
-        return nodes.values_list('uuid', flat=True) if uuids_only else nodes
+
+    def get_node_uuids(self):
+        return self.get_nodes().values_list('uuid', flat=True)
 
 
 @receiver(pre_delete, sender=DataSet)

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -833,6 +833,13 @@ class DataSet(SharableResource):
         else:
             return False
 
+    def get_nodes(self, uuids_only=False):
+        nodes = Node.objects.filter(
+            assay=self.get_latest_assay(),
+            study=self.get_latest_study()
+        )
+        return nodes.values_list('uuid', flat=True) if uuids_only else nodes
+
 
 @receiver(pre_delete, sender=DataSet)
 def _dataset_delete(sender, instance, *args, **kwargs):

--- a/refinery/core/tests.py
+++ b/refinery/core/tests.py
@@ -1550,10 +1550,7 @@ class DataSetTests(TestCase):
 
     def test_get_nodes_no_nodes_available(self):
         Node.objects.all().delete()
-        self.assertEqual(
-            self.dataset.get_nodes(),
-            []  # empty QuerySet
-        )
+        self.assertQuerysetEqual(self.dataset.get_nodes(), [])
 
     def test_get_nodes_uuids_only(self):
         node_uuids = Node.objects.all().values_list("uuid", flat=True)
@@ -1565,10 +1562,7 @@ class DataSetTests(TestCase):
 
     def test_get_nodes_uuids_only_no_nodes_available(self):
         Node.objects.all().delete()
-        self.assertEqual(
-            self.dataset.get_nodes(uuids_only=True),
-            []  # empty QuerySet
-        )
+        self.assertQuerysetEqual(self.dataset.get_nodes(uuids_only=True), [])
 
 
 class DataSetApiV2Tests(APITestCase):

--- a/refinery/core/tests.py
+++ b/refinery/core/tests.py
@@ -1543,6 +1543,27 @@ class DataSetTests(TestCase):
             dataset.get_latest_study()
             self.assertIn("Couldn't fetch Study", context.exception.message)
 
+    def test_get_nodes(self):
+        nodes = Node.objects.all()
+        self.assertGreater(nodes.count(), 0)
+        [self.assertIn(node, self.dataset.get_nodes()) for node in nodes]
+
+    def test_get_nodes_no_nodes_available(self):
+        Node.objects.all().delete()
+        self.assertEqual(len(self.dataset.get_nodes()), 0)
+
+    def test_get_nodes_uuids_only(self):
+        node_uuids = Node.objects.all().values_list("uuid")
+        self.assertGreater(node_uuids.count(), 0)
+        [
+            self.assertIn(node_uuid, self.dataset.get_nodes(uuids_only=True))
+            for node_uuid in node_uuids
+        ]
+
+    def test_get_nodes_uuids_only_no_nodes_available(self):
+        Node.objects.all().delete()
+        self.assertEqual(len(self.dataset.get_nodes(uuids_only=True)), 0)
+
 
 class DataSetApiV2Tests(APITestCase):
 

--- a/refinery/core/tests.py
+++ b/refinery/core/tests.py
@@ -1546,7 +1546,8 @@ class DataSetTests(TestCase):
     def test_get_nodes(self):
         nodes = Node.objects.all()
         self.assertGreater(nodes.count(), 0)
-        [self.assertIn(node, self.dataset.get_nodes()) for node in nodes]
+        for node in self.dataset.get_nodes():
+            self.assertIn(node, nodes)
 
     def test_get_nodes_no_nodes_available(self):
         Node.objects.all().delete()
@@ -1555,10 +1556,8 @@ class DataSetTests(TestCase):
     def test_get_node_uuids(self):
         node_uuids = Node.objects.all().values_list("uuid", flat=True)
         self.assertGreater(node_uuids.count(), 0)
-        [
-            self.assertIn(node_uuid, self.dataset.get_node_uuids())
-            for node_uuid in node_uuids
-        ]
+        for node_uuid in self.dataset.get_node_uuids():
+            self.assertIn(node_uuid, node_uuids)
 
     def test_get_node_uuids_no_nodes_available(self):
         Node.objects.all().delete()

--- a/refinery/core/tests.py
+++ b/refinery/core/tests.py
@@ -1552,17 +1552,17 @@ class DataSetTests(TestCase):
         Node.objects.all().delete()
         self.assertQuerysetEqual(self.dataset.get_nodes(), [])
 
-    def test_get_nodes_uuids_only(self):
+    def test_get_node_uuids(self):
         node_uuids = Node.objects.all().values_list("uuid", flat=True)
         self.assertGreater(node_uuids.count(), 0)
         [
-            self.assertIn(node_uuid, self.dataset.get_nodes(uuids_only=True))
+            self.assertIn(node_uuid, self.dataset.get_node_uuids())
             for node_uuid in node_uuids
         ]
 
-    def test_get_nodes_uuids_only_no_nodes_available(self):
+    def test_get_node_uuids_no_nodes_available(self):
         Node.objects.all().delete()
-        self.assertQuerysetEqual(self.dataset.get_nodes(uuids_only=True), [])
+        self.assertQuerysetEqual(self.dataset.get_node_uuids(), [])
 
 
 class DataSetApiV2Tests(APITestCase):

--- a/refinery/core/tests.py
+++ b/refinery/core/tests.py
@@ -1553,7 +1553,7 @@ class DataSetTests(TestCase):
         self.assertEqual(len(self.dataset.get_nodes()), 0)
 
     def test_get_nodes_uuids_only(self):
-        node_uuids = Node.objects.all().values_list("uuid")
+        node_uuids = Node.objects.all().values_list("uuid", flat=True)
         self.assertGreater(node_uuids.count(), 0)
         [
             self.assertIn(node_uuid, self.dataset.get_nodes(uuids_only=True))

--- a/refinery/core/tests.py
+++ b/refinery/core/tests.py
@@ -1550,7 +1550,10 @@ class DataSetTests(TestCase):
 
     def test_get_nodes_no_nodes_available(self):
         Node.objects.all().delete()
-        self.assertEqual(len(self.dataset.get_nodes()), 0)
+        self.assertEqual(
+            self.dataset.get_nodes(),
+            []  # empty QuerySet
+        )
 
     def test_get_nodes_uuids_only(self):
         node_uuids = Node.objects.all().values_list("uuid", flat=True)
@@ -1562,7 +1565,10 @@ class DataSetTests(TestCase):
 
     def test_get_nodes_uuids_only_no_nodes_available(self):
         Node.objects.all().delete()
-        self.assertEqual(len(self.dataset.get_nodes(uuids_only=True)), 0)
+        self.assertEqual(
+            self.dataset.get_nodes(uuids_only=True),
+            []  # empty QuerySet
+        )
 
 
 class DataSetApiV2Tests(APITestCase):

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -476,9 +476,11 @@ class VisualizationTool(Tool):
             self.API_PREFIX: self.get_relative_container_url() + "/",
             self.FILE_RELATIONSHIPS: self.get_file_relationships_urls(),
             ToolDefinition.PARAMETERS: self._get_visualization_parameters(),
-            self.INPUT_NODE_INFORMATION: self._get_detailed_nodes_dict(),
+            self.INPUT_NODE_INFORMATION: self._get_detailed_nodes_dict(
+                self.get_input_node_uuids()
+            ),
             self.ALL_NODE_INFORMATION: self._get_detailed_nodes_dict(
-                fetch_all_nodes=True
+                self.dataset.get_node_uuids()
             ),
             ToolDefinition.EXTRA_DIRECTORIES:
                 self.tool_definition.get_extra_directories()
@@ -489,21 +491,16 @@ class VisualizationTool(Tool):
         if len(self._django_docker_client.list()) >= max_containers:
             raise VisualizationToolError('Max containers')
 
-    def _get_detailed_nodes_dict(self, fetch_all_nodes=False):
+    def _get_detailed_nodes_dict(self, node_uuid_list):
         """
         Create and return a dict with detailed information about all of our
-        Tool's input Nodes. If `fetch_all_nodes` == True then we construct
-        the resulting dict from all nodes in our Tool's DataSet, not the
-        input nodes to the Tool alone.
+        Nodes corresponding to the UUIDs in the given `node_uuid_list`.
 
         This detailed info contains:
             - Whatever we have in our Solr index for a given Node
             - A full url pointing to our Node's FileStoreItem's datafile
         """
-        solr_response_json = get_solr_response_json(
-            self.dataset.get_nodes(uuids_only=True) if fetch_all_nodes
-            else self.get_input_node_uuids()
-        )
+        solr_response_json = get_solr_response_json(node_uuid_list)
         node_info = {
             node["uuid"]: {
                 self.NODE_SOLR_INFO: node,

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -479,6 +479,8 @@ class VisualizationTool(Tool):
             self.INPUT_NODE_INFORMATION: self._get_detailed_nodes_dict(
                 self.get_input_node_uuids()
             ),
+            # TODO: adding all of a DataSet's Node info seems excessive. Would
+            #  be great if we had a VisualizationTool using all of this info
             self.ALL_NODE_INFORMATION: self._get_detailed_nodes_dict(
                 self.dataset.get_node_uuids()
             ),

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -1657,7 +1657,9 @@ class VisualizationToolTests(ToolManagerTestBase):
         }
 
     def test_get_detailed_input_nodes_dict(self):
-        input_nodes_meta_info = self.tool._get_detailed_nodes_dict()
+        input_nodes_meta_info = self.tool._get_detailed_nodes_dict(
+            self.tool.get_input_node_uuids()
+        )
         self.assertEqual(
             input_nodes_meta_info,
             self._create_detailed_nodes_dict(self.tool._get_input_nodes())
@@ -1670,7 +1672,7 @@ class VisualizationToolTests(ToolManagerTestBase):
             all_dataset_nodes=True
         )
         all_dataset_nodes_meta_info = self.tool._get_detailed_nodes_dict(
-            fetch_all_nodes=True
+            self.tool.dataset.get_node_uuids()
         )
         self.assertEqual(
             all_dataset_nodes_meta_info,
@@ -1689,9 +1691,13 @@ class VisualizationToolTests(ToolManagerTestBase):
                     self.tool.get_relative_container_url() + "/",
                 Tool.FILE_RELATIONSHIPS: file_relationships,
                 VisualizationTool.INPUT_NODE_INFORMATION:
-                    self.tool._get_detailed_nodes_dict(),
+                    self.tool._get_detailed_nodes_dict(
+                        self.tool.get_input_node_uuids()
+                    ),
                 VisualizationTool.ALL_NODE_INFORMATION:
-                    self.tool._get_detailed_nodes_dict(fetch_all_nodes=True),
+                    self.tool._get_detailed_nodes_dict(
+                        self.tool.dataset.get_node_uuids()
+                    ),
                 ToolDefinition.PARAMETERS:
                     self.tool._get_visualization_parameters(),
                 ToolDefinition.EXTRA_DIRECTORIES:

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -283,11 +283,7 @@ class ToolManagerTestBase(ToolManagerMocks):
             django_docker_cleanup()
         super(ToolManagerTestBase, self).tearDown()
 
-    def create_solr_mock_response(self, tool, all_dataset_nodes=False):
-        nodes = (
-            tool.dataset.get_nodes() if all_dataset_nodes else
-            tool._get_input_nodes()
-        )
+    def create_solr_mock_response(self, nodes):
         node_uuids = [n.uuid for n in nodes]
         return json.dumps(
             {
@@ -1634,7 +1630,7 @@ class VisualizationToolTests(ToolManagerTestBase):
         self.search_solr_mock = mock.patch(
             "data_set_manager.utils.search_solr",
             return_value=self.create_solr_mock_response(
-                self.visualization_tool
+                self.visualization_tool._get_input_nodes()
             )
         ).start()
 
@@ -1668,8 +1664,7 @@ class VisualizationToolTests(ToolManagerTestBase):
 
     def test_get_detailed_input_nodes_dict_all_dataset_nodes(self):
         self.search_solr_mock.return_value = self.create_solr_mock_response(
-            self.tool,
-            all_dataset_nodes=True
+            self.tool.dataset.get_nodes()
         )
         all_dataset_nodes_meta_info = self.tool._get_detailed_nodes_dict(
             self.tool.dataset.get_node_uuids()
@@ -3535,7 +3530,7 @@ class VisualizationToolLaunchTests(ToolManagerTestBase,  # TODO: Cypress
         with mock.patch(
             "data_set_manager.utils.search_solr",
             return_value=self.create_solr_mock_response(
-                visualization_tool
+                visualization_tool._get_input_nodes()
             )
         ):
             visualization_tool.launch()


### PR DESCRIPTION
Fixes: #2413 

@mccalluc There would be some backwards compatibility issues with existing VisualizationTools if all of the checkboxes from #2413 were addressed. It still feels kind of dirty to me to send all this extra information over without a concrete use case for it (that I know of). 

Would like to have a quick chat about this again, no rush though.