### PR TITLE
Scottx611x/collect stats

### DIFF
--- a/refinery/config/settings/base.py
+++ b/refinery/config/settings/base.py
@@ -323,7 +323,6 @@ EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 CELERYD_MAX_TASKS_PER_CHILD = get_setting("CELERYD_MAX_TASKS_PER_CHILD")
 CELERY_ROUTES = {"file_store.tasks.import_file": {"queue": "file_import"}}
 CELERY_ACCEPT_CONTENT = ['pickle']
-# TODO: Does this belong here or in config.json.erb?
 CELERYBEAT_SCHEDULE = {
     'collect_site_statistics': {
         'task': 'core.tasks.collect_site_statistics',

--- a/refinery/config/settings/base.py
+++ b/refinery/config/settings/base.py
@@ -325,6 +325,13 @@ CELERY_ROUTES = {"file_store.tasks.import_file": {"queue": "file_import"}}
 CELERY_ACCEPT_CONTENT = ['pickle']
 # TODO: Does this belong here or in config.json.erb?
 CELERYBEAT_SCHEDULE = {
+    'collect_site_statistics': {
+        'task': 'core.tasks.collect_site_statistics',
+        'schedule': timedelta(weeks=1),
+        'options': {
+            'expires': 30,  # seconds
+        }
+    },
     'django_docker_cleanup': {
         'task': 'tool_manager.tasks.django_docker_cleanup',
         'schedule': timedelta(seconds=30),

--- a/refinery/config/settings/base.py
+++ b/refinery/config/settings/base.py
@@ -327,7 +327,7 @@ CELERY_ACCEPT_CONTENT = ['pickle']
 CELERYBEAT_SCHEDULE = {
     'collect_site_statistics': {
         'task': 'core.tasks.collect_site_statistics',
-        'schedule': timedelta(weeks=1),
+        'schedule': timedelta(days=1),
         'options': {
             'expires': 30,  # seconds
         }

--- a/refinery/core/admin.py
+++ b/refinery/core/admin.py
@@ -9,10 +9,14 @@ from django.contrib import admin
 from django_extensions.admin import ForeignKeyAutocompleteAdmin
 from guardian.admin import GuardedModelAdmin
 
-from .models import (Analysis, AnalysisNodeConnection, AnalysisResult, DataSet,
-                     Download, ExtendedGroup, InvestigationLink, Invitation,
-                     Ontology, Project, SiteProfile, Tutorials, UserProfile,
-                     Workflow, WorkflowEngine)
+from tool_manager.utils import AdminFieldPopulator
+
+from .models import (
+    Analysis, AnalysisNodeConnection, AnalysisResult, DataSet, Download,
+    ExtendedGroup, InvestigationLink, Invitation, Ontology, Project,
+    SiteProfile, SiteStatistics, Tutorials, UserProfile, Workflow,
+    WorkflowEngine
+)
 from .utils import admin_ui_deletion
 
 
@@ -147,6 +151,10 @@ class SiteProfileAdmin(GuardedModelAdmin):
     list_display = ['__unicode__', 'site']
 
 
+class SiteStatisticsAdmin(AdminFieldPopulator):
+    pass
+
+
 admin.site.register(ExtendedGroup, ExtendedGroupAdmin)
 admin.site.register(Project, ProjectAdmin)
 admin.site.register(DataSet, DataSetAdmin)
@@ -162,3 +170,4 @@ admin.site.register(UserProfile, UserProfileAdmin)
 admin.site.register(Tutorials, TutorialsAdmin)
 admin.site.register(Ontology, OntologyAdmin)
 admin.site.register(SiteProfile, SiteProfileAdmin)
+admin.site.register(SiteStatistics, SiteStatisticsAdmin)

--- a/refinery/core/migrations/0019_sitestatistics.py
+++ b/refinery/core/migrations/0019_sitestatistics.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0018_auto_20180306_1333'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='SiteStatistics',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('run_date', models.DateTimeField()),
+                ('datasets_uploaded', models.IntegerField(default=0)),
+                ('datasets_shared', models.IntegerField(default=0)),
+                ('users_created', models.IntegerField(default=0)),
+                ('groups_created', models.IntegerField(default=0)),
+                ('unique_user_logins', models.IntegerField(default=0)),
+                ('total_user_logins', models.IntegerField(default=0)),
+                ('total_workflow_launches', models.IntegerField(default=0)),
+                ('total_visualization_launches', models.IntegerField(default=0)),
+            ],
+            options={
+                'verbose_name_plural': 'Site Statistics',
+            },
+        ),
+    ]

--- a/refinery/core/migrations/0020_create_initial_site_statistics.py
+++ b/refinery/core/migrations/0020_create_initial_site_statistics.py
@@ -22,7 +22,7 @@ def create_initial_site_statistics(apps, schema_editor):
             [dataset for dataset in DataSet.objects.all() if dataset.shared]
         ),
         users_created=User.objects.count(),
-        groups_created=ExtendedGroup.objects.count(),
+        groups_created=ExtendedGroup.objects.exclude(manager_group=None).count(),
         unique_user_logins=User.objects.filter(
             last_login__lte=timezone.now()
         ).count(),

--- a/refinery/core/migrations/0020_create_initial_site_statistics.py
+++ b/refinery/core/migrations/0020_create_initial_site_statistics.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.utils import timezone
+
+
+from core.models import DataSet, UserProfile
+
+
+def create_initial_site_statistics(apps, schema_editor):
+    SiteStatistics = apps.get_model("core", "SiteStatistics")
+    User = apps.get_model("auth", "User")
+    ExtendedGroup = apps.get_model("core", "ExtendedGroup")
+    WorkflowTool = apps.get_model("tool_manager", "WorkflowTool")
+    VisualizationTool = apps.get_model("tool_manager", "VisualizationTool")
+
+    SiteStatistics.objects.create(
+        run_date=timezone.now(),
+        datasets_uploaded=DataSet.objects.count(),
+        datasets_shared=len(
+            [dataset for dataset in DataSet.objects.all() if dataset.shared]
+        ),
+        users_created=User.objects.count(),
+        groups_created=ExtendedGroup.objects.count(),
+        unique_user_logins=User.objects.filter(
+            last_login__lte=timezone.now()
+        ).count(),
+        total_user_logins=sum([u.login_count for u in
+                              UserProfile.objects.all()]),
+        total_workflow_launches=WorkflowTool.objects.count(),
+        total_visualization_launches=VisualizationTool.objects.count()
+    )
+
+
+def noop(apps, schema_editor):
+    return None  # Newer Django's >= 1.8 have a migrations.RunPython.noop to
+    # be able to move backwards in migrations yet have a data migration's
+    # results remain
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('core', '0019_sitestatistics'),
+        ('tool_manager', '0025_auto_20180226_2153')
+    ]
+
+    operations = [
+        migrations.RunPython(create_initial_site_statistics, noop),
+    ]

--- a/refinery/core/migrations/0021_auto_20180327_1923.py
+++ b/refinery/core/migrations/0021_auto_20180327_1923.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0020_create_initial_site_statistics'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='sitestatistics',
+            options={'verbose_name_plural': 'site statistics'},
+        ),
+        migrations.AlterField(
+            model_name='sitestatistics',
+            name='datasets_shared',
+            field=models.IntegerField(),
+        ),
+        migrations.AlterField(
+            model_name='sitestatistics',
+            name='datasets_uploaded',
+            field=models.IntegerField(),
+        ),
+        migrations.AlterField(
+            model_name='sitestatistics',
+            name='groups_created',
+            field=models.IntegerField(),
+        ),
+        migrations.AlterField(
+            model_name='sitestatistics',
+            name='total_user_logins',
+            field=models.IntegerField(),
+        ),
+        migrations.AlterField(
+            model_name='sitestatistics',
+            name='total_visualization_launches',
+            field=models.IntegerField(),
+        ),
+        migrations.AlterField(
+            model_name='sitestatistics',
+            name='total_workflow_launches',
+            field=models.IntegerField(),
+        ),
+        migrations.AlterField(
+            model_name='sitestatistics',
+            name='unique_user_logins',
+            field=models.IntegerField(),
+        ),
+        migrations.AlterField(
+            model_name='sitestatistics',
+            name='users_created',
+            field=models.IntegerField(),
+        ),
+    ]

