### PR TITLE
Scottx611x/provide vis tools with url to their input data

### DIFF
--- a/refinery/tool_manager/migrations/0026_remove_tooldefinition_container_input_path.py
+++ b/refinery/tool_manager/migrations/0026_remove_tooldefinition_container_input_path.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tool_manager', '0025_auto_20180226_2153'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='tooldefinition',
+            name='container_input_path',
+        ),
+    ]

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -330,7 +330,8 @@ class Tool(OwnableResource):
 
     @property
     def container_input_json_url(self):
-        """Return the url that will expose a Tool's input data (as JSON) on
+        """
+        Return the url that will expose a Tool's input data (as JSON) on
         GET requests
         """
         return urljoin(

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -189,10 +189,6 @@ class ToolDefinition(models.Model):
     file_relationship = models.ForeignKey(FileRelationship)
     parameters = models.ManyToManyField(Parameter)
     image_name = models.CharField(max_length=255, blank=True)
-    container_input_path = models.CharField(
-        max_length=500,
-        blank=True
-    )
     annotation = models.TextField()
     workflow = models.ForeignKey(Workflow, null=True)
 

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -589,6 +589,9 @@ class VisualizationTool(Tool):
             - <HttpResponseBadRequest>, <HttpServerError>
         """
         self._check_max_running_containers()
