### PR TITLE
Upgrade django-docker-engine

### DIFF
--- a/refinery/config/settings/base.py
+++ b/refinery/config/settings/base.py
@@ -220,7 +220,7 @@ INSTALLED_APPS = (
     'rest_framework',
     'rest_framework_swagger',
     'django_docker_engine',
-    'httpproxy',
+    'revproxy',
     'cuser',
 )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ django-celery==3.1.17
 django-chunked-upload==1.1.0
 django-cuser==2017.3.16
 django-debug-toolbar==1.4
-django-docker-engine==0.0.42.2
+django-docker-engine==0.0.59
 django-extensions==1.6.7
 django-flatblocks==0.9.2
 django-guardian==1.4.1


### PR DESCRIPTION
Fix #2847. Not adding a link in the UI, since this is really just a debugging tool.