### PR TITLE
Scottx611x/remove receiver subclasses decorator

### DIFF
--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -809,7 +809,6 @@ def _dataset_delete(sender, instance, *args, **kwargs):
     delete_data_set_index(instance)
     delete_data_set_neo4j(instance.uuid)
     async_update_annotation_sets_neo4j()
-
     invalidate_cached_object(instance)
 
 

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -810,11 +810,14 @@ def _dataset_delete(sender, instance, *args, **kwargs):
     delete_data_set_neo4j(instance.uuid)
     async_update_annotation_sets_neo4j()
 
+    invalidate_cached_object(instance)
+
 
 @receiver(post_save, sender=DataSet)
 def _dataset_saved(sender, instance, *args, **kwargs):
     async_update_annotation_sets_neo4j()
     update_data_set_index(instance)
+    invalidate_cached_object(instance)
 
 
 class InvestigationLink(models.Model):

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -27,7 +27,7 @@ from django.core.mail import send_mail
 from django.db import models, transaction
 from django.db.models import Max
 from django.db.models.fields import IntegerField
-from django.db.models.signals import post_delete, post_save, pre_delete
+from django.db.models.signals import post_save, pre_delete
 from django.dispatch import receiver
 from django.forms import ValidationError
 from django.template import loader
@@ -1988,64 +1988,6 @@ class Ontology(models.Model):
 @receiver(pre_delete, sender=Ontology)
 def _ontology_delete(sender, instance, *args, **kwargs):
     delete_ontology_from_neo4j(instance.acronym)
-
-
-# http://web.archive.org/web/20140826013240/http://codeblogging.net/blogs/1/14/
-def get_subclasses(classes, level=0):
-    """
-        Return the list of all subclasses given class (or list of classes) has.
-        Inspired by this question:
-        http://stackoverflow.com/questions/3862310/how-can-i-find-all-
-        subclasses-of-a-given-class-in-python
-    """
-    # for convenience, only one class can can be accepted as argument
-    # converting to list if this is the case
-    if not isinstance(classes, list):
-        classes = [classes]
-
-    if level < len(classes):
-        classes += classes[level].__subclasses__()
-        return get_subclasses(classes, level + 1)
-    else:
-        return classes
-
-
-def receiver_subclasses(signal, sender, dispatch_uid_prefix, **kwargs):
-    """
-    A decorator for connecting receivers and all receiver's subclasses to
-    signals. Used by passing in the signal and keyword arguments to connect::
-        @receiver_subclasses(post_save, sender=MyModel)
-        def signal_receiver(sender, **kwargs):
-            ...
-    """
-
-    def _decorator(func):
-        all_senders = get_subclasses(sender)
-        for snd in all_senders:
-            signal.connect(
-                func, sender=snd, dispatch_uid=dispatch_uid_prefix + '_' +
-                snd.__name__, **kwargs)
-        return func
-
-    return _decorator
-
-
-@receiver_subclasses(post_delete, BaseResource, "baseresource_post_delete")
-def _baseresource_delete(sender, instance, **kwargs):
-    '''
-        Handles the invalidation of cached objects that inherit from
-        BaseResource after being deleted
-    '''
-    invalidate_cached_object(instance)
-
-
-@receiver_subclasses(post_save, BaseResource, "baseresource_post_save")
-def _baseresource_save(sender, instance, **kwargs):
-    '''
-        Handles the invalidation of cached objects that inherit from
-        BaseResource after being saved
-    '''
-    invalidate_cached_object(instance)
 
 
 class AuthenticationFormUsernameOrEmail(AuthenticationForm):


### PR DESCRIPTION
Fixes #2658 
We only support the caching functionality for DataSets, so it makes no sense to have this in `BaseResource`