+
+        # Pulls docker image if it doesn't exist yet, and launches container
+        # asynchronously
         start_container.delay(self)
         return JsonResponse({Tool.TOOL_URL: self.get_relative_container_url()})
 

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -494,7 +494,7 @@ class VisualizationTool(Tool):
 
     def get_container_input_dict(self):
         """
-        Creat a dictionary containing information that Dockerized
+        Create a dictionary containing information that Dockerized
         Visualizations will have access to
         """
         return {

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -1426,9 +1426,7 @@ def remove_tool_container(sender, instance, *args, **kwargs):
     VisualizationTool's launch.
     """
     try:
-        DockerClientWrapper(
-            settings.DJANGO_DOCKER_ENGINE_DATA_DIR
-        ).purge_by_label(instance.uuid)
+        instance.django_docker_client.purge_by_label(instance.uuid)
     except APIError as e:
         logger.error("Couldn't purge container for Tool with UUID: %s %s",
                      instance.uuid, e)

--- a/refinery/tool_manager/schemas/ToolDefinition.json
+++ b/refinery/tool_manager/schemas/ToolDefinition.json
@@ -37,7 +37,6 @@
         "file_relationship",
         "parameters",
         "extra_directories",
-        "container_input_path",
         "image_name"
       ],
       "properties": {
@@ -59,9 +58,6 @@
         "tool_type":{
           "type": "string",
           "enum": ["VISUALIZATION"]
-        },
-        "container_input_path": {
-          "type": "string"
         },
         "extra_directories": {
           "type": "array",

--- a/refinery/tool_manager/tasks.py
+++ b/refinery/tool_manager/tasks.py
@@ -10,3 +10,10 @@ def django_docker_cleanup():
     DockerClientWrapper().purge_inactive(
         settings.DJANGO_DOCKER_ENGINE_SECONDS_INACTIVE
     )
+
+
+@task()
+def start_container(visualization_tool):
+    visualization_tool.django_docker_client.run(
+        visualization_tool.create_container_spec()
+    )

--- a/refinery/tool_manager/tasks.py
+++ b/refinery/tool_manager/tasks.py
@@ -7,5 +7,6 @@ from django_docker_engine.docker_utils import DockerClientWrapper
 @task()
 def django_docker_cleanup():
     # TODO: Specify manager, if not default
-    client = DockerClientWrapper(settings.DJANGO_DOCKER_ENGINE_DATA_DIR)
-    client.purge_inactive(settings.DJANGO_DOCKER_ENGINE_SECONDS_INACTIVE)
+    DockerClientWrapper().purge_inactive(
+        settings.DJANGO_DOCKER_ENGINE_SECONDS_INACTIVE
+    )

--- a/refinery/tool_manager/test_data/visualizations/LIST_visualization_bad_extra_directories_structure.json
+++ b/refinery/tool_manager/test_data/visualizations/LIST_visualization_bad_extra_directories_structure.json
@@ -2,7 +2,6 @@
   "name": "Test LIST Visualization bad extra_directories",
   "tool_type": "VISUALIZATION",
   "annotation": {
-    "container_input_path": "/var/www/html/input.json",
     "extra_directories": {"/test": "dir"},
     "image_name": "nginx:1.10.3-alpine",
     "description": "This visualization does really cool things",

--- a/refinery/tool_manager/test_data/visualizations/LIST_visualization_good_extra_directories.json
+++ b/refinery/tool_manager/test_data/visualizations/LIST_visualization_good_extra_directories.json
@@ -2,7 +2,6 @@
   "name": "Test LIST Visualization bad extra_directories",
   "tool_type": "VISUALIZATION",
   "annotation": {
-    "container_input_path": "/var/www/html/input.json",
     "extra_directories": [],
     "image_name": "nginx:1.10.3-alpine",
     "description": "This visualization does really cool things",

--- a/refinery/tool_manager/test_data/visualizations/LIST_visualization_missing_extra_directories.json
+++ b/refinery/tool_manager/test_data/visualizations/LIST_visualization_missing_extra_directories.json
@@ -2,7 +2,6 @@
   "name": "Test LIST Visualization bad extra_directories",
   "tool_type": "VISUALIZATION",
   "annotation": {
-    "container_input_path": "/var/www/html/input.json",
     "image_name": "nginx:1.10.3-alpine",
     "description": "This visualization does really cool things",
     "parameters": [],

--- a/refinery/tool_manager/test_data/visualizations/bad_filetype.json
+++ b/refinery/tool_manager/test_data/visualizations/bad_filetype.json
@@ -2,7 +2,6 @@
   "name": "IGV with a bad filetype specified",
   "tool_type": "VISUALIZATION",
   "annotation": {
-    "container_input_path": "/var/www/data/input.json",
     "extra_directories": ["/refinery-data"],
     "image_name": "gehlenborglab/docker_igv_js:v0.0.3",
     "description": "This visualization does really cool things... with IGV",

--- a/refinery/tool_manager/test_data/visualizations/hello_world.json
+++ b/refinery/tool_manager/test_data/visualizations/hello_world.json
@@ -2,7 +2,6 @@
   "name": "Test LIST Visualization Hello World",
   "tool_type": "VISUALIZATION",
   "annotation": {
-    "container_input_path": "/var/www/html/input.json",
     "extra_directories": ["/refinery-data"],
     "image_name": "nginx:1.10.3-alpine",
     "description": "This visualization does really cool things",

--- a/refinery/tool_manager/test_data/visualizations/higlass.json
+++ b/refinery/tool_manager/test_data/visualizations/higlass.json
@@ -2,7 +2,6 @@
   "name": "Test LIST Visualization HiGlass",
   "tool_type": "VISUALIZATION",
   "annotation": {
-    "container_input_path": "/data/input.json",
     "extra_directories": ["/refinery-data"],
     "image_name": "scottx611x/refinery-higlass-docker:v0.1.0",
     "description": "This visualization does really cool things... with Higlass",

--- a/refinery/tool_manager/test_data/visualizations/igv.json
+++ b/refinery/tool_manager/test_data/visualizations/igv.json
@@ -2,7 +2,6 @@
   "name": "Test LIST Visualization IGV",
   "tool_type": "VISUALIZATION",
   "annotation": {
-    "container_input_path": "/var/www/data/input.json",
     "extra_directories": ["/refinery-data"],
     "image_name": "gehlenborglab/docker_igv_js:v0.0.3",
     "description": "This visualization does really cool things... with IGV",

--- a/refinery/tool_manager/test_data/visualizations/no_docker_image_version.json
+++ b/refinery/tool_manager/test_data/visualizations/no_docker_image_version.json
@@ -2,7 +2,6 @@
   "name": "IGV with no docker image version specified",
   "tool_type": "VISUALIZATION",
   "annotation": {
-    "container_input_path": "/var/www/data/input.json",
     "extra_directories": ["/refinery-data"],
     "image_name": "gehlenborglab/docker_igv_js",
     "description": "This visualization does really cool things... with IGV",

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -244,7 +244,9 @@ class ToolManagerTestBase(ToolManagerMocks):
             }
         )
         self.tool_relaunch_view = ToolsViewSet.as_view({"get": "relaunch"})
-
+        self.tool_container_input_data_view = ToolsViewSet.as_view(
+            {"get": "container_input_data"}
+        )
         self.tools_url_root = '/api/v2/tools/'
         self.tool_defs_url_root = '/api/v2/tool_definitions/'
 

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -1678,8 +1678,8 @@ class VisualizationToolTests(ToolManagerTestBase):
         )
         self.assertTrue(self.search_solr_mock.called)
 
-    def test__create_container_input_dict(self):
-        tool_input_dict = self.tool._create_container_input_dict()
+    def test_get_container_input_dict(self):
+        tool_input_dict = self.tool.get_container_input_dict()
         file_relationships = self.tool.get_file_relationships_urls()
 
         self.assertEqual(

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -2866,9 +2866,7 @@ class ToolAPITests(APITestCase, ToolManagerTestBase):
         get_request = self.factory.get(relaunch_url)
         force_authenticate(get_request, self.user)
         get_response = self.tool_relaunch_view(get_request, uuid=tool_uuid)
-        self.assertEqual(get_response.status_code, 400)
-        self.assertIn("Couldn't retrieve VisualizationTool",
-                      get_response.content)
+        self.assertEqual(get_response.status_code, 404)
 
     def test_relaunch_failure_insufficient_user_perms(self):
         self.create_tool(ToolDefinition.VISUALIZATION)
@@ -2906,9 +2904,7 @@ class ToolAPITests(APITestCase, ToolManagerTestBase):
             get_request,
             uuid=self.tool.uuid
         )
-        self.assertEqual(get_response.status_code, 400)
-        self.assertIn("Couldn't retrieve VisualizationTool",
-                      get_response.content)
+        self.assertEqual(get_response.status_code, 404)
 
     def test_api_response_has_proper_fields_present(self):
         self.create_tool(ToolDefinition.VISUALIZATION)
@@ -3038,7 +3034,7 @@ class ToolAPITests(APITestCase, ToolManagerTestBase):
             get_request,
             uuid=str(uuid.uuid4())  # uuid doesn't correspond to any Tool
         )
-        self.assertEqual(get_response.status_code, 400)
+        self.assertEqual(get_response.status_code, 404)
 
 
 class WorkflowToolLaunchTests(ToolManagerTestBase):

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -13,8 +13,9 @@ from django.http import HttpResponseBadRequest
 from django.test import TestCase
 
 import bioblend
-from bioblend.galaxy.dataset_collections import (CollectionElement,
-                                                 HistoryDatasetElement)
+from bioblend.galaxy.dataset_collections import (
+    CollectionElement, HistoryDatasetElement
+)
 from bioblend.galaxy.histories import HistoryClient
 from bioblend.galaxy.jobs import JobsClient
 from bioblend.galaxy.libraries import LibraryClient
@@ -25,54 +26,50 @@ from django_docker_engine.docker_utils import DockerClientWrapper
 from docker.errors import NotFound
 from guardian.shortcuts import assign_perm, remove_perm
 import mock
-from rest_framework.test import (APIRequestFactory, APITestCase,
-                                 force_authenticate)
-from test_data.galaxy_mocks import (galaxy_dataset_provenance_0,
-                                    galaxy_dataset_provenance_1,
-                                    galaxy_datasets_list,
-                                    galaxy_datasets_list_same_output_names,
-                                    galaxy_history_contents,
-                                    galaxy_history_contents_same_names,
-                                    galaxy_job_a, galaxy_job_b,
-                                    galaxy_tool_data, galaxy_workflow_dict,
-                                    galaxy_workflow_dict_collection,
-                                    galaxy_workflow_invocation,
-                                    galaxy_workflow_invocation_data,
-                                    history_dataset_dict, history_dict,
-                                    library_dataset_dict, library_dict)
+from rest_framework.test import (
+    APIRequestFactory, APITestCase, force_authenticate
+)
+from test_data.galaxy_mocks import (
+    galaxy_dataset_provenance_0, galaxy_dataset_provenance_1,
+    galaxy_datasets_list, galaxy_datasets_list_same_output_names,
+    galaxy_history_contents, galaxy_history_contents_same_names, galaxy_job_a,
+    galaxy_job_b, galaxy_tool_data, galaxy_workflow_dict,
+    galaxy_workflow_dict_collection, galaxy_workflow_invocation,
+    galaxy_workflow_invocation_data, history_dataset_dict, history_dict,
+    library_dataset_dict, library_dict
+)
 
 from analysis_manager.models import AnalysisStatus
-from analysis_manager.tasks import (_galaxy_file_import,
-                                    _get_galaxy_download_task_ids,
-                                    _get_workflow_tool,
-                                    _invoke_galaxy_workflow,
-                                    _refinery_file_import,
-                                    _run_galaxy_file_import,
-                                    _run_galaxy_workflow, run_analysis)
-from core.models import (INPUT_CONNECTION, OUTPUT_CONNECTION, Analysis,
-                         AnalysisNodeConnection, AnalysisResult, ExtendedGroup,
-                         Project, Workflow, WorkflowEngine)
+from analysis_manager.tasks import (
+    _galaxy_file_import, _get_galaxy_download_task_ids, _get_workflow_tool,
+    _invoke_galaxy_workflow, _refinery_file_import, _run_galaxy_file_import,
+    _run_galaxy_workflow, run_analysis
+)
+from core.models import (
+    INPUT_CONNECTION, OUTPUT_CONNECTION, Analysis, AnalysisNodeConnection,
+    AnalysisResult, ExtendedGroup, Project, Workflow, WorkflowEngine
+)
 from data_set_manager.models import Assay, Attribute, Node
 from data_set_manager.utils import _create_solr_params_from_node_uuids
-from factory_boy.django_model_factories import (AnnotatedNodeFactory,
-                                                AttributeFactory,
-                                                GalaxyInstanceFactory,
-                                                NodeFactory, ParameterFactory,
-                                                ToolFactory)
+from factory_boy.django_model_factories import (
+    AnnotatedNodeFactory, AttributeFactory, GalaxyInstanceFactory, NodeFactory,
+    ParameterFactory, ToolFactory
+)
 from factory_boy.utils import create_dataset_with_necessary_models
 from file_store.models import FileStoreItem, FileType
 from tool_manager.management.commands.load_tools import \
     Command as LoadToolsCommand
 from tool_manager.tasks import django_docker_cleanup
 
-from .models import (FileRelationship, GalaxyParameter, InputFile, Parameter,
-                     Tool, ToolDefinition, VisualizationTool,
-                     VisualizationToolError, WorkflowTool)
-from .utils import (FileTypeValidationError, create_tool,
-                    create_tool_definition, get_workflows,
-                    user_has_access_to_tool, validate_tool_annotation,
-                    validate_tool_launch_configuration,
-                    validate_workflow_step_annotation)
+from .models import (
+    FileRelationship, GalaxyParameter, InputFile, Parameter, Tool,
+    ToolDefinition, VisualizationTool, VisualizationToolError, WorkflowTool
+)
+from .utils import (
+    FileTypeValidationError, create_tool, create_tool_definition,
+    get_workflows, user_has_access_to_tool, validate_tool_annotation,
+    validate_tool_launch_configuration, validate_workflow_step_annotation
+)
 from .views import ToolDefinitionsViewSet, ToolsViewSet
 
 logger = logging.getLogger(__name__)
@@ -3016,6 +3013,28 @@ class ToolAPITests(APITestCase, ToolManagerTestBase):
 
     def test_vis_tool_url_user_without_permission(self):
         self._test_launch_vis_container(user_has_permission=False)
+
+    def test_get_container_input_data_detail_route(self):
+        self.create_tool(ToolDefinition.VISUALIZATION)
+        get_request = self.factory.get(self.tool.container_input_json_url)
+        with mock.patch("tool_manager.models.get_solr_response_json"):
+            get_response = self.tool_container_input_data_view(
+                get_request,
+                uuid=self.tool.uuid
+            )
+            self.assertEqual(
+                json.loads(get_response.content),
+                self.tool.get_container_input_dict()
+            )
+
+    def test_get_container_input_data_detail_route_bad_uuid(self):
+        self.create_tool(ToolDefinition.VISUALIZATION)
+        get_request = self.factory.get(self.tool.container_input_json_url)
+        get_response = self.tool_container_input_data_view(
+            get_request,
+            uuid=str(uuid.uuid4())  # uuid doesn't correspond to any Tool
+        )
+        self.assertEqual(get_response.status_code, 400)
 
 
 class WorkflowToolLaunchTests(ToolManagerTestBase):

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -361,7 +361,7 @@ class ToolManagerTestBase(ToolManagerMocks):
 
         # Mock the spinning up of containers
         run_container_mock = mock.patch(
-            "django_docker_engine.docker_utils.DockerClientWrapper.run"
+            "django_docker_engine.docker_utils.DockerClientRunWrapper.run"
         )
 
         if tool_type == ToolDefinition.VISUALIZATION:
@@ -3605,9 +3605,7 @@ class VisualizationToolLaunchTests(ToolManagerTestBase):
         settings.DJANGO_DOCKER_ENGINE_SECONDS_INACTIVE = wait_time
 
         def assertions(tool):
-            client = DockerClientWrapper(
-                settings.DJANGO_DOCKER_ENGINE_DATA_DIR
-            )
+            client = DockerClientWrapper()
             client.lookup_container_url(tool.container_name)
 
             self.assertTrue(tool.is_running())

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.management import CommandError, call_command
 from django.http import HttpResponseBadRequest
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 import bioblend
 from bioblend.galaxy.dataset_collections import (
@@ -306,6 +306,7 @@ class ToolManagerTestBase(ToolManagerMocks):
             }
         )
 
+    @override_settings(CELERY_ALWAYS_EAGER=True)
     def create_tool(self,
                     tool_type,
                     create_unique_name=False,
@@ -2817,6 +2818,7 @@ class ToolAPITests(APITestCase, ToolManagerTestBase):
                 self.tool._get_owner_info_as_dict()
             )
 
+    @override_settings(CELERY_ALWAYS_EAGER=True)
     def test_vis_tool_can_be_relaunched(self):
         self.create_tool(ToolDefinition.VISUALIZATION,
                          start_vis_container=True)
@@ -3538,6 +3540,7 @@ class VisualizationToolLaunchTests(ToolManagerTestBase):
         self.assertIn("DataSet matching query does not exist.",
                       self.post_response.content)
 
+    @override_settings(CELERY_ALWAYS_EAGER=True)
     def _start_visualization(
             self, json_name, file_relationships,
             assertions=None, count=1

--- a/refinery/tool_manager/utils.py
+++ b/refinery/tool_manager/utils.py
@@ -131,7 +131,6 @@ def create_tool_definition(annotation_data):
     elif tool_type == ToolDefinition.VISUALIZATION:
         tool_definition = ToolDefinitionFactory(
             image_name=annotation["image_name"],
-            container_input_path=annotation["container_input_path"],
             **common_tool_definition_params
         )
 

--- a/refinery/tool_manager/utils.py
+++ b/refinery/tool_manager/utils.py
@@ -13,14 +13,11 @@ from jsonschema import RefResolver, ValidationError, validate
 import networkx
 
 from core.models import DataSet, Workflow, WorkflowEngine
-from factory_boy.django_model_factories import (FileRelationshipFactory,
-                                                GalaxyParameterFactory,
-                                                InputFileFactory,
-                                                ParameterFactory,
-                                                ToolDefinitionFactory,
-                                                VisualizationToolFactory,
-                                                WorkflowFactory,
-                                                WorkflowToolFactory)
+from factory_boy.django_model_factories import (
+    FileRelationshipFactory, GalaxyParameterFactory, InputFileFactory,
+    ParameterFactory, ToolDefinitionFactory, VisualizationToolFactory,
+    WorkflowFactory, WorkflowToolFactory
+)
 from file_store.models import FileType
 
 from .models import Tool, ToolDefinition, WorkflowTool
@@ -152,9 +149,7 @@ def create_tool_definition(annotation_data):
             logger.debug(
                 "Pulling Docker image: %s", tool_definition.image_name
             )
-            DockerClientWrapper(
-                settings.DJANGO_DOCKER_ENGINE_DATA_DIR
-            ).pull(image_name, version=version)
+            DockerClientWrapper().pull(image_name, version=version)
 
     tool_definition.annotation = json.dumps(annotation)
     tool_definition.save()

--- a/refinery/tool_manager/views.py
+++ b/refinery/tool_manager/views.py
@@ -148,14 +148,10 @@ class ToolsViewSet(ToolManagerViewSetBase):
         if not tool_uuid:
             return HttpResponseBadRequest("Relaunching a Tool requires a Tool "
                                           "UUID")
-        try:
-            tool = VisualizationTool.objects.get(uuid=tool_uuid)
-        except (VisualizationTool.DoesNotExist,
-                VisualizationTool.MultipleObjectsReturned) as e:
-            return HttpResponseBadRequest(
-                "Couldn't retrieve VisualizationTool with UUID: {}, {}"
-                .format(tool_uuid, e)
-            )
+        tool = get_object_or_404(
+            VisualizationTool,
+            uuid=tool_uuid
+        )
 
         if not user_has_access_to_tool(request.user, tool):
             return HttpResponseForbidden(
@@ -176,14 +172,10 @@ class ToolsViewSet(ToolManagerViewSetBase):
     @detail_route(methods=['get'])
     def container_input_data(self, request, *args, **kwargs):
         tool_uuid = kwargs.get("uuid")
-        try:
-            tool = VisualizationTool.objects.get(uuid=tool_uuid)
-        except (VisualizationTool.DoesNotExist,
-                VisualizationTool.MultipleObjectsReturned) as e:
-            return HttpResponseBadRequest(
-                "Couldn't retrieve VisualizationTool with UUID: {}, {}"
-                .format(tool_uuid, e)
-            )
+        tool = get_object_or_404(
+            VisualizationTool,
+            uuid=tool_uuid
+        )
         return JsonResponse(tool.get_container_input_dict())
 
 

--- a/refinery/tool_manager/views.py
+++ b/refinery/tool_manager/views.py
@@ -148,10 +148,7 @@ class ToolsViewSet(ToolManagerViewSetBase):
         if not tool_uuid:
             return HttpResponseBadRequest("Relaunching a Tool requires a Tool "
                                           "UUID")
-        tool = get_object_or_404(
-            VisualizationTool,
-            uuid=tool_uuid
-        )
+        tool = get_object_or_404(VisualizationTool, uuid=tool_uuid)
 
         if not user_has_access_to_tool(request.user, tool):
             return HttpResponseForbidden(

--- a/refinery/tool_manager/views.py
+++ b/refinery/tool_manager/views.py
@@ -182,7 +182,6 @@ class AutoRelaunchProxy(Proxy, object):
     """
     def __init__(self):
         super(AutoRelaunchProxy, self).__init__(
-            None,  # TODO: django_docker_engine code should remove need for arg
             please_wait_title='Please wait...',
             please_wait_body_html='''
                 <style>

--- a/refinery/tool_manager/views.py
+++ b/refinery/tool_manager/views.py
@@ -196,7 +196,7 @@ class AutoRelaunchProxy(Proxy, object):
     """
     def __init__(self):
         super(AutoRelaunchProxy, self).__init__(
-            settings.DJANGO_DOCKER_ENGINE_DATA_DIR,
+            None,  # TODO: django_docker_engine code should remove need for arg
             please_wait_title='Please wait...',
             please_wait_body_html='''
                 <style>

--- a/refinery/tool_manager/views.py
+++ b/refinery/tool_manager/views.py
@@ -169,10 +169,7 @@ class ToolsViewSet(ToolManagerViewSetBase):
     @detail_route(methods=['get'])
     def container_input_data(self, request, *args, **kwargs):
         tool_uuid = kwargs.get("uuid")
-        tool = get_object_or_404(
-            VisualizationTool,
-            uuid=tool_uuid
-        )
+        tool = get_object_or_404(VisualizationTool, uuid=tool_uuid)
         return JsonResponse(tool.get_container_input_dict())
 
 

--- a/refinery/ui/source/js/tool-launch/services/file-relationship-service.spec.js
+++ b/refinery/ui/source/js/tool-launch/services/file-relationship-service.spec.js
@@ -89,7 +89,6 @@
         description: 'Test LIST:LIST:PAIR description',
         tool_type: 'WORKFLOW',
         docker_image_name: '',
-        container_input_path: null,
         galaxy_workflow_id: null,
         workflow_engine: null
       };

--- a/refinery/ui/source/js/tool-launch/services/tool-params-service.spec.js
+++ b/refinery/ui/source/js/tool-launch/services/tool-params-service.spec.js
@@ -47,7 +47,6 @@
         description: 'Runs FASTQC quality control on a set of FASTQ files.',
         tool_type: 'WORKFLOW',
         image_name: '',
-        container_input_path: '',
         galaxy_workflow_id: 'c0279aab05812500',
         workflow_engine: 1
       };

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ django-auth-ldap==1.2.6
 django-celery==3.1.17
 django-chunked-upload==1.1.0
 django-debug-toolbar==1.4
