### PR TITLE
Scottx611x/add access control to events api

### DIFF
--- a/refinery/core/admin.py
+++ b/refinery/core/admin.py
@@ -15,8 +15,8 @@ from .models import (
     Analysis, AnalysisNodeConnection, AnalysisResult, DataSet, Download,
     ExtendedGroup, InvestigationLink, Invitation, Ontology, Project,
     SiteProfile, SiteStatistics, Tutorials, UserProfile, Workflow,
-    WorkflowEngine
-)
+    WorkflowEngine,
+    Event)
 from .utils import admin_ui_deletion
 
 
@@ -155,6 +155,10 @@ class SiteStatisticsAdmin(AdminFieldPopulator):
     pass
 
 
+class EventAdmin(AdminFieldPopulator):
+    pass
+
+
 admin.site.register(ExtendedGroup, ExtendedGroupAdmin)
 admin.site.register(Project, ProjectAdmin)
 admin.site.register(DataSet, DataSetAdmin)
@@ -171,3 +175,4 @@ admin.site.register(Tutorials, TutorialsAdmin)
 admin.site.register(Ontology, OntologyAdmin)
 admin.site.register(SiteProfile, SiteProfileAdmin)
 admin.site.register(SiteStatistics, SiteStatisticsAdmin)
+admin.site.register(Event, EventAdmin)

--- a/refinery/core/admin.py
+++ b/refinery/core/admin.py
@@ -13,10 +13,9 @@ from tool_manager.utils import AdminFieldPopulator
 
 from .models import (
     Analysis, AnalysisNodeConnection, AnalysisResult, DataSet, Download,
-    ExtendedGroup, InvestigationLink, Invitation, Ontology, Project,
+    ExtendedGroup, Event, InvestigationLink, Invitation, Ontology, Project,
     SiteProfile, SiteStatistics, Tutorials, UserProfile, Workflow,
-    WorkflowEngine,
-    Event)
+    WorkflowEngine)
 from .utils import admin_ui_deletion
 
 

--- a/refinery/core/migrations/0027_auto_20180611_1640.py
+++ b/refinery/core/migrations/0027_auto_20180611_1640.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0026_auto_20180608_1123'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='event',
+            old_name='json',
+            new_name='details',
+        ),
+    ]

