### PR TITLE
Scottx611x/persistent visualization urls

### DIFF
--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -2987,7 +2987,7 @@ class ToolAPITests(APITestCase, ToolManagerTestBase):
             assign_perm('core.read_dataset', self.user, self.tool.dataset)
 
         # Need to set_password() to be able to login. Otherwise
-        # usr.password in the hash representation which is not what the
+        # user.password is the hash representation which is not what the
         # login() expects
         temp_password = "password"
         self.user.set_password(temp_password)

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -2874,7 +2874,7 @@ class ToolAPITests(APITestCase, ToolManagerTestBase):
             uuid=self.tool.uuid
         )
         self.assertEqual(get_response.status_code, 403)
-        self.assertIn("not have sufficient permissions",
+        self.assertIn("User does not have permission",
                       get_response.content)
 
     def test_relaunch_failure_tool_already_running(self):

--- a/refinery/tool_manager/urls.py
+++ b/refinery/tool_manager/urls.py
@@ -1,10 +1,9 @@
 from django.conf import settings
 from django.conf.urls import include, url
 
-from django_docker_engine.proxy import Proxy
 from rest_framework.routers import DefaultRouter
 
-from .views import ToolDefinitionsViewSet, ToolsViewSet
+from .views import ToolDefinitionsViewSet, ToolsViewSet, VisualizationToolProxy
 
 # DRF url routing
 tool_manager_router = DefaultRouter()
@@ -15,33 +14,7 @@ tool_manager_router.register(
     base_name="tooldefinition"
 )
 
-url_patterns = Proxy(
-    settings.DJANGO_DOCKER_ENGINE_DATA_DIR,
-    please_wait_title='Please wait...',
-    please_wait_body_html='''
-        <style>
-        body {{
-          font-family: "Source Sans Pro",Helvetica,Arial,sans-serif;
-          font-size: 40pt;
-          text-align: center;
-        }}
-        div {{
-          position: absolute;
-          top: 50%;
-          left: 50%;
-          margin-right: -50%;
-          transform: translate(-50%, -50%)
-        }}
-        </style>
-
-        <div>
-        <img src="{0}/logo.svg" width='150'>
-        <p>Please wait...</p>
-        <img src="{0}/spinner.gif">
-        </div>
-    '''.format(settings.STATIC_URL + 'images')  # noqa
-).url_patterns()
 django_docker_engine_url = url(
     r'^{}/'.format(settings.DJANGO_DOCKER_ENGINE_BASE_URL),
-    include(url_patterns)
+    include(VisualizationToolProxy().url_patterns())
 )

--- a/refinery/tool_manager/urls.py
+++ b/refinery/tool_manager/urls.py
@@ -3,7 +3,7 @@ from django.conf.urls import include, url
 
 from rest_framework.routers import DefaultRouter
 
-from .views import ToolDefinitionsViewSet, ToolsViewSet, VisualizationToolProxy
+from .views import AutoRelaunchProxy, ToolDefinitionsViewSet, ToolsViewSet
 
 # DRF url routing
 tool_manager_router = DefaultRouter()
@@ -16,5 +16,5 @@ tool_manager_router.register(
 
 django_docker_engine_url = url(
     r'^{}/'.format(settings.DJANGO_DOCKER_ENGINE_BASE_URL),
-    include(VisualizationToolProxy().url_patterns())
+    include(AutoRelaunchProxy().url_patterns())
 )

--- a/refinery/tool_manager/utils.py
+++ b/refinery/tool_manager/utils.py
@@ -568,5 +568,4 @@ def create_expanded_workflow_graph(galaxy_workflow_dict):
 
 
 def user_has_access_to_tool(user, tool):
-    return \
-        False if not user.has_perm('core.read_dataset', tool.dataset) else True
+    return user.has_perm('core.read_dataset', tool.dataset)

--- a/refinery/tool_manager/utils.py
+++ b/refinery/tool_manager/utils.py
@@ -565,3 +565,8 @@ def create_expanded_workflow_graph(galaxy_workflow_dict):
             )
             graph[parent_node_id][current_node_id]['input_id'] = edge_input_id
     return graph
+
+
+def user_has_access_to_tool(user, tool):
+    return \
+        False if not user.has_perm('core.read_dataset', tool.dataset) else True

--- a/refinery/tool_manager/views.py
+++ b/refinery/tool_manager/views.py
@@ -170,7 +170,7 @@ class ToolsViewSet(ToolManagerViewSetBase):
             return HttpResponseBadRequest(e)
 
 
-class VisualizationToolProxy(Proxy, object):
+class AutoRelaunchProxy(Proxy, object):
     """
     Wrapper around Django-Docker-Engine Proxy to allow for VisualizationTools
     that had been launched previously to have persisting urls even after
@@ -178,7 +178,7 @@ class VisualizationToolProxy(Proxy, object):
     manually relaunch (although that remains an option).
     """
     def __init__(self):
-        super(VisualizationToolProxy, self).__init__(
+        super(AutoRelaunchProxy, self).__init__(
             settings.DJANGO_DOCKER_ENGINE_DATA_DIR,
             please_wait_title='Please wait...',
             please_wait_body_html='''
@@ -219,7 +219,7 @@ class VisualizationToolProxy(Proxy, object):
         if not visualization_tool.is_running():
             visualization_tool.launch()
 
-        return super(VisualizationToolProxy, self)._proxy_view(
+        return super(AutoRelaunchProxy, self)._proxy_view(
             request,
             container_name,
             url

--- a/refinery/tool_manager/views.py
+++ b/refinery/tool_manager/views.py
@@ -210,7 +210,7 @@ class VisualizationToolProxy(Proxy, object):
             VisualizationTool,
             container_name=container_name
         )
-        if not user_has_access_to_tool(request.user, VisualizationTool):
+        if not user_has_access_to_tool(request.user, visualization_tool):
             return HttpResponseForbidden(
                 "Requesting User does not have sufficient permissions to "
                 "view Tool with uuid: {}".format(visualization_tool.uuid)

--- a/refinery/tool_manager/views.py
+++ b/refinery/tool_manager/views.py
@@ -156,8 +156,9 @@ class ToolsViewSet(ToolManagerViewSetBase):
 
         if not user_has_access_to_tool(request.user, tool):
             return HttpResponseForbidden(
-                "Requesting User does not have sufficient permissions to "
-                "relaunch Tool with uuid: {}".format(tool_uuid)
+                 "User does not have permission to view Tool: {}".format(
+                     tool_uuid
+                 )
             )
 
         if tool.is_running():
@@ -212,8 +213,9 @@ class AutoRelaunchProxy(Proxy, object):
         )
         if not user_has_access_to_tool(request.user, visualization_tool):
             return HttpResponseForbidden(
-                "Requesting User does not have sufficient permissions to "
-                "view Tool with uuid: {}".format(visualization_tool.uuid)
+                "User does not have permission to view Tool: {}".format(
+                    visualization_tool.uuid
+                )
             )
 
         if not visualization_tool.is_running():

--- a/refinery/tool_manager/views.py
+++ b/refinery/tool_manager/views.py
@@ -1,10 +1,13 @@
 import logging
 
+from django.conf import settings
 from django.db import transaction
 from django.http import HttpResponseBadRequest, HttpResponseForbidden
 
+from django_docker_engine.proxy import Proxy
 from rest_framework import status
 from rest_framework.decorators import detail_route
+from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
@@ -12,7 +15,8 @@ from core.models import DataSet
 
 from .models import Tool, ToolDefinition, VisualizationTool, WorkflowTool
 from .serializers import ToolDefinitionSerializer, ToolSerializer
-from .utils import create_tool, validate_tool_launch_configuration
+from .utils import (create_tool, user_has_access_to_tool,
+                    validate_tool_launch_configuration)
 
 logger = logging.getLogger(__name__)
 
@@ -150,7 +154,7 @@ class ToolsViewSet(ToolManagerViewSetBase):
                 .format(tool_uuid, e)
             )
 
-        if not request.user.has_perm('core.read_dataset', tool.dataset):
+        if not user_has_access_to_tool(request.user, tool):
             return HttpResponseForbidden(
                 "Requesting User does not have sufficient permissions to "
                 "relaunch Tool with uuid: {}".format(tool_uuid)
@@ -164,3 +168,59 @@ class ToolsViewSet(ToolManagerViewSetBase):
         except Exception as e:
             logger.error(e)
             return HttpResponseBadRequest(e)
+
+
+class VisualizationToolProxy(Proxy, object):
+    """
+    Wrapper around Django-Docker-Engine Proxy to allow for VisualizationTools
+    that had been launched previously to have persisting urls even after
+    their containers hve been destroyed, rather than relying on users to
+    manually relaunch (although that remains an option).
+    """
+    def __init__(self):
+        super(VisualizationToolProxy, self).__init__(
+            settings.DJANGO_DOCKER_ENGINE_DATA_DIR,
+            please_wait_title='Please wait...',
+            please_wait_body_html='''
+                <style>
+                body {{
+                  font-family: "Source Sans Pro",Helvetica,Arial,sans-serif;
+                  font-size: 40pt;
+                  text-align: center;
+                }}
+                div {{
+                  position: absolute;
+                  top: 50%;
+                  left: 50%;
+                  margin-right: -50%;
+                  transform: translate(-50%, -50%)
+                }}
+                </style>
+
+                <div>
+                <img src="{0}/logo.svg" width='150'>
+                <p>Please wait...</p>
+                <img src="{0}/spinner.gif">
+                </div>
+            '''.format(settings.STATIC_URL + 'images')
+        )
+
+    def _proxy_view(self, request, container_name, url):
+        visualization_tool = get_object_or_404(
+            VisualizationTool,
+            container_name=container_name
+        )
+        if not user_has_access_to_tool(request.user, VisualizationTool):
+            return HttpResponseForbidden(
+                "Requesting User does not have sufficient permissions to "
+                "view Tool with uuid: {}".format(visualization_tool.uuid)
+            )
+
+        if not visualization_tool.is_running():
+            visualization_tool.launch()
+
+        return super(VisualizationToolProxy, self)._proxy_view(
+            request,
+            container_name,
+            url
+        )


### PR DESCRIPTION
I noticed this morning that although we have the ability to relaunch `VisualizationTools` from the UI, if one was to share the url of a running `VisualizationTool` with someone else who accesses said url after said `VisualizationTool's` container had been purged then they would get the "Please Wait" page indefinitely.

This PR relaunches `VisualizationTools` if they aren't already running when their url is accessed
![feb-28-2018 14-17-20](https://user-images.githubusercontent.com/5629547/36807926-2b7e8ba0-1c92-11e8-94e7-2e726a77bddc.gif)