-django-docker-engine==0.0.36
+django-docker-engine==0.0.41
 django-extensions==1.6.7
 django-flatblocks==0.9.2
 django-guardian==1.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ django-auth-ldap==1.2.6
 django-celery==3.1.17
 django-chunked-upload==1.1.0
 django-debug-toolbar==1.4
-django-docker-engine==0.0.41
+django-docker-engine==0.0.42
 django-extensions==1.6.7
 django-flatblocks==0.9.2
 django-guardian==1.4.1


### PR DESCRIPTION
Introduce detail route to `/api/v2/tools/` that returns a launched Tools input data as JSON. This approach (sending a url pointing to a Tool's input data) will be used moving forward for its ease of use w/ a 2nd host running docker. Before, we noticed that there were underlying ssh commands in `django_docker_engine` to create directories on said host to place a launched `VisualizationTool's` input data, and ssh key management between the Refinery EC2 and Docker EC2 was troublesome to automate. This will also prove reusable if we ever need to move to something like ECS or Fargate.

TODO:
- [x] Update existing VisualizationTools to read input data from a url
  - [refinery-developer-vis-tool](https://github.com/refinery-platform/refinery-developer-vis-tool) has been [updated to do this](https://github.com/refinery-platform/refinery-developer-vis-tool/blob/master/context/on_startup.py#L6-L12) so far

**Note:** This shouldn't be merged until we have the 2nd host for docker up and running w/ terraform. See #2597 EDIT: We have the 2nd host working more or less and are just making some final adjustments