--- a/refinery/core/migrations/0022_auto_20180409_1127.py
+++ b/refinery/core/migrations/0022_auto_20180409_1127.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0021_auto_20180327_1923'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='sitestatistics',
+            name='datasets_shared',
+            field=models.IntegerField(default=0),
+        ),
+        migrations.AlterField(
+            model_name='sitestatistics',
+            name='datasets_uploaded',
+            field=models.IntegerField(default=0),
+        ),
+        migrations.AlterField(
+            model_name='sitestatistics',
+            name='groups_created',
+            field=models.IntegerField(default=0),
+        ),
+        migrations.AlterField(
+            model_name='sitestatistics',
+            name='run_date',
+            field=models.DateTimeField(auto_now=True),
+        ),
+        migrations.AlterField(
+            model_name='sitestatistics',
+            name='total_user_logins',
+            field=models.IntegerField(default=0),
+        ),
+        migrations.AlterField(
+            model_name='sitestatistics',
+            name='total_visualization_launches',
+            field=models.IntegerField(default=0),
+        ),
+        migrations.AlterField(
+            model_name='sitestatistics',
+            name='total_workflow_launches',
+            field=models.IntegerField(default=0),
+        ),
+        migrations.AlterField(
+            model_name='sitestatistics',
+            name='unique_user_logins',
+            field=models.IntegerField(default=0),
+        ),
+        migrations.AlterField(
+            model_name='sitestatistics',
+            name='users_created',
+            field=models.IntegerField(default=0),
+        ),
+    ]

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -784,6 +784,10 @@ class DataSet(SharableResource):
     def is_isatab_based(self):
         return bool(self.get_investigation().isa_archive)
 