--- a/refinery/core/migrations/0028_auto_20180611_1640.py
+++ b/refinery/core/migrations/0028_auto_20180611_1640.py
@@ -7,7 +7,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('core', '0026_auto_20180608_1123'),
+        ('core', '0027_userprofile_primary_group'),
     ]
 
     operations = [

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -39,7 +39,6 @@ from cuser.middleware import CuserMiddleware
 from django.utils.functional import cached_property
 from django_auth_ldap.backend import LDAPBackend
 from django_extensions.db.fields import UUIDField
-
 from guardian.models import UserObjectPermission
 from guardian.shortcuts import (
     assign_perm, get_groups_with_perms, get_objects_for_group,

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -2273,7 +2273,9 @@ class Event(models.Model):
     @staticmethod
     def record_data_set_create(data_set):
         user = CuserMiddleware.get_user()
-        Event.objects.create(data_set=data_set, user=user, type=Event.CREATE)
+        Event.objects.create(
+            data_set=data_set, user=user, type=Event.CREATE, json='{}'
+        )
 
     def render_data_set_create(self):
         return '{:%x %X}: {} created data set {}'.format(

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -2277,7 +2277,7 @@ class Event(models.Model):
     def record_data_set_create(data_set):
         user = CuserMiddleware.get_user()
         Event.objects.create(
-            data_set=data_set, user=user, type=Event.CREATE, json='{}'
+            data_set=data_set, user=user, type=Event.CREATE, details='{}'
         )
 
     def render_data_set_create(self):
@@ -2342,7 +2342,7 @@ class Event(models.Model):
         blob = json.dumps({
             'display_name': display_name
         })
-        event = Event(data_set=data_set, user=user, json=blob,
+        event = Event(data_set=data_set, user=user, details=blob,
                       type=Event.UPDATE, sub_type=Event.VISUALIZATION_CREATION)
         event.save()
 
@@ -2373,7 +2373,7 @@ class Event(models.Model):
         blob = json.dumps({
             'display_name': display_name
         })
-        event = Event(data_set=data_set, user=user, json=blob,
+        event = Event(data_set=data_set, user=user, details=blob,
                       type=Event.UPDATE, sub_type=Event.ANALYSIS_CREATION)
         event.save()
 

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -2261,7 +2261,7 @@ class Event(models.Model):
     type = models.CharField(max_length=32)
 
     sub_type = models.CharField(max_length=32)
-    json = models.TextField()
+    details = models.TextField()
 
     # Types
     CREATE = 'CREATE'
@@ -2269,6 +2269,9 @@ class Event(models.Model):
     # DELETE = 'DELETE'
     # Note: No delete, because when the object in question no longer exists,
     # no one has any access to it.
+
+    def get_details_as_dict(self):
+        return json.loads(self.details)
 
     @staticmethod
     def record_data_set_create(data_set):
@@ -2344,9 +2347,10 @@ class Event(models.Model):
         event.save()
 
     def render_data_set_visualization_creation(self):
-        data = json.loads(self.json)
+        details = self.get_details_as_dict()
         return '{:%x %X}: {} launched visualization {} on data set {}'.format(
-            self.date_time, self.user, data['display_name'], self.data_set.name
+            self.date_time, self.user, details['display_name'],
+            self.data_set.name
         )
 
     VISUALIZATION_DELETION = 'VISUALIZATION_DELETION'
@@ -2374,9 +2378,10 @@ class Event(models.Model):
         event.save()
 
     def render_data_set_analysis_creation(self):
-        data = json.loads(self.json)
+        details = self.get_details_as_dict()
         return '{:%x %X}: {} launched analysis {} on data set {}'.format(
-            self.date_time, self.user, data['display_name'], self.data_set.name
+            self.date_time, self.user, details['display_name'],
+            self.data_set.name
         )
 
     ANALYSIS_DELETION = 'ANALYSIS_DELETION'

--- a/refinery/core/serializers.py
+++ b/refinery/core/serializers.py
@@ -169,12 +169,10 @@ class NodeSerializer(serializers.HyperlinkedModelSerializer):
 
 class EventSerializer(serializers.ModelSerializer):
     data_set = serializers.SlugRelatedField(
-        read_only=True,
-        slug_field='uuid'
+        read_only=True, slug_field='uuid'
     )
     user = serializers.SlugRelatedField(
-        read_only=True,
-        slug_field='username'
+        read_only=True, slug_field='username'
     )
     message = serializers.SerializerMethodField()
     details = serializers.JSONField(source="get_details_as_dict")
@@ -187,5 +185,6 @@ class EventSerializer(serializers.ModelSerializer):
             'type', 'sub_type', 'details', 'message'
         ]
 
-    def get_message(self, obj):
+    @staticmethod
+    def get_message(obj):
         return str(obj)

--- a/refinery/core/serializers.py
+++ b/refinery/core/serializers.py
@@ -168,6 +168,11 @@ class NodeSerializer(serializers.HyperlinkedModelSerializer):
 
 
 class EventSerializer(serializers.ModelSerializer):
+    data_set = serializers.SlugRelatedField(
+        read_only=True,
+        slug_field='uuid'
+    )
+
     class Meta:
         model = Event
         fields = ['data_set', 'group', 'user', 'type', 'sub_type', 'json']

--- a/refinery/core/serializers.py
+++ b/refinery/core/serializers.py
@@ -1,4 +1,3 @@
-import json
 import logging
 
 import celery
@@ -177,12 +176,6 @@ class _StrObjectField(serializers.Field):
         return str(obj)
 
 
-class _DeserializeJSONField(serializers.Field):
-
-    def to_representation(self, obj):
-        return json.loads(obj)
-
-
 class EventSerializer(serializers.ModelSerializer):
     data_set = serializers.SlugRelatedField(
         read_only=True,
@@ -196,13 +189,12 @@ class EventSerializer(serializers.ModelSerializer):
 
     message = _StrObjectField()
 
-    json = _DeserializeJSONField()
-
+    details = serializers.JSONField(source="get_details_as_dict")
     date_time = serializers.DateTimeField()
 
     class Meta:
         model = Event
         fields = [
             'date_time', 'data_set', 'group', 'user',
-            'type', 'sub_type', 'json', 'message'
+            'type', 'sub_type', 'details', 'message'
         ]

--- a/refinery/core/serializers.py
+++ b/refinery/core/serializers.py
@@ -7,7 +7,7 @@ from rest_framework.validators import UniqueValidator
 from data_set_manager.models import Node
 from file_store.models import FileStoreItem
 
-from .models import DataSet, Workflow
+from .models import DataSet, Event, Workflow
 
 logger = logging.getLogger(__name__)
 
@@ -165,3 +165,9 @@ class NodeSerializer(serializers.HyperlinkedModelSerializer):
             'ready_for_igv_detail_view',
             'file_uuid'
         ]
+
+
+class EventSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Event
+        fields = ['dataset', 'group', 'user', 'type', 'sub_type', 'json']

--- a/refinery/core/serializers.py
+++ b/refinery/core/serializers.py
@@ -198,8 +198,11 @@ class EventSerializer(serializers.ModelSerializer):
 
     json = _DeserializeJSONField()
 
+    date_time = serializers.DateTimeField()
+
     class Meta:
         model = Event
         fields = [
-            'data_set', 'group', 'user', 'type', 'sub_type', 'json', 'message'
+            'date_time', 'data_set', 'group', 'user',
+            'type', 'sub_type', 'json', 'message'
         ]

--- a/refinery/core/serializers.py
+++ b/refinery/core/serializers.py
@@ -167,28 +167,16 @@ class NodeSerializer(serializers.HyperlinkedModelSerializer):
         ]
 
 
-class _StrObjectField(serializers.Field):
-    def get_attribute(self, obj):
-        # Without this, it tries to access a field by the same name.
-        return obj
-
-    def to_representation(self, obj):
-        return str(obj)
-
-
 class EventSerializer(serializers.ModelSerializer):
     data_set = serializers.SlugRelatedField(
         read_only=True,
         slug_field='uuid'
     )
-
     user = serializers.SlugRelatedField(
         read_only=True,
         slug_field='username'
     )
-
-    message = _StrObjectField()
-
+    message = serializers.SerializerMethodField()
     details = serializers.JSONField(source="get_details_as_dict")
     date_time = serializers.DateTimeField()
 
@@ -198,3 +186,6 @@ class EventSerializer(serializers.ModelSerializer):
             'date_time', 'data_set', 'group', 'user',
             'type', 'sub_type', 'details', 'message'
         ]
+
+    def get_message(self, obj):
+        return str(obj)

--- a/refinery/core/serializers.py
+++ b/refinery/core/serializers.py
@@ -173,6 +173,11 @@ class EventSerializer(serializers.ModelSerializer):
         slug_field='uuid'
     )
 
+    user = serializers.SlugRelatedField(
+        read_only=True,
+        slug_field='username'
+    )
+
     class Meta:
         model = Event
         fields = ['data_set', 'group', 'user', 'type', 'sub_type', 'json']

--- a/refinery/core/serializers.py
+++ b/refinery/core/serializers.py
@@ -167,6 +167,15 @@ class NodeSerializer(serializers.HyperlinkedModelSerializer):
         ]
 
 
