### PR TITLE
Show PENDING state for datafiles added from the UI

### DIFF
--- a/refinery/core/views.py
+++ b/refinery/core/views.py
@@ -40,7 +40,6 @@ from rest_framework.views import APIView
 import xmltodict
 
 from data_set_manager.models import Node
-from data_set_manager.search_indexes import NodeIndex
 from file_store.models import FileStoreItem
 
 from .forms import ProjectForm, UserForm, UserProfileForm, WorkflowForm
@@ -761,7 +760,7 @@ class NodeViewSet(APIView):
             serializer = NodeSerializer(node, data=request.data, partial=True)
             if serializer.is_valid():
                 self.update_file_store(old_file_uuid, node.file_uuid)
-                NodeIndex().update_object(node, using="data_set_manager")
+                node.update_solr_index()
                 serializer.save()
                 return Response(
                     serializer.data, status=status.HTTP_202_ACCEPTED

--- a/refinery/core/views.py
+++ b/refinery/core/views.py
@@ -40,6 +40,7 @@ from rest_framework.views import APIView
 import xmltodict
 
 from data_set_manager.models import Node
+from data_set_manager.search_indexes import NodeIndex
 from file_store.models import FileStoreItem
 
 from .forms import ProjectForm, UserForm, UserProfileForm, WorkflowForm

--- a/refinery/core/views.py
+++ b/refinery/core/views.py
@@ -40,7 +40,6 @@ from rest_framework.views import APIView
 import xmltodict
 
 from data_set_manager.models import Node
-from data_set_manager.search_indexes import NodeIndex
 from file_store.models import FileStoreItem
 
 from .forms import ProjectForm, UserForm, UserProfileForm, WorkflowForm
@@ -769,7 +768,7 @@ class NodeViewSet(APIView):
                 else:
                     file_store_item.delete_datafile()
 
-            NodeIndex().update_object(node, using="data_set_manager")
+            node.update_solr_index()
             return Response(
                 NodeSerializer(node).data, status=status.HTTP_200_OK
             )

--- a/refinery/data_set_manager/models.py
+++ b/refinery/data_set_manager/models.py
@@ -708,6 +708,11 @@ class Node(models.Model):
         else:
             return None
 
+    def update_solr_index(self):
+        data_set_manager.search_indexes.NodeIndex().update_object(
+            self, using="data_set_manager"
+        )
+
 
 @receiver(pre_delete, sender=Node)
 def _node_delete(sender, instance, *args, **kwargs):

--- a/refinery/data_set_manager/test_views.py
+++ b/refinery/data_set_manager/test_views.py
@@ -9,7 +9,7 @@ from factory_boy.utils import create_dataset_with_necessary_models
 from .views import AddFileToNodeView
 
 
-class AddFilesToDataSetViewTests(APITestCase):
+class AddFileToNodeViewTests(APITestCase):
     def setUp(self):
         self.username = 'guest_user'
         self.password = User.objects.make_random_password()
@@ -28,17 +28,14 @@ class AddFilesToDataSetViewTests(APITestCase):
 
         self.post_request = self.factory.post(
             self.url_root,
-            data={
-                'data_set_uuid': self.data_set.uuid,
-                'node_uuid': self.node.uuid
-            },
+            data={'node_uuid': self.node.uuid},
             format="json"
         )
 
     def test_post_returns_404_invalid_uuid(self):
         post_request = self.factory.post(
             self.url_root,
-            data={'data_set_uuid': uuid.uuid4()},
+            data={'node_uuid': uuid.uuid4()},
             format="json"
         )
         post_response = self.view(post_request)
@@ -59,22 +56,13 @@ class AddFilesToDataSetViewTests(APITestCase):
         post_response = self.view(self.post_request)
         self.assertEqual(post_response.status_code, 202)
 
-    def test_post_returns_400_for_node_not_associated_with_dataset(self):
-        another_dataset = create_dataset_with_necessary_models()
-        another_node = another_dataset.get_nodes()[0]
-
-        # POST with a node_uuid that isn't one of self.dataset's nodes
+    def test_post_returns_400_node_uuid_not_present(self):
         post_request = self.factory.post(
             self.url_root,
-            data={
-                'data_set_uuid': self.data_set.uuid,
-                'node_uuid': another_node.uuid
-            },
+            data={},
             format="json"
         )
         post_request.user = self.user
         force_authenticate(post_request, user=self.user)
         post_response = self.view(post_request)
         self.assertEqual(post_response.status_code, 400)
-        self.assertEqual(post_response.content,
-                         "Node is not associated with the given DataSet")

--- a/refinery/data_set_manager/test_views.py
+++ b/refinery/data_set_manager/test_views.py
@@ -24,10 +24,14 @@ class AddFilesToDataSetViewTests(APITestCase):
 
         # Create Datasets
         self.data_set = create_dataset_with_necessary_models(user=self.user)
+        self.node = self.data_set.get_nodes()[0]
 
         self.post_request = self.factory.post(
             self.url_root,
-            data={'data_set_uuid': self.data_set.uuid},
+            data={
+                'data_set_uuid': self.data_set.uuid,
+                'node_uuid': self.node.uuid
+            },
             format="json"
         )
 

--- a/refinery/data_set_manager/test_views.py
+++ b/refinery/data_set_manager/test_views.py
@@ -6,7 +6,7 @@ from rest_framework.test import (APIClient, APIRequestFactory, APITestCase,
                                  force_authenticate)
 from factory_boy.utils import create_dataset_with_necessary_models
 
-from .views import AddFilesToDataSetView
+from .views import AddFileToNodeView
 
 
 class AddFilesToDataSetViewTests(APITestCase):
@@ -19,7 +19,7 @@ class AddFilesToDataSetViewTests(APITestCase):
         self.factory = APIRequestFactory()
         self.client = APIClient()
         self.url_root = '/api/v2/data_set_manager/add-files/'
-        self.view = AddFilesToDataSetView.as_view()
+        self.view = AddFileToNodeView.as_view()
         self.client.login(username=self.username, password=self.password)
 
         # Create Datasets

--- a/refinery/data_set_manager/urls.py
+++ b/refinery/data_set_manager/urls.py
@@ -11,7 +11,7 @@ from django.views.decorators.csrf import csrf_exempt
 from constants import UUID_RE
 from rest_framework.routers import DefaultRouter
 
-from .views import (AddFilesToDataSetView, Assays, AssaysAttributes,
+from .views import (AddFileToNodeView, Assays, AssaysAttributes,
                     AssaysFiles, CheckDataFilesView,
                     ChunkedFileUploadCompleteView, ChunkedFileUploadView,
                     DataSetImportView, ImportISATabView, ProcessISATabView,
@@ -54,6 +54,6 @@ data_set_manager_router.urls.extend([
         AssaysFiles.as_view()),
     url(r'^assays/(?P<uuid>' + UUID_RE + ')/attributes/$',
         AssaysAttributes.as_view()),
-    url(r'^data_set_manager/add-files/$',
-        AddFilesToDataSetView.as_view()),
+    url(r'^data_set_manager/add-file/$',
+        AddFileToNodeView.as_view()),
 ])

--- a/refinery/data_set_manager/utils.py
+++ b/refinery/data_set_manager/utils.py
@@ -602,10 +602,9 @@ def _index_annotated_nodes(node_type, study_uuid, assay_uuid=None,
     logger.info("%s nodes for indexing", str(nodes.count()))
     # index nodes
     start = time.time()
-    node_index = NodeIndex()
     counter = 0
     for node in nodes:
-        node_index.update_object(node, using="data_set_manager")
+        node.update_solr_index()
         counter += 1
     end = time.time()
     logger.info("%s nodes indexed in %s", str(counter), str(end - start))

--- a/refinery/data_set_manager/views.py
+++ b/refinery/data_set_manager/views.py
@@ -1039,7 +1039,7 @@ class AssaysAttributes(APIView):
             return Response(message, status=status.HTTP_401_UNAUTHORIZED)
 
 
-class AddFilesToDataSetView(APIView):
+class AddFileToNodeView(APIView):
     """Add file(s) to an existing data set from upload directory or bucket"""
     http_method_names = ['post']
 

--- a/refinery/data_set_manager/views.py
+++ b/refinery/data_set_manager/views.py
@@ -1064,14 +1064,16 @@ class AddFilesToDataSetView(APIView):
             file_store_item = node.get_file_store_item()
             if file_store_item is not None:
                 if not file_store_item.datafile.name:
-                    # Put Node into PENDING state in the UI
-                    file_store_item.import_task_id = ""
-                    file_store_item.save()
-                    NodeIndex().update_object(node, using="data_set_manager")
-
                     if (file_store_item.source.startswith(
                         (settings.REFINERY_DATA_IMPORT_DIR, 's3://')
                     )):
+                        # Put Node into PENDING state in the UI by removing
+                        # the associated FileStoreItem's import_task_id and
+                        # updating said Node's Solr index entry
+                        file_store_item.import_task_id = ""
+                        file_store_item.save()
+                        NodeIndex().update_object(node,
+                                                  using="data_set_manager")
                         import_file.delay(file_store_item.uuid)
 
         return HttpResponse(status=202)  # Accepted

--- a/refinery/data_set_manager/views.py
+++ b/refinery/data_set_manager/views.py
@@ -1061,6 +1061,12 @@ class AddFileToNodeView(APIView):
 
         logger.debug("Adding files to data set '%s'", data_set)
         node = get_object_or_404(Node, uuid=request.data.get('node_uuid'))
+
+        if node not in data_set.get_nodes():
+            return HttpResponseBadRequest(
+                "Node is not associated with the given DataSet"
+            )
+
         file_store_item = node.get_file_store_item()
         if (file_store_item and not file_store_item.datafile and
                 file_store_item.source.startswith(

--- a/refinery/data_set_manager/views.py
+++ b/refinery/data_set_manager/views.py
@@ -6,7 +6,6 @@ Created on May 11, 2012
 
 import json
 import logging
-
 import os
 import shutil
 import traceback

--- a/refinery/file_store/tasks.py
+++ b/refinery/file_store/tasks.py
@@ -18,7 +18,6 @@ from requests.exceptions import (ConnectionError, ContentDecodingError,
                                  HTTPError)
 
 from data_set_manager.models import Node
-from data_set_manager.search_indexes import NodeIndex
 
 from .models import FileStoreItem, _mkdir, get_temp_dir, parse_s3_url
 from .utils import S3MediaStorage, SymlinkedFileSystemStorage, _delete_file
@@ -347,7 +346,7 @@ def update_solr_index(**kwargs):
         logger.error("Could not retrieve Node with file UUID '%s': %s",
                      file_store_item_uuid, exc)
     else:
-        NodeIndex().update_object(node, using="data_set_manager")
+        node.update_solr_index()
         logger.info("Updated Solr index with file import state for Node '%s'",
                     node.uuid)
 

--- a/refinery/ui/source/js/data-set-import/controllers/file-upload-s3.js
+++ b/refinery/ui/source/js/data-set-import/controllers/file-upload-s3.js
@@ -92,7 +92,10 @@
         $scope.$apply(function () {
           file.success = true;
           if (vm.isNodeUpdate) {
-            addFileToDataSetService.update({ data_set_uuid: $window.dataSetUuid }).$promise
+            addFileToDataSetService.update({
+              data_set_uuid: $window.dataSetUuid,
+              node_uuid: vm.nodeUuid
+            }).$promise
               .then(function () {
                 vm.addFileStatus = 'success';
               }, function () {

--- a/refinery/ui/source/js/data-set-import/controllers/file-upload-s3.js
+++ b/refinery/ui/source/js/data-set-import/controllers/file-upload-s3.js
@@ -93,7 +93,6 @@
           file.success = true;
           if (vm.isNodeUpdate) {
             addFileToDataSetService.update({
-              data_set_uuid: $window.dataSetUuid,
               node_uuid: vm.nodeUuid
             }).$promise
               .then(function () {

--- a/refinery/ui/source/js/data-set-import/controllers/file-upload.js
+++ b/refinery/ui/source/js/data-set-import/controllers/file-upload.js
@@ -143,7 +143,6 @@ function RefineryFileUploadCtrl (
       }
       if (vm.isNodeUpdate) {
         addFileToDataSetService.update({
-          data_set_uuid: $window.dataSetUuid,
           node_uuid: vm.nodeUuid
         }).$promise
           .then(function () {

--- a/refinery/ui/source/js/data-set-import/controllers/file-upload.js
+++ b/refinery/ui/source/js/data-set-import/controllers/file-upload.js
@@ -142,7 +142,10 @@ function RefineryFileUploadCtrl (
         vm.overallFileStatus = fileUploadStatusService.setFileUploadStatus('queuing');
       }
       if (vm.isNodeUpdate) {
-        addFileToDataSetService.update({ data_set_uuid: $window.dataSetUuid }).$promise
+        addFileToDataSetService.update({
+          data_set_uuid: $window.dataSetUuid,
+          node_uuid: vm.nodeUuid
+        }).$promise
           .then(function () {
             vm.addFileStatus = 'success';
           }, function () {

--- a/refinery/ui/source/js/data-set-import/directives/file-upload-s3.js
+++ b/refinery/ui/source/js/data-set-import/directives/file-upload-s3.js
@@ -12,7 +12,8 @@
       restrict: 'E',
       bindToController: {
         isNodeUpdate: '=',
-        fileName: '='
+        fileName: '=',
+        nodeUuid: '='
       },
       controller: 'RefineryFileUploadS3Ctrl as FileCtrl',
       templateUrl: function () {

--- a/refinery/ui/source/js/data-set-import/directives/file-upload.js
+++ b/refinery/ui/source/js/data-set-import/directives/file-upload.js
@@ -12,7 +12,8 @@
       restrict: 'E',
       bindToController: {
         isNodeUpdate: '=',
-        fileName: '='
+        fileName: '=',
+        nodeUuid: '='
       },
       controller: 'RefineryFileUploadCtrl as FileCtrl',
       templateUrl: function () {

--- a/refinery/ui/source/js/data-set-import/services/add-file-to-data-set-service.js
+++ b/refinery/ui/source/js/data-set-import/services/add-file-to-data-set-service.js
@@ -20,8 +20,6 @@
       },
       {
        /* update: Add file to data set node
-            @params: data_set_uuid (req)
-            type: string
             @params: node_uuid (req)
             type: string
        */

--- a/refinery/ui/source/js/data-set-import/services/add-file-to-data-set-service.js
+++ b/refinery/ui/source/js/data-set-import/services/add-file-to-data-set-service.js
@@ -14,13 +14,15 @@
 
   function addFileToDataSetService ($resource, settings) {
     var addFile = $resource(
-      settings.appRoot + settings.refineryApiV2 + '/data_set_manager/add-files/',
+      settings.appRoot + settings.refineryApiV2 + '/data_set_manager/add-file/',
       {
         format: 'json'
       },
       {
        /* update: Add file to data set node
             @params: data_set_uuid (req)
+            type: string
+            @params: node_uuid (req)
             type: string
        */
         update: {

--- a/refinery/ui/source/js/data-set-import/services/add-file-to-data-set-service.spec.js
+++ b/refinery/ui/source/js/data-set-import/services/add-file-to-data-set-service.spec.js
@@ -39,7 +39,7 @@ describe('Common.service.addFileToDataSetService: unit tests', function () {
         .expectPOST(
           refinerySettings.appRoot +
           refinerySettings.refineryApiV2 +
-          '/data_set_manager/add-files/?format=json',
+          '/data_set_manager/add-file/?format=json',
           param
       ).respond(202, mockResponse);
 

--- a/refinery/ui/source/js/file-browser/ctrls/data-file-edit-modal-ctrl.js
+++ b/refinery/ui/source/js/file-browser/ctrls/data-file-edit-modal-ctrl.js
@@ -84,6 +84,7 @@
       var nameInternal = fileBrowserFactory.attributesNameKey.Name;
       vm.nodeURL = vm.resolve.config.nodeObj.REFINERY_DOWNLOAD_URL_s;
       vm.nodeName = vm.resolve.config.nodeObj[nameInternal];
+      vm.nodeUuid = vm.resolve.config.nodeObj.uuid;
 
       $scope.$watch(
         function () {

--- a/refinery/ui/source/js/file-browser/partials/data-file-edit-modal.html
+++ b/refinery/ui/source/js/file-browser/partials/data-file-edit-modal.html
@@ -26,11 +26,13 @@
         <rp-file-upload-s3
           is-node-update="true"
           file-name="$ctrl.nodeName"
+          node-uuid="$ctrl.nodeUuid"
           ng-if="$ctrl.useS3">
         </rp-file-upload-s3>
         <rp-file-upload
           is-node-update="true"
           file-name="$ctrl.nodeName"
+          node-uuid="$ctrl.nodeUuid"
           ng-if="!$ctrl.useS3">
         </rp-file-upload>
       </div>


### PR DESCRIPTION
Data files that were being added from the FileBrowser UI were not properly showing the `PENDING` state / Clock icon. This is problematic for users adding larger files since they would see a lightning bolt until said file's import task completed which could take a long time.

This PR fixes that problem, along with only running `import_file` tasks for a `DataSet's` `FileStoreItems` that don't have a datafile associated for easier future debugging of `AddFilesToDataSetView`.

Looking at the `AddFilesToDataSetView` it would be really great if we could send over a `Node` uuid along with the `data_set_uuid` that we are currently sending over so that we can run a single `import_file` task. The current solution spawns a number of `import_file` tasks dependent on the size of a `DataSet` making things hard to debug, and potentially hairy when DataSet sizes (number of `Nodes`) becomes large.

![jul-12-2018 15-58-05](https://user-images.githubusercontent.com/5629547/42656169-67a0c864-85ec-11e8-9677-8fc69e737b04.gif)
