### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/refinery/core/views.py
+++ b/refinery/core/views.py
@@ -528,7 +528,7 @@ def doi(request, id):
     # slashes.
     id = urllib.unquote(id).decode('utf8')
     id = id.replace('$', '/')
-    url = "https://dx.doi.org/{id}".format(id=id)
+    url = "https://doi.org/{id}".format(id=id)
     headers = {'Accept': 'application/json'}
 
     try:

--- a/refinery/ui/source/js/commons/services/citations.js
+++ b/refinery/ui/source/js/commons/services/citations.js
@@ -150,7 +150,7 @@ angular
 
         // Check if DOI
         var matches = reference.match(
-          /^(http:\/\/dx\.doi\.org\/)?(doi:\s?)?(10\.[0-9]+\/[a-zA-Z0-9\.\/]+)$/
+          /^(https?:\/\/(dx\.)?doi\.org\/)?(doi:\s?)?(10\.[0-9]+\/[a-zA-Z0-9\.\/]+)$/
         );
         if (matches !== null) {
           // Query the DOI API

--- a/refinery/ui/source/js/dashboard/directives/data-set-preview.html
+++ b/refinery/ui/source/js/dashboard/directives/data-set-preview.html
@@ -293,7 +293,7 @@
               <a
                 target="_blank"
                 ng-if="publication.doi"
-                ng-href="http://dx.doi.org/{{ publication.doi }}">
+                ng-href="https://doi.org/{{ publication.doi }}">
                 <i class="fa fa-external-link-square" aria-hidden="true"></i>
                 Source
               </a>


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update the code that generates new DOI links.

Cheers!