### PR TITLE
Update load_tools mgmt command to utilize `nargs`;

### DIFF
--- a/refinery/tool_manager/management/commands/load_tools.py
+++ b/refinery/tool_manager/management/commands/load_tools.py
@@ -22,8 +22,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument(
             '--visualizations',
-            # TODO: In Python 3, nargs='+' is supported
-            action='append',
+            nargs='+',
             dest='visualizations',
             help='Generate ToolDefinitions for visualizations, '
                  'either by filename, or from the registry'


### PR DESCRIPTION
This is supported in Python 2, I was getting tired of having to type `--visualizations` many times

Now we'll be able to run:
`./manage.py load_tools --visualizations igv multiqc higlass` ...etc