### PR TITLE
Add `--fake-initial` to our migrate commands to provide the behavior …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ before_script:
   - cd refinery
 # See http://www.stuartellis.eu/articles/erb/#running-erb-from-the-command-line
   - erb config/config.json.erb > config/config.json
-  - python manage.py migrate --noinput
+  - python manage.py migrate --noinput --fake-initial
   - npm install -g grunt-cli@0.1.13 bower@1.8.2 --progress false --quiet || ( cat npm-debug.log && false )
   - cd ui
   - npm install --progress false --quiet || ( cat npm-debug.log && false )

--- a/deployment/refinery-modules/refinery/manifests/init.pp
+++ b/deployment/refinery-modules/refinery/manifests/init.pp
@@ -32,7 +32,7 @@ file { "${django_root}/config/config.json":
 }
 ->
 exec { "migrate":
-  command     => "${virtualenv}/bin/python ${django_root}/manage.py migrate --noinput",
+  command     => "${virtualenv}/bin/python ${django_root}/manage.py migrate --noinput --fake-initial",
   environment => ["DJANGO_SETTINGS_MODULE=${django_settings_module}"],
   user        => $app_user,
   group       => $app_group,

--- a/fabfile.py
+++ b/fabfile.py
@@ -136,7 +136,7 @@ def update_refinery():
         run("pip install -r {refinery_project_dir}/requirements.txt"
             .format(**env))
         run("find . -name '*.pyc' -delete")
-        run("{refinery_app_dir}/manage.py migrate --noinput"
+        run("{refinery_app_dir}/manage.py migrate --noinput --fake-initial"
             .format(**env))
         run("{refinery_app_dir}/manage.py collectstatic --clear --noinput"
             .format(**env))
@@ -164,7 +164,8 @@ def relaunch_refinery(dependencies=False, migrations=False):
                 .format(**env))
         run("find . -name '*.pyc' -delete")
         if migrations:
-            run("{refinery_app_dir}/manage.py migrate --noinput".format(**env))
+            run("{refinery_app_dir}/manage.py migrate --noinput "
+                "--fake-initial".format(**env))
         run("{refinery_app_dir}/manage.py collectstatic --noinput"
             .format(**env))
         run("supervisorctl restart all")


### PR DESCRIPTION
…that Django 1.7 gave by default

Without this flag I ran into the following `django.db.utils.ProgrammingError` while upgrading an existing local `Django 1.7` instance to the 1.8 branch.

```
Running migrations:
  Rendering model states... DONE
  Applying chunked_upload.0001_initial...Traceback (most recent call last):
  File "./manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/home/vagrant/.virtualenvs/refinery-platform/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 354, in execute_from_command_line
    utility.execute()
  File "/home/vagrant/.virtualenvs/refinery-platform/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 346, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/vagrant/.virtualenvs/refinery-platform/local/lib/python2.7/site-packages/django/core/management/base.py", line 394, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/home/vagrant/.virtualenvs/refinery-platform/local/lib/python2.7/site-packages/django/core/management/base.py", line 445, in execute
    output = self.handle(*args, **options)
  File "/home/vagrant/.virtualenvs/refinery-platform/local/lib/python2.7/site-packages/django/core/management/commands/migrate.py", line 222, in handle
    executor.migrate(targets, plan, fake=fake, fake_initial=fake_initial)
  File "/home/vagrant/.virtualenvs/refinery-platform/local/lib/python2.7/site-packages/django/db/migrations/executor.py", line 110, in migrate
    self.apply_migration(states[migration], migration, fake=fake, fake_initial=fake_initial)
  File "/home/vagrant/.virtualenvs/refinery-platform/local/lib/python2.7/site-packages/django/db/migrations/executor.py", line 148, in apply_migration
    state = migration.apply(state, schema_editor)
  File "/home/vagrant/.virtualenvs/refinery-platform/local/lib/python2.7/site-packages/django/db/migrations/migration.py", line 115, in apply
    operation.database_forwards(self.app_label, schema_editor, old_state, project_state)
  File "/home/vagrant/.virtualenvs/refinery-platform/local/lib/python2.7/site-packages/django/db/migrations/operations/models.py", line 59, in database_forwards
    schema_editor.create_model(model)
  File "/home/vagrant/.virtualenvs/refinery-platform/local/lib/python2.7/site-packages/django/db/backends/base/schema.py", line 286, in create_model
    self.execute(sql, params or None)
  File "/home/vagrant/.virtualenvs/refinery-platform/local/lib/python2.7/site-packages/django/db/backends/base/schema.py", line 111, in execute
    cursor.execute(sql, params)
  File "/home/vagrant/.virtualenvs/refinery-platform/local/lib/python2.7/site-packages/django/db/backends/utils.py", line 79, in execute
    return super(CursorDebugWrapper, self).execute(sql, params)
  File "/home/vagrant/.virtualenvs/refinery-platform/local/lib/python2.7/site-packages/django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
  File "/home/vagrant/.virtualenvs/refinery-platform/local/lib/python2.7/site-packages/django/db/utils.py", line 98, in __exit__
    six.reraise(dj_exc_type, dj_exc_value, traceback)
  File "/home/vagrant/.virtualenvs/refinery-platform/local/lib/python2.7/site-packages/django/db/backends/utils.py", line 62, in execute
    return self.cursor.execute(sql)
django.db.utils.ProgrammingError: relation "chunked_upload_chunkedupload" already exists
```

See: https://docs.djangoproject.com/en/1.8/topics/migrations/#adding-migrations-to-apps

```
Changed in Django 1.8:
The --fake-initial flag to migrate was added. Previously, Django would always automatically fake-apply initial migrations if it detected that the tables exist.
```