+class _StrObjectField(serializers.Field):
+    def get_attribute(self, obj):
+        # Without this, it tries to access a field by the same name.
+        return obj
+
+    def to_representation(self, obj):
+        return str(obj)
+
+
 class EventSerializer(serializers.ModelSerializer):
     data_set = serializers.SlugRelatedField(
         read_only=True,
@@ -178,6 +187,10 @@ class EventSerializer(serializers.ModelSerializer):
         slug_field='username'
     )
 
+    message = _StrObjectField()
+
     class Meta:
         model = Event
-        fields = ['data_set', 'group', 'user', 'type', 'sub_type', 'json']
+        fields = [
+            'data_set', 'group', 'user', 'type', 'sub_type', 'json', 'message'
+        ]

--- a/refinery/core/serializers.py
+++ b/refinery/core/serializers.py
@@ -170,4 +170,4 @@ class NodeSerializer(serializers.HyperlinkedModelSerializer):
 class EventSerializer(serializers.ModelSerializer):
     class Meta:
         model = Event
-        fields = ['dataset', 'group', 'user', 'type', 'sub_type', 'json']
+        fields = ['data_set', 'group', 'user', 'type', 'sub_type', 'json']

--- a/refinery/core/serializers.py
+++ b/refinery/core/serializers.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 import celery
@@ -176,6 +177,12 @@ class _StrObjectField(serializers.Field):
         return str(obj)
 
 
+class _DeserializeJSONField(serializers.Field):
+
+    def to_representation(self, obj):
+        return json.loads(obj)
+
+
 class EventSerializer(serializers.ModelSerializer):
     data_set = serializers.SlugRelatedField(
         read_only=True,
@@ -188,6 +195,8 @@ class EventSerializer(serializers.ModelSerializer):
     )
 
     message = _StrObjectField()
+
+    json = _DeserializeJSONField()
 
     class Meta:
         model = Event

--- a/refinery/core/test_views.py
+++ b/refinery/core/test_views.py
@@ -955,17 +955,18 @@ class EventApiV2Tests(APIV2TestCase):
 
     def test_get_event_list(self):
         create_dataset_with_necessary_models()
+        uuid = DataSet.objects.get(pk=1).uuid
         get_request = self.factory.get(urljoin(self.url_root, '/'))
         get_response = self.view(get_request).render()
         # TODO: Why do I need render()?
         self.assertEqual(
             json.loads(get_response.content),
             [{
-                "data_set": 1,
-                "group": None,
-                "user": None,
-                "type": "CREATE",
-                "sub_type": "",
-                "json": ""
+                u"data_set": uuid,
+                u"group": None,
+                u"user": None,
+                u"type": "CREATE",
+                u"sub_type": "",
+                u"json": ""
             }]
         )

--- a/refinery/core/test_views.py
+++ b/refinery/core/test_views.py
@@ -968,6 +968,9 @@ class EventApiV2Tests(APIV2TestCase):
         display_names = [
             json.loads(_.json).get('display_name') for _ in events
         ]