+    @property
+    def shared(self):  # is_shared breaks a tastypie interal
+        return len(self.get_groups()) > 0
+
 
 @receiver(pre_delete, sender=DataSet)
 def _dataset_delete(sender, instance, *args, **kwargs):

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -2243,10 +2243,10 @@ class SiteStatistics(models.Model):
     def collect(self):
         self.datasets_uploaded = self._get_datasets_uploaded()
         self.datasets_shared = self._get_datasets_shared()
-        self.groups_created = self._get_number_of_groups_created()
+        self.groups_created = self._get_groups_created()
         self.users_created = self._get_users_created()
         self.unique_user_logins = self._get_unique_user_logins()
-        self.total_user_logins = self._get_number_of_total_user_logins()
+        self.total_user_logins = self._get_total_user_logins()
         self.total_workflow_launches = self._get_total_workflow_launches()
         self.total_visualization_launches = \
             self._get_total_visualization_launches()
@@ -2293,11 +2293,14 @@ class SiteStatistics(models.Model):
             date_joined__gte=self._get_previous_instance().run_date
         ).count()
 
-    def _get_number_of_groups_created(self):
+    def _get_groups_created(self):
         return ExtendedGroup.objects.exclude(manager_group=None).count() - sum(
-            [s.groups_created for s in SiteStatistics.objects.all()]
+            s.groups_created for s in SiteStatistics.objects.exclude(
+                id=self.id
+            )
         )
 
-    def _get_number_of_total_user_logins(self):
-        return sum([u.login_count for u in UserProfile.objects.all()]) - \
-               sum([s.total_user_logins for s in SiteStatistics.objects.all()])
+    def _get_total_user_logins(self):
+        return sum(u.login_count for u in UserProfile.objects.all()) - \
+               sum(s.total_user_logins for s in
+                   SiteStatistics.objects.exclude(id=self.id))

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -38,30 +38,33 @@ from bioblend import galaxy
 from django_auth_ldap.backend import LDAPBackend
 from django_extensions.db.fields import UUIDField
 from guardian.models import UserObjectPermission
-from guardian.shortcuts import (assign_perm, get_groups_with_perms,
-                                get_objects_for_group, get_users_with_perms,
-                                remove_perm)
+from guardian.shortcuts import (
+    assign_perm, get_groups_with_perms, get_objects_for_group,
+    get_users_with_perms, remove_perm
+)
 import pysolr
 from registration.models import RegistrationManager, RegistrationProfile
 from registration.signals import user_activated, user_registered
 
-from data_set_manager.models import (Assay, Investigation, Node,
-                                     NodeCollection, Study)
+from data_set_manager.models import (
+    Assay, Investigation, Node, NodeCollection, Study
+)
 from data_set_manager.search_indexes import NodeIndex
-from data_set_manager.utils import (add_annotated_nodes_selection,
-                                    index_annotated_nodes_selection)
+from data_set_manager.utils import (
+    add_annotated_nodes_selection, index_annotated_nodes_selection
+)
 from file_store.models import FileStoreItem, FileType
 from file_store.tasks import rename
 from galaxy_connector.models import Instance
 import tool_manager
 
-from .utils import (add_or_update_user_to_neo4j, add_read_access_in_neo4j,
-                    async_update_annotation_sets_neo4j, delete_data_set_index,
-                    delete_data_set_neo4j, delete_ontology_from_neo4j,
-                    delete_user_in_neo4j, email_admin,
-                    invalidate_cached_object, remove_read_access_in_neo4j,
-                    skip_if_test_run, sync_update_annotation_sets_neo4j,
-                    update_data_set_index)
+from .utils import (
+    add_or_update_user_to_neo4j, add_read_access_in_neo4j,
+    async_update_annotation_sets_neo4j, delete_data_set_index,
+    delete_data_set_neo4j, delete_ontology_from_neo4j, delete_user_in_neo4j,
+    email_admin, invalidate_cached_object, remove_read_access_in_neo4j,
+    skip_if_test_run, sync_update_annotation_sets_neo4j, update_data_set_index
+)
 
 logger = logging.getLogger(__name__)
 
