### PR TITLE
Scottx611x/terminate file import tasks on analysis cancel

### DIFF
--- a/refinery/analysis_manager/tests.py
+++ b/refinery/analysis_manager/tests.py
@@ -301,6 +301,13 @@ class AnalysisRunTests(AnalysisManagerTestBase):
             run_analysis(self.analysis.uuid)
             self.assertTrue(terminate_mock.called)
 
+    def test_file_import_task_termination_on_analysis_cancel(self):
+        with mock.patch(
+            "core.models.Analysis.terminate_file_import_tasks"
+        ) as terminate_mock:
+            self.analysis.cancel()
+            self.assertTrue(terminate_mock.called)
+
     @mock.patch.object(Analysis, "galaxy_progress", side_effect=RuntimeError)
     @mock.patch("analysis_manager.tasks.get_taskset_result")
     @mock.patch("core.models.Analysis.send_email")

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -1209,6 +1209,7 @@ class Analysis(OwnableResource):
     def cancel(self):
         """Mark analysis as cancelled"""
         self.canceled = True
+        self.terminate_file_import_tasks()
         self.set_status(Analysis.FAILURE_STATUS, "Cancelled at user's request")
         # jobs in a running workflow are stopped by deleting its history
         self.galaxy_cleanup()


### PR DESCRIPTION
I observed today that an Analysis' `import_file` tasks will not be terminated if an analysis is cancelled before they have completed.