+        date_times = [
+            _.date_time.isoformat().replace('+00:00', 'Z') for _ in events
+        ]
 
         get_request = self.factory.get(urljoin(self.url_root, '/'))
         get_response = self.view(get_request).render()
@@ -978,6 +981,7 @@ class EventApiV2Tests(APIV2TestCase):
             json.loads(get_response.content),
             [
                 {
+                    'date_time': date_times[0],
                     'message': messages[0],
                     'data_set': data_sets[0],
                     'group': None,
@@ -987,6 +991,7 @@ class EventApiV2Tests(APIV2TestCase):
                     'json': {}
                 },
                 {
+                    'date_time': date_times[1],
                     'message': messages[1],
                     'data_set': data_sets[1],
                     'group': None,
@@ -996,6 +1001,7 @@ class EventApiV2Tests(APIV2TestCase):
                     'json': {'display_name': display_names[1]}
                 },
                 {
+                    'date_time': date_times[2],
                     'message': messages[2],
                     'data_set': data_sets[2],
                     'group': None,
@@ -1005,6 +1011,7 @@ class EventApiV2Tests(APIV2TestCase):
                     'json': {}
                 },
                 {
+                    'date_time': date_times[3],
                     'message': messages[3],
                     'data_set': data_sets[3],
                     'group': None,

--- a/refinery/core/test_views.py
+++ b/refinery/core/test_views.py
@@ -958,8 +958,7 @@ class EventApiV2Tests(APIV2TestCase):
         user = User.objects.create_user('testuser')
         CuserMiddleware.set_user(user)
 
-        create_dataset_with_necessary_models()
-        uuid = DataSet.objects.get(pk=1).uuid
+        data_set = create_dataset_with_necessary_models()
 
         get_request = self.factory.get(urljoin(self.url_root, '/'))
         get_response = self.view(get_request).render()
@@ -967,9 +966,9 @@ class EventApiV2Tests(APIV2TestCase):
         self.assertEqual(
             json.loads(get_response.content),
             [{
-                u"data_set": uuid,
+                u"data_set": data_set.uuid,
                 u"group": None,
-                u"user": user.id,
+                u"user": user.username,
                 u"type": "CREATE",
                 u"sub_type": "",
                 u"json": ""

--- a/refinery/core/test_views.py
+++ b/refinery/core/test_views.py
@@ -962,12 +962,12 @@ class EventApiV2Tests(APIV2TestCase):
 
         events = Event.objects.all()
         self.assertEqual(len(events), 4)
+
         messages = [str(_) for _ in events]
         data_sets = [_.data_set.uuid for _ in events]
-        jsons = [_.json for _ in events]
-        # Could get all the other fields, too, but this is the only one
-        # we can only get from the Event object
-        # (and if we shift more rendering to the view, it would disappear).
+        display_names = [
+            json.loads(_.json).get('display_name') for _ in events
+        ]
 
         get_request = self.factory.get(urljoin(self.url_root, '/'))
         get_response = self.view(get_request).render()
@@ -984,7 +984,7 @@ class EventApiV2Tests(APIV2TestCase):
                     'user': user.username,
                     'type': 'CREATE',
                     'sub_type': '',
-                    'json': ''
+                    'json': {}
                 },
                 {
                     'message': messages[1],
@@ -993,7 +993,7 @@ class EventApiV2Tests(APIV2TestCase):
                     'user': user.username,
                     'type': 'UPDATE',
                     'sub_type': 'VISUALIZATION_CREATION',
-                    'json': jsons[1]
+                    'json': {'display_name': display_names[1]}
                 },
                 {
                     'message': messages[2],
@@ -1002,7 +1002,7 @@ class EventApiV2Tests(APIV2TestCase):
                     'user': user.username,
                     'type': 'CREATE',
                     'sub_type': '',
-                    'json': ''
+                    'json': {}
                 },
                 {
                     'message': messages[3],
@@ -1011,7 +1011,7 @@ class EventApiV2Tests(APIV2TestCase):
                     'user': user.username,
                     'type': 'UPDATE',
                     'sub_type': 'ANALYSIS_CREATION',
-                    'json': jsons[3]
+                    'json': {'display_name': display_names[3]}
                 }
             ]
         )

--- a/refinery/core/test_views.py
+++ b/refinery/core/test_views.py
@@ -22,7 +22,7 @@ from factory_boy.django_model_factories import (
 )
 from factory_boy.utils import create_dataset_with_necessary_models
 
-from .models import (Analysis, DataSet, ExtendedGroup, Project,
+from .models import (Analysis, DataSet, Event, ExtendedGroup, Project,
                      Workflow, WorkflowEngine)
 from .views import (AnalysesViewSet, DataSetsViewSet, EventViewSet,
                     WorkflowViewSet)
@@ -951,21 +951,27 @@ class EventApiV2Tests(APIV2TestCase):
             api_base_name="events/",
             view=EventViewSet.as_view({"get": "list"})
         )
-        # Create a dataset?
-        # Or log an event directly?
 
     def test_get_event_list(self):
         user = User.objects.create_user('testuser')
         CuserMiddleware.set_user(user)
 
         data_set = create_dataset_with_necessary_models()
+        events = Event.objects.all()
+        self.assertEqual(len(events), 1)
+        message = str(events[0])
+        # Could get all the other fields, too, but this is the only one
+        # we can only get from the Event object
+        # (and if we shift more rendering to the view, it would disappear).
 
         get_request = self.factory.get(urljoin(self.url_root, '/'))
         get_response = self.view(get_request).render()
         # TODO: Why do I need render()?
+
         self.assertEqual(
             json.loads(get_response.content),
             [{
+                u"message": message,
                 u"data_set": data_set.uuid,
                 u"group": None,
                 u"user": user.username,

--- a/refinery/core/test_views.py
+++ b/refinery/core/test_views.py
@@ -954,4 +954,7 @@ class EventApiV2Tests(APIV2TestCase):
         # Or log an event directly?
 
     def test_get_event_list(self):
-        pass
+        get_request = self.factory.get(urljoin(self.url_root, '/'))
+        get_response = self.view(get_request).render()
+        # TODO: Why Do I need render?
+        self.assertEqual(get_response.content, '[]')

--- a/refinery/core/test_views.py
+++ b/refinery/core/test_views.py
@@ -21,7 +21,8 @@ from factory_boy.utils import create_dataset_with_necessary_models
 
 from .models import (Analysis, DataSet, ExtendedGroup, Project,
                      Workflow, WorkflowEngine)
-from .views import AnalysesViewSet, DataSetsViewSet, WorkflowViewSet
+from .views import (AnalysesViewSet, DataSetsViewSet, EventViewSet,
+                    WorkflowViewSet)
 
 cache = memcache.Client(["127.0.0.1:11211"])
 
@@ -934,3 +935,16 @@ class WorkflowApiV2Tests(APIV2TestCase):
             uuid=self.workflow.uuid
         )
         self.assertEqual(get_response.content, self.mock_workflow_graph)
+
+
+class EventApiV2Tests(APIV2TestCase):
+    def setUp(self):
+        super(EventApiV2Tests, self).setUp(
+            api_base_name="events/",
+            view=EventViewSet.as_view()  # dict arg?
+        )
+        # Create a dataset?
+        # Or log an event directly?
+
+    def test_get_event_list(self):
+        pass

--- a/refinery/core/test_views.py
+++ b/refinery/core/test_views.py
@@ -954,7 +954,18 @@ class EventApiV2Tests(APIV2TestCase):
         # Or log an event directly?
 
     def test_get_event_list(self):
+        create_dataset_with_necessary_models()
         get_request = self.factory.get(urljoin(self.url_root, '/'))
         get_response = self.view(get_request).render()
-        # TODO: Why Do I need render?
-        self.assertEqual(get_response.content, '[]')
+        # TODO: Why do I need render()?
+        self.assertEqual(
+            json.loads(get_response.content),
+            [{
+                "data_set": 1,
+                "group": None,
+                "user": None,
+                "type": "CREATE",
+                "sub_type": "",
+                "json": ""
+            }]
+        )

--- a/refinery/core/test_views.py
+++ b/refinery/core/test_views.py
@@ -7,6 +7,7 @@ from urlparse import urljoin
 from django.contrib.auth.models import User
 from django.utils.functional import SimpleLazyObject
 
+from cuser.middleware import CuserMiddleware
 from guardian.shortcuts import get_groups_with_perms
 import mock
 import mockcache as memcache
@@ -954,8 +955,12 @@ class EventApiV2Tests(APIV2TestCase):
         # Or log an event directly?
 
     def test_get_event_list(self):
+        user = User.objects.create_user('testuser')
+        CuserMiddleware.set_user(user)
+
         create_dataset_with_necessary_models()
         uuid = DataSet.objects.get(pk=1).uuid
+
         get_request = self.factory.get(urljoin(self.url_root, '/'))
         get_response = self.view(get_request).render()
         # TODO: Why do I need render()?
@@ -964,7 +969,7 @@ class EventApiV2Tests(APIV2TestCase):
             [{
                 u"data_set": uuid,
                 u"group": None,
-                u"user": None,
+                u"user": user.id,
                 u"type": "CREATE",
                 u"sub_type": "",
                 u"json": ""

--- a/refinery/core/test_views.py
+++ b/refinery/core/test_views.py
@@ -13,6 +13,8 @@ import mockcache as memcache
 from rest_framework.test import (
     APIClient, APIRequestFactory, APITestCase, force_authenticate
 )
+
+from core.management.commands.create_public_group import create_public_group
 from data_set_manager.models import (Assay, Investigation, Node, Study)
 from factory_boy.django_model_factories import (
     GalaxyInstanceFactory, WorkflowEngineFactory, WorkflowFactory
@@ -939,9 +941,14 @@ class WorkflowApiV2Tests(APIV2TestCase):
 
 class EventApiV2Tests(APIV2TestCase):
     def setUp(self):
+        create_public_group()
+        # Prints a warning and continues if public group already exists.
+        # Necessary if using "--settings=config.settings.quick_test".
+        # TODO: Move to superclass?
+
         super(EventApiV2Tests, self).setUp(
             api_base_name="events/",
-            view=EventViewSet.as_view()  # dict arg?
+            view=EventViewSet.as_view({"get": "list"})
         )
         # Create a dataset?
         # Or log an event directly?

--- a/refinery/core/test_views.py
+++ b/refinery/core/test_views.py
@@ -950,20 +950,18 @@ class EventApiV2Tests(APIV2TestCase):
         )
 
     def test_get_event_list_provides_access_control_between_users(self):
-        CuserMiddleware.set_user(self.user)
-
         # Create objects that trigger Events for "another_user"
         another_user = User.objects.create_user("Another", "User",
                                                 "another_user@example.com")
         create_tool_with_necessary_models("VISUALIZATION", user=another_user)
         events = Event.objects.all()
         self.assertEqual(len(events), 2)
-        get_request = self.factory.get(urljoin(self.url_root, '/'))
 
-        # Ensure that request made by "self.user" doesn't return Events from
-        #  "another_user"
+        get_request = self.factory.get(urljoin(self.url_root, '/'))
         get_request.user = self.user
         get_response = self.view(get_request).render()
+        # Ensure that request made by "self.user" doesn't return Events from
+        #  "another_user"
         self.assertEqual(json.loads(get_response.content), [])
 
     def test_get_event_list(self):

--- a/refinery/core/tests.py
+++ b/refinery/core/tests.py
@@ -1979,7 +1979,8 @@ class SiteStatisticsIntegrationTests(TestCase):
 class EventTests(TestCase):
 
     def setUp(self):
-        CuserMiddleware.set_user(User.objects.create_user('testuser'))
+        self.user = User.objects.create_user('testuser')
+        CuserMiddleware.set_user(self.user)
         self.pre_re = r'^\d{2}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}: testuser '
         self.post_re = r' data set Test DataSet - [0-9a-f-]+$'
 
@@ -2064,3 +2065,14 @@ class EventTests(TestCase):
 
     def test_group_user_removal(self):
         pass  # TODO
+
+    def test_get_details_as_dict(self):
+        tool = create_tool_with_necessary_models("VISUALIZATION",
+                                                 user=self.user)
+        event = Event.objects.last()
+        self.assertEqual(
+            event.get_details_as_dict(),
+            {
+                u'display_name': u'{}'.format(tool.display_name)
+            }
+        )

--- a/refinery/core/tests.py
+++ b/refinery/core/tests.py
@@ -2073,6 +2073,6 @@ class EventTests(TestCase):
         self.assertEqual(
             event.get_details_as_dict(),
             {
-                u'display_name': u'{}'.format(tool.display_name)
+                u'display_name': tool.display_name
             }
         )

--- a/refinery/core/urls.py
+++ b/refinery/core/urls.py
@@ -9,8 +9,8 @@ from django.conf.urls import patterns, url
 from constants import UUID_RE
 from rest_framework.routers import DefaultRouter
 
-from .views import (AnalysesViewSet, DataSetsViewSet, NodeViewSet,
-                    OpenIDToken, WorkflowViewSet)
+from .views import (AnalysesViewSet, DataSetsViewSet, EventViewSet,
+                    NodeViewSet, OpenIDToken, WorkflowViewSet)
 
 urlpatterns = patterns(
     'core.views',
@@ -75,6 +75,7 @@ urlpatterns = patterns(
 core_router = DefaultRouter()
 core_router.register(r'nodes', NodeViewSet)
 core_router.register(r'workflows', WorkflowViewSet)
+core_router.register(r'events', EventViewSet)
 core_router.urls.extend([
     url(r'^data_sets/$', DataSetsViewSet.as_view()),
     url(r'^data_sets/(?P<uuid>' + UUID_RE + r')/$',

--- a/refinery/core/views.py
+++ b/refinery/core/views.py
@@ -705,7 +705,6 @@ class EventViewSet(viewsets.ModelViewSet):
     """API endpoint that allows Events to be viewed"""
     queryset = Event.objects.all()
     serializer_class = EventSerializer
-    # Don't think I need a lookup_field?
     http_method_names = ['get']
 
     def list(self, request, *args, **kwargs):

--- a/refinery/core/views.py
+++ b/refinery/core/views.py
@@ -39,10 +39,11 @@ import xmltodict
 from data_set_manager.models import Node
 
 from .forms import ProjectForm, UserForm, UserProfileForm, WorkflowForm
-from .models import (Analysis, CustomRegistrationProfile, DataSet,
+from .models import (Analysis, CustomRegistrationProfile, DataSet, Event,
                      ExtendedGroup, Invitation, Ontology, Project,
                      UserProfile, Workflow, WorkflowEngine)
-from .serializers import DataSetSerializer, NodeSerializer, WorkflowSerializer
+from .serializers import (DataSetSerializer, EventSerializer, NodeSerializer,
+                          WorkflowSerializer)
 from .utils import (api_error_response, get_data_sets_annotations,
                     get_resources_for_user)
 
@@ -696,6 +697,14 @@ class NodeViewSet(viewsets.ModelViewSet):
     lookup_field = 'uuid'
     http_method_names = ['get']
     # permission_classes = (IsAuthenticated,)
+
+
+class EventViewSet(viewsets.ModelViewSet):
+    """API endpoint that allows Events to be viewed"""
+    queryset = Event.objects.all()
+    serializer_class = EventSerializer
+    # Don't think I need a lookup_field?
+    http_method_names = ['get']
 
 
 class DataSetsViewSet(APIView):

--- a/refinery/core/views.py
+++ b/refinery/core/views.py
@@ -708,11 +708,12 @@ class EventViewSet(viewsets.ModelViewSet):
     http_method_names = ['get']
 
     def list(self, request, *args, **kwargs):
+        """Overrides ModelViewSet.list to create an updated queryset based
+        on DataSets that the requesting User has permission to access
+        """
         data_sets_for_user = get_objects_for_user(
             request.user, 'core.read_meta_dataset'
         )
-        # Update queryset to only grab Events that are pertinent to a given
-        # User
         self.queryset = self.queryset.filter(data_set__in=data_sets_for_user)
         return super(EventViewSet, self).list(request, *args, **kwargs)
 

--- a/refinery/factory_boy/utils.py
+++ b/refinery/factory_boy/utils.py
@@ -178,7 +178,7 @@ def _create_dataset_objects(dataset, is_isatab_based, latest_version):
     return study
 
 
-def create_tool_with_necessary_models(tool_type):
+def create_tool_with_necessary_models(tool_type, user=None):
     """
     Create a minimal representation of a Visualization/Workflow
     Tool for use in tests.
@@ -197,12 +197,15 @@ def create_tool_with_necessary_models(tool_type):
     tool_factory = tool_type_to_factory_mapping[tool_type]
     name = "Test {} Tool: {}".format(tool_type, uuid_builtin.uuid4())
 
-    return tool_factory(
+    tool = tool_factory(
         tool_definition=ToolDefinitionFactory(
             tool_type=tool_type,
             name=name,
             file_relationship=FileRelationshipFactory()
         ),
         display_name=name,
-        dataset=create_dataset_with_necessary_models()
+        dataset=create_dataset_with_necessary_models(user=user)
     )
+    if user is not None:
+        tool.set_owner(user)
+    return tool

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -609,6 +609,8 @@ class VisualizationTool(Tool):
 
 @receiver(post_save, sender=VisualizationTool)
 def _visualization_saved(sender, instance, *args, **kwargs):
+    # Once a VisualizationTool is created with a display_name there are no
+    # further changes being made
     if instance.display_name:
         Event.record_data_set_visualization_creation(
             instance.dataset, instance.display_name
@@ -1468,6 +1470,8 @@ class WorkflowTool(Tool):
 
 @receiver(post_save, sender=WorkflowTool)
 def _workflow_saved(sender, instance, *args, **kwargs):
+    # Once a WorkflowTool is created with a display_name there are no
+    # further changes being made
     if instance.display_name:
         Event.record_data_set_analysis_creation(
             instance.dataset, instance.display_name

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -609,10 +609,10 @@ class VisualizationTool(Tool):
 
 @receiver(post_save, sender=VisualizationTool)
 def _visualization_saved(sender, instance, *args, **kwargs):
-    # TODO: Distinguish creation from modification?
-    Event.record_data_set_visualization_creation(
-        instance.dataset, instance.display_name
-    )
+    if instance.display_name:
+        Event.record_data_set_visualization_creation(
+            instance.dataset, instance.display_name
+        )
 
 
 @receiver(pre_delete, sender=VisualizationTool)
@@ -1468,7 +1468,7 @@ class WorkflowTool(Tool):
 
 @receiver(post_save, sender=WorkflowTool)
 def _workflow_saved(sender, instance, *args, **kwargs):
-    # TODO: Distinguish creation from modification?
-    Event.record_data_set_analysis_creation(
-        instance.dataset, instance.display_name
-    )
+    if instance.display_name:
+        Event.record_data_set_analysis_creation(
+            instance.dataset, instance.display_name
+        )

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -3553,12 +3553,6 @@ class WorkflowToolLaunchTests(ToolManagerTestBase):
         )
         self.assertEqual(self.tool.display_name, display_name)
 
-    def test_workflow_tool_creation_triggers_a_single_event(self):
-        Event.objects.all().delete()
-        create_tool_with_necessary_models("WORKFLOW")
-        self.assertEqual(Event.objects.filter(
-            sub_type=Event.ANALYSIS_CREATION).count(), 1)
-
 
 class VisualizationToolLaunchTests(ToolManagerTestBase):
     def setUp(self):
@@ -3734,12 +3728,6 @@ class VisualizationToolLaunchTests(ToolManagerTestBase):
             display_name=display_name
         )
         self.assertEqual(self.tool.display_name, display_name)
-
-    def test_visualization_tool_creation_triggers_a_single_event(self):
-        Event.objects.all().delete()
-        create_tool_with_necessary_models("VISUALIZATION")
-        self.assertEqual(Event.objects.filter(
-            sub_type=Event.VISUALIZATION_CREATION).count(), 1)
 
 
 class ToolLaunchConfigurationTests(ToolManagerTestBase):
@@ -4052,3 +4040,27 @@ class ParameterTests(TestCase):
                 test_float,
                 parameter.cast_param_value_to_proper_type(element)
             )
+
+
+class ToolEventCreationTests(TestCase):
+    def test_visualization_tool_creation_triggers_a_single_event(self):
+        create_tool_with_necessary_models("VISUALIZATION")
+
+        # A Tool needs a Dataset to be created. Assert that there is one Event
+        # for DataSet creation and one for Tool creation
+        self.assertEqual(Event.objects.count(), 2)
+        self.assertIsNotNone(Event.objects.get(type=Event.CREATE))
+        self.assertIsNotNone(
+            Event.objects.get(sub_type=Event.VISUALIZATION_CREATION)
+        )
+
+    def test_workflow_tool_creation_triggers_a_single_event(self):
+        create_tool_with_necessary_models("WORKFLOW")
+
+        # A Tool needs a Dataset to be created. Assert that there is one Event
+        # for DataSet creation and one for Tool creation
+        self.assertEqual(Event.objects.count(), 2)
+        self.assertIsNotNone(Event.objects.get(type=Event.CREATE))
+        self.assertIsNotNone(
+            Event.objects.get(sub_type=Event.ANALYSIS_CREATION)
+        )

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -52,7 +52,7 @@ from analysis_manager.tasks import (_galaxy_file_import,
                                     _run_galaxy_workflow, run_analysis)
 from core.models import (INPUT_CONNECTION, OUTPUT_CONNECTION, Analysis,
                          AnalysisNodeConnection, AnalysisResult, ExtendedGroup,
-                         Project, Workflow, WorkflowEngine)
+                         Event, Project, Workflow, WorkflowEngine)
 from data_set_manager.models import Assay, Attribute, Node
 from data_set_manager.utils import _create_solr_params_from_node_uuids
 from factory_boy.django_model_factories import (AnnotatedNodeFactory,
@@ -60,7 +60,8 @@ from factory_boy.django_model_factories import (AnnotatedNodeFactory,
                                                 GalaxyInstanceFactory,
                                                 NodeFactory, ParameterFactory,
                                                 ToolFactory)
-from factory_boy.utils import create_dataset_with_necessary_models
+from factory_boy.utils import create_dataset_with_necessary_models, \
+    create_tool_with_necessary_models
 from file_store.models import FileStoreItem, FileType
 from tool_manager.management.commands.load_tools import \
     Command as LoadToolsCommand
@@ -3552,6 +3553,12 @@ class WorkflowToolLaunchTests(ToolManagerTestBase):
         )
         self.assertEqual(self.tool.display_name, display_name)
 
+    def test_workflow_tool_creation_triggers_a_single_event(self):
+        Event.objects.all().delete()
+        create_tool_with_necessary_models("WORKFLOW")
+        self.assertEqual(Event.objects.filter(
+            sub_type=Event.ANALYSIS_CREATION).count(), 1)
+
 
 class VisualizationToolLaunchTests(ToolManagerTestBase):
     def setUp(self):
@@ -3727,6 +3734,12 @@ class VisualizationToolLaunchTests(ToolManagerTestBase):
             display_name=display_name
         )
         self.assertEqual(self.tool.display_name, display_name)
+
+    def test_visualization_tool_creation_triggers_a_single_event(self):
+        Event.objects.all().delete()
+        create_tool_with_necessary_models("VISUALIZATION")
+        self.assertEqual(Event.objects.filter(
+            sub_type=Event.VISUALIZATION_CREATION).count(), 1)
 
 
 class ToolLaunchConfigurationTests(ToolManagerTestBase):


### PR DESCRIPTION
Only return `Events` from the `api/v2/event` that correspond to `DataSets` that a `User` has access to (Through `Group` membership or `DataSet` ownership).