@@ -2213,3 +2216,87 @@ class SiteProfile(models.Model):
 
     def __unicode__(self):
         return self.site.name
+
+
+class SiteStatistics(models.Model):
+    """
+    A model to encapsulate various information about a deployed Refinery
+    Instance's utilization.
+    """
+    datasets_shared = models.IntegerField()
+    datasets_uploaded = models.IntegerField()
+    groups_created = models.IntegerField()
+    run_date = models.DateTimeField()
+    total_user_logins = models.IntegerField()
+    total_visualization_launches = models.IntegerField()
+    total_workflow_launches = models.IntegerField()
+    users_created = models.IntegerField()
+    unique_user_logins = models.IntegerField()
+
+    class Meta:
+        verbose_name_plural = "site statistics"
+
+    def save(self, force_insert=False, force_update=False, using=None,
+             update_fields=None):
+        self.run_date = timezone.now()
+        self.datasets_uploaded = self._get_datasets_uploaded().count()
+        self.datasets_shared = len(self._get_datasets_shared())
+        self.groups_created = self._get_number_of_groups_created()
+        self.users_created = self._get_users_created().count()
+        self.unique_user_logins = self._get_unique_user_logins().count()
+        self.total_user_logins = self._get_number_of_total_user_logins()
+        self.total_workflow_launches = \
+            self._get_total_workflow_launches().count()
+        self.total_visualization_launches = \
+            self._get_total_visualization_launches().count()
+        super(SiteStatistics, self).save()
+
+    def _get_previous_instance(self):
+        previous_instance = SiteStatistics.objects.filter(
+            run_date__lt=self.run_date
+        ).order_by('-run_date').first()
+
+        # Return the previous instance by run_date, or the current instance
+        # if a prior one doesn't exist
+        return previous_instance or self
+
+    def _get_datasets_shared(self):
+        return [
+            dataset for dataset in DataSet.objects.filter(
+                modification_date__gte=self._get_previous_instance().run_date
+            ) if dataset.shared
+        ]
+
+    def _get_datasets_uploaded(self):
+        return DataSet.objects.filter(
+            creation_date__gte=self._get_previous_instance().run_date
+        )
+
+    def _get_total_visualization_launches(self):
+        return tool_manager.models.VisualizationTool.objects.filter(
+            creation_date__gte=self._get_previous_instance().run_date
+        )
+
+    def _get_total_workflow_launches(self):
+        return tool_manager.models.WorkflowTool.objects.filter(
+            creation_date__gte=self._get_previous_instance().run_date
+        )
+
+    def _get_unique_user_logins(self):
+        return User.objects.filter(
+            last_login__gte=self._get_previous_instance().run_date
+        )
+
+    def _get_users_created(self):
+        return User.objects.filter(
+            date_joined__gte=self._get_previous_instance().run_date
+        )
+
+    def _get_number_of_groups_created(self):
+        return ExtendedGroup.objects.count() - sum(
+            [s.groups_created for s in SiteStatistics.objects.all()]
+        )
+
+    def _get_number_of_total_user_logins(self):
+        return sum([u.login_count for u in UserProfile.objects.all()]) - \
+               sum([s.total_user_logins for s in SiteStatistics.objects.all()])

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -2297,7 +2297,7 @@ class SiteStatistics(models.Model):
         )
 
     def _get_number_of_groups_created(self):
