### PR TITLE
Order event and tools by creation_time.

### DIFF
--- a/refinery/ui/source/js/dashboard/partials/history-card.html
+++ b/refinery/ui/source/js/dashboard/partials/history-card.html
@@ -17,8 +17,8 @@
       </h4>
     </div>
      <ul class="list-unstyled scrollable-list main-content-list">
-       <li ng-repeat="tool in $ctrl.tools" class="event-item">
-          {{ tool.modification_date | date:"MM/dd/yyyy" }}
+       <li ng-repeat="tool in $ctrl.tools | orderBy: '-creation_date'" class="event-item">
+          {{ tool.creation_date | date:"MM/dd/yyyy" }}
          <span class="p-l-1-2" ng-if="tool.tool_definition.tool_type === 'WORKFLOW'">
             <a ng-href="/data_sets/{{ tool.dataset.uuid }}/#/analyses">
              <i class="fa fa-cogs"></i>

--- a/refinery/ui/source/js/data-set-visualization/partials/visualization.html
+++ b/refinery/ui/source/js/data-set-visualization/partials/visualization.html
@@ -37,7 +37,7 @@
     </div>
 
     <ul class="analysesList">
-      <li class="analysesListItems" ng-repeat="vis in $ctrl.visualizations">
+      <li class="analysesListItems" ng-repeat="vis in $ctrl.visualizations | orderBy: '-creation_date'">
         <div class="row">
           <div class="col-md-1 analysis-icon">
             <span class="spinner">


### PR DESCRIPTION
Ref #2768 

@scottx611x Temp (hot) fix using the UI filtering. The better solution is to add the django-filter and order in the DRF serializer. Adding the dependency will take some coordination due to making it compatible with our other 'older' dependencies. 