-        return ExtendedGroup.objects.count() - sum(
+        return ExtendedGroup.objects.exclude(manager_group=None).count() - sum(
             [s.groups_created for s in SiteStatistics.objects.all()]
         )
 

--- a/refinery/core/tasks.py
+++ b/refinery/core/tasks.py
@@ -10,7 +10,7 @@ from data_set_manager.tasks import annotate_nodes
 from file_store.models import FileStoreItem
 from file_store.tasks import import_file
 
-from .models import DataSet, InvestigationLink
+from .models import DataSet, InvestigationLink, SiteStatistics
 
 logger = logging.getLogger(__name__)
 
@@ -220,3 +220,8 @@ def copy_dataset(dataset, owner, versions=None, copy_files=False):
     dataset_copy.save()
 
     return dataset_copy
+
+
+@task()
+def collect_site_statistics():
+    SiteStatistics.objects.create()

--- a/refinery/core/tasks.py
+++ b/refinery/core/tasks.py
@@ -224,4 +224,4 @@ def copy_dataset(dataset, owner, versions=None, copy_files=False):
 
 @task()
 def collect_site_statistics():
-    SiteStatistics.objects.create()
+    SiteStatistics.objects.create().collect()

--- a/refinery/core/tests.py
+++ b/refinery/core/tests.py
@@ -2327,7 +2327,7 @@ class InitialSiteStatisticsCreationTest(TestMigrations):
         self.assertEqual(initial_site_statistics.datasets_uploaded, 2)
         self.assertEqual(initial_site_statistics.datasets_shared, 1)
         self.assertEqual(initial_site_statistics.users_created, 3)
-        self.assertEqual(initial_site_statistics.groups_created, 2)
+        self.assertEqual(initial_site_statistics.groups_created, 1)
         self.assertEqual(initial_site_statistics.unique_user_logins, 1)
         self.assertEqual(initial_site_statistics.total_user_logins, 2)
         self.assertEqual(initial_site_statistics.total_workflow_launches, 0)
@@ -2400,9 +2400,7 @@ class SiteStatisticsTests(TestCase):
     def test_groups_created(self):
         self.assertEqual(self.site_statistics_a.groups_created, 0)
         self.assertEqual(self.site_statistics_b.groups_created, 0)
-
-        # Every Group creation gets a .Managers group as well
-        self.assertEqual(self.site_statistics_c.groups_created, 2)
+        self.assertEqual(self.site_statistics_c.groups_created, 1)
 
     def test_unique_user_logins(self):
         self.assertEqual(self.site_statistics_a.unique_user_logins, 1)

--- a/refinery/core/tests.py
+++ b/refinery/core/tests.py
@@ -2432,10 +2432,7 @@ class SiteStatisticsTests(TestCase):
 
     def test__get_previous_instance_returns_itself_if_only_instance(self):
         SiteStatistics.objects.all().delete()
-
         site_statistics = SiteStatistics.objects.create()
-        site_statistics.collect()
-        self.assertIsNotNone(site_statistics._get_previous_instance())
         self.assertEqual(site_statistics._get_previous_instance(),
                          site_statistics)
 

--- a/refinery/core/tests.py
+++ b/refinery/core/tests.py
@@ -2453,7 +2453,6 @@ class SiteStatisticsTests(TestCase):
 
     def test_collect_site_statistics_creates_new_instance(self):
         initial_site_statistics_count = SiteStatistics.objects.count()
-        with self.settings(CELERY_ALWAYS_EAGER=True):
-            collect_site_statistics()
+        collect_site_statistics()
         self.assertEqual(initial_site_statistics_count + 1,
                          SiteStatistics.objects.count())

--- a/refinery/core/tests.py
+++ b/refinery/core/tests.py
@@ -2346,9 +2346,11 @@ class SiteStatisticsTests(TestCase):
         self.dataset_b = create_dataset_with_necessary_models(user=user_a)
         self.dataset_b.share(public_group)
         self.site_statistics_a = SiteStatistics.objects.create()
+        self.site_statistics_a.collect()
 
         # Simulate a week where nothing happened
         self.site_statistics_b = SiteStatistics.objects.create()
+        self.site_statistics_b.collect()
 
         # Simulate another week of user activity
         user_b = User.objects.create_user("user_b", "", "user_b")
@@ -2366,6 +2368,7 @@ class SiteStatisticsTests(TestCase):
         create_tool_with_necessary_models("VISUALIZATION")  # creates a DataSet
         create_tool_with_necessary_models("WORKFLOW")  # creates a DataSet
         self.site_statistics_c = SiteStatistics.objects.create()
+        self.site_statistics_c.collect()
 
     def test__get_previous_instance(self):
         self.assertEqual(self.site_statistics_a._get_previous_instance().id, 1)
@@ -2431,6 +2434,7 @@ class SiteStatisticsTests(TestCase):
         SiteStatistics.objects.all().delete()
 
         site_statistics = SiteStatistics.objects.create()
+        site_statistics.collect()
         self.assertIsNotNone(site_statistics._get_previous_instance())
         self.assertEqual(site_statistics._get_previous_instance(),
                          site_statistics)

--- a/refinery/core/tests.py
+++ b/refinery/core/tests.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 import json
 import random
 import re
@@ -5,6 +6,7 @@ import string
 from urlparse import urljoin
 
 from django.apps import apps
+from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, Group, User
 from django.contrib.sites.models import Site
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -2433,3 +2435,15 @@ class SiteStatisticsTests(TestCase):
         self.assertIsNotNone(site_statistics._get_previous_instance())
         self.assertEqual(site_statistics._get_previous_instance(),
                          site_statistics)
+
+    def test_periodic_task_is_scheduled_for_weekly_runs(self):
+        self.assertEqual(
+            settings.CELERYBEAT_SCHEDULE["collect_site_statistics"],
+            {
+                'task': 'core.tasks.collect_site_statistics',
+                'schedule': timedelta(weeks=1),
+                'options': {
+                    'expires': 30,  # seconds
+                }
+            }
+        )

--- a/refinery/core/tests.py
+++ b/refinery/core/tests.py
@@ -2439,7 +2439,7 @@ class SiteStatisticsTests(TestCase):
         self.assertEqual(site_statistics._get_previous_instance(),
                          site_statistics)
 
-    def test_periodic_task_is_scheduled_for_weekly_runs(self):
+    def test_periodic_task_is_scheduled_for_daily_runs(self):
         self.assertEqual(
             settings.CELERYBEAT_SCHEDULE["collect_site_statistics"],
             {

--- a/refinery/core/tests.py
+++ b/refinery/core/tests.py
@@ -2440,7 +2440,7 @@ class SiteStatisticsTests(TestCase):
             settings.CELERYBEAT_SCHEDULE["collect_site_statistics"],
             {
                 'task': 'core.tasks.collect_site_statistics',
-                'schedule': timedelta(weeks=1),
+                'schedule': timedelta(days=1),
                 'options': {
                     'expires': 30,  # seconds
                 }

--- a/refinery/core/tests.py
+++ b/refinery/core/tests.py
@@ -27,6 +27,7 @@ from tastypie.exceptions import NotFound
 from tastypie.test import ResourceTestCase
 
 from analysis_manager.models import AnalysisStatus
+from core.tasks import collect_site_statistics
 from data_set_manager.models import (
     AnnotatedNode, Assay, Contact, Investigation, Node, NodeCollection, Study
 )
@@ -2447,3 +2448,10 @@ class SiteStatisticsTests(TestCase):
                 }
             }
         )
+
+    def test_collect_site_statistics_creates_new_instance(self):
+        initial_site_statistics_count = SiteStatistics.objects.count()
+        with self.settings(CELERY_ALWAYS_EAGER=True):
+            collect_site_statistics()
+        self.assertEqual(initial_site_statistics_count + 1,
+                         SiteStatistics.objects.count())

--- a/refinery/core/tests.py
+++ b/refinery/core/tests.py
@@ -2417,73 +2417,91 @@ class SiteStatisticsIntegrationTests(TestCase):
         self.client.login(username="user_c", password="user_c")
         self.dataset_c = create_dataset_with_necessary_models(user=user_b)
         self.dataset_d = create_dataset_with_necessary_models(user=user_b)
-        self.dataset_d.share(public_group)
+        self.dataset_d.share(test_group)
         self.dataset_e = create_dataset_with_necessary_models(user=user_c)
-        self.dataset_e.share(public_group)
-        ExtendedGroup.objects.create(name="Test Group")
+        self.dataset_e.share(test_group)
+        ExtendedGroup.objects.create(name="Test Group B")
         create_tool_with_necessary_models("VISUALIZATION")  # creates a DataSet
         create_tool_with_necessary_models("WORKFLOW")  # creates a DataSet
         self.site_statistics_c = SiteStatistics.objects.create()
         self.site_statistics_c.collect()
 
     def test__get_previous_instance(self):
-        self.assertEqual(self.site_statistics_a._get_previous_instance().id, 1)
-        self.assertEqual(self.site_statistics_b._get_previous_instance(),
-                         self.site_statistics_a)
-        self.assertEqual(self.site_statistics_c._get_previous_instance(),
-                         self.site_statistics_b)
+        self.assertEqual(
+            (self.site_statistics_a._get_previous_instance().id,
+             self.site_statistics_b._get_previous_instance().id,
+             self.site_statistics_c._get_previous_instance().id),
+            (SiteStatistics.objects.first().id,
+             self.site_statistics_a.id,
+             self.site_statistics_b.id)
+        )
 
     def test_datasets_uploaded(self):
-        self.assertEqual(self.site_statistics_a.datasets_uploaded, 2)
-        self.assertEqual(self.site_statistics_b.datasets_uploaded, 0)
-        self.assertEqual(self.site_statistics_c.datasets_uploaded, 5)
+        self.assertEqual(
+            (self.site_statistics_a.datasets_uploaded,
+             self.site_statistics_b.datasets_uploaded,
+             self.site_statistics_c.datasets_uploaded),
+            (2, 0, 5)
+        )
 
     def test_datasets_shared(self):
-        self.assertEqual(self.site_statistics_a.datasets_shared, 1)
-        self.assertEqual(self.site_statistics_b.datasets_shared, 0)
-        self.assertEqual(self.site_statistics_c.datasets_shared, 2)
+        self.assertEqual(
+            (self.site_statistics_a.datasets_shared,
+             self.site_statistics_b.datasets_shared,
+             self.site_statistics_c.datasets_shared),
+            (1, 0, 2)
+        )
 
     def test_users_created(self):
-        # + 2 instead of the expected 1 because the emission of
-        # the post_migrate signal creates the AnonymousUser
         self.assertEqual(
-            self.site_statistics_a.users_created,
-            self.site_statistics_a._get_previous_instance().users_created + 2
-        )
-        self.assertEqual(self.site_statistics_b.users_created, 0)
-        self.assertEqual(
-            self.site_statistics_c.users_created,
-            self.site_statistics_c._get_previous_instance().users_created + 2
+            (self.site_statistics_a.users_created,
+             self.site_statistics_b.users_created,
+             self.site_statistics_c.users_created),
+            # + 2 instead of the expected 1 because the emission of
+            # the post_migrate signal creates the AnonymousUser
+            (self.site_statistics_a._get_previous_instance().users_created + 2,
+             0,
+             self.site_statistics_c._get_previous_instance().users_created + 2)
         )
 
     def test_groups_created(self):
-        self.assertEqual(self.site_statistics_a.groups_created, 0)
-        self.assertEqual(self.site_statistics_b.groups_created, 0)
-        self.assertEqual(self.site_statistics_c.groups_created, 1)
+        self.assertEqual(
+            (self.site_statistics_a.groups_created,
+             self.site_statistics_b.groups_created,
+             self.site_statistics_c.groups_created),
+            (1, 0, 1)
+        )
 
     def test_unique_user_logins(self):
-        self.assertEqual(self.site_statistics_a.unique_user_logins, 1)
-        self.assertEqual(self.site_statistics_b.unique_user_logins, 0)
-        self.assertEqual(self.site_statistics_c.unique_user_logins, 2)
+        self.assertEqual(
+            (self.site_statistics_a.unique_user_logins,
+             self.site_statistics_b.unique_user_logins,
+             self.site_statistics_c.unique_user_logins),
+            (1, 0, 2)
+        )
 
     def test_total_user_logins(self):
-        self.assertEqual(self.site_statistics_a.total_user_logins, 1)
-        self.assertEqual(self.site_statistics_b.total_user_logins, 0)
-        self.assertEqual(self.site_statistics_c.total_user_logins, 4)
+        self.assertEqual(
+            (self.site_statistics_a.total_user_logins,
+             self.site_statistics_b.total_user_logins,
+             self.site_statistics_c.total_user_logins),
+            (1, 0, 4)
+        )
 
     def test_total_workflow_launches(self):
-        self.assertEqual(self.site_statistics_a.total_workflow_launches, 0)
-        self.assertEqual(self.site_statistics_b.total_workflow_launches, 0)
-        self.assertEqual(self.site_statistics_c.total_workflow_launches, 1)
+        self.assertEqual(
+            (self.site_statistics_a.total_workflow_launches,
+             self.site_statistics_b.total_workflow_launches,
+             self.site_statistics_c.total_workflow_launches),
+            (0, 0, 1)
+        )
 
     def test_total_visualization_launches(self):
         self.assertEqual(
-            self.site_statistics_a.total_visualization_launches, 0)
-        self.assertEqual(
-            self.site_statistics_b.total_visualization_launches, 0)
-        self.assertEqual(
-            self.site_statistics_c.total_visualization_launches,
-            1
+            (self.site_statistics_a.total_visualization_launches,
+             self.site_statistics_b.total_visualization_launches,
+             self.site_statistics_c.total_visualization_launches),
+            (0, 0, 1)
         )
 
     def test__get_previous_instance_returns_itself_if_only_instance(self):

--- a/refinery/core/tests.py
+++ b/refinery/core/tests.py
@@ -2391,6 +2391,7 @@ class SiteStatisticsUnitTests(TestCase):
         self.assertEqual(self.site_statistics._get_total_user_logins(), 4)
 
 
+        # Simulate a day of user activity
         user_a = User.objects.create_user("user_a", "", "user_a")
         self.client.login(username="user_a", password="user_a")
         self.dataset_a = create_dataset_with_necessary_models(user=user_a)
@@ -2399,11 +2400,11 @@ class SiteStatisticsUnitTests(TestCase):
         self.site_statistics_a = SiteStatistics.objects.create()
         self.site_statistics_a.collect()
 
-        # Simulate a week where nothing happened
+        # Simulate a day where nothing happened
         self.site_statistics_b = SiteStatistics.objects.create()
         self.site_statistics_b.collect()
 
-        # Simulate another week of user activity
+        # Simulate another day of user activity
         user_b = User.objects.create_user("user_b", "", "user_b")
         user_c = User.objects.create_user("user_c", "", "user_c")
         self.client.login(username="user_b", password="user_b")

--- a/refinery/core/tests.py
+++ b/refinery/core/tests.py
@@ -2391,12 +2391,16 @@ class SiteStatisticsUnitTests(TestCase):
         self.assertEqual(self.site_statistics._get_total_user_logins(), 4)
 
 
+class SiteStatisticsIntegrationTests(TestCase):
+    def setUp(self):
+        test_group = ExtendedGroup.objects.create(name="Test Group A")
+
         # Simulate a day of user activity
         user_a = User.objects.create_user("user_a", "", "user_a")
         self.client.login(username="user_a", password="user_a")
         self.dataset_a = create_dataset_with_necessary_models(user=user_a)
         self.dataset_b = create_dataset_with_necessary_models(user=user_a)
-        self.dataset_b.share(public_group)
+        self.dataset_b.share(test_group)
         self.site_statistics_a = SiteStatistics.objects.create()
         self.site_statistics_a.collect()
 

--- a/refinery/factory_boy/utils.py
+++ b/refinery/factory_boy/utils.py
@@ -5,11 +5,13 @@ from data_set_manager.models import Node
 from factory_boy.django_model_factories import (
     AnalysisFactory, AnalysisNodeConnectionFactory, AnalysisResultFactory,
     AnalysisStatusFactory, AnnotatedNodeFactory, AssayFactory,
-    AttributeFactory, DataSetFactory, FileStoreItemFactory,
-    GalaxyInstanceFactory, InvestigationFactory, InvestigationLinkFactory,
-    NodeFactory, ProjectFactory, StudyFactory, WorkflowEngineFactory,
-    WorkflowFactory
+    AttributeFactory, DataSetFactory, FileRelationshipFactory,
+    FileStoreItemFactory, GalaxyInstanceFactory, InvestigationFactory,
+    InvestigationLinkFactory, NodeFactory, ProjectFactory, StudyFactory,
+    ToolDefinitionFactory, VisualizationToolFactory, WorkflowEngineFactory,
+    WorkflowFactory, WorkflowToolFactory
 )
+from tool_manager.models import ToolDefinition
 
 
 def create_analysis(project, dataset, workflow, user_instance):
@@ -174,3 +176,31 @@ def _create_dataset_objects(dataset, is_isatab_based, latest_version):
             version=i
         )
     return study
+
+
+def create_tool_with_necessary_models(tool_type):
+    """
+    Create a minimal representation of a Visualization/Workflow
+    Tool for use in tests.
+    :param tool_type: The type of tool to create.
+    Must be one of: ["VISUALIZATION", "WORKFLOW"]
+    :returns: WorkflowTool/VisualizationTool instance
+    """
+    if tool_type not in [ToolDefinition.WORKFLOW,
+                         ToolDefinition.VISUALIZATION]:
+        raise RuntimeError("Invalid tool_type")
+
+    tool_type_to_factory_mapping = {
+        ToolDefinition.WORKFLOW: WorkflowToolFactory,
+        ToolDefinition.VISUALIZATION: VisualizationToolFactory
+    }
+    tool_factory = tool_type_to_factory_mapping[tool_type]
+
+    return tool_factory(
+        tool_definition=ToolDefinitionFactory(
+            tool_type=tool_type,
+            name="Test {} Tool: {}".format(tool_type, uuid_builtin.uuid4()),
+            file_relationship=FileRelationshipFactory()
+        ),
+        dataset=create_dataset_with_necessary_models()
+    )


### PR DESCRIPTION
Resolves #2694 

Things to note:
- `ExtendedGroup` creation currently has a `post_save` signal handler that runs `core.models.create_manager_group` so the `groups_created` metric will always be 2x (I don't think this is what we want)
  - [x] Exclude `manager` groups
- We currently have no notion of a `User` being a `Core Consultant`
  - This doesn't matter for now
- There are probably some edge cases when/if `Users` get deleted because this could skew things like: `total_user_logins`
- [x] Run this script daily
- The collected information is currently available through the admin ui, but I'm not sure if anything more is expected. Maybe an admin_only view?
  - Maybe in the future, numbers are fine for now