### PR TITLE
Fix checking ownership by user perms not group.

### DIFF
--- a/refinery/core/api.py
+++ b/refinery/core/api.py
@@ -161,12 +161,13 @@ class SharableResourceAPIInterface(object):
                 )
 
         if cache_check is None:
+            # for ownership, don't check group perms
             owned_res_set = Set(
                 get_objects_for_user(
                     user,
-                    'core.share_%s' %
-                    self.res_type._meta.verbose_name).values_list("id",
-                                                                  flat=True))
+                    'core.add_%s' %
+                    self.res_type._meta.verbose_name,
+                    use_groups=False).values_list("id", flat=True))
 
             public_res_set = Set(
                 get_objects_for_group(
@@ -743,8 +744,9 @@ class DataSetResource(SharableResourceAPIInterface, ModelResource):
             if group.group == ExtendedGroup.objects.public_group():
                 is_public = True
 
+        # get_owner in core models uses add to distinguish owner
         is_owner = request.user.has_perm(
-            'core.share_dataset', ds
+            'core.add_dataset', ds
         )
 
         try:

--- a/refinery/core/api.py
+++ b/refinery/core/api.py
@@ -167,7 +167,8 @@ class SharableResourceAPIInterface(object):
                     user,
                     'core.add_%s' %
                     self.res_type._meta.verbose_name,
-                    use_groups=False).values_list("id", flat=True))
+                    use_groups=False
+                ).values_list("id", flat=True))
 
             public_res_set = Set(
                 get_objects_for_group(
@@ -745,9 +746,7 @@ class DataSetResource(SharableResourceAPIInterface, ModelResource):
                 is_public = True
 
         # get_owner in core models uses add to distinguish owner
-        is_owner = request.user.has_perm(
-            'core.add_dataset', ds
-        )
+        is_owner = request.user.has_perm('core.add_dataset', ds)
 
         try:
             user_uuid = request.user.profile.uuid

--- a/refinery/ui/source/js/data-set-about/partials/details.html
+++ b/refinery/ui/source/js/data-set-about/partials/details.html
@@ -397,24 +397,28 @@
     </a>
       - {{ADCtrl.fileStoreItem.file_size | fileSizeFormat}}
   </p>
-  <a
-    class="refinery-base btn btn-primary"
-    ng-if="ADCtrl.dataSet.is_owner"
-    ng-disabled="!ADCtrl.dataSet.is_clean"
-    href="/data_set_manager/import/?data_set_title={{ ADCtrl.dataSet.title }}/#/isa-tab-import?data_set_uuid={{ ADCtrl.dataSet.uuid }}">
-    Revise Metadata
-  </a>
-  <span class="p-l-1-3" ng-if="ADCtrl.dataSet.is_owner">
-    <a
-      popover-placement="right"
-      uib-popover-html="'Redirects to the Data Set Upload page where you
-      can upload revised metadata. <strong>Note:</strong> Once you have
-      run an analysis or visualization on a data set, its metadata can no longer be revised.'"
-      popover-title="Revise Meta Data"
-      popover-trigger="'outsideClick'"
-      popover-append-to-body="true">
-        <i class="fa fa-question-circle info-icon icon-only"></i>
-    </a>
+   <span
+     class="p-l-1"
+     ng-class="{banned: !FBCtrl.dataSet.is_clean}"
+     ng-if="ADCtrl.dataSet.is_owner">
+      <a
+        class="refinery-base btn btn-default"
+        ng-class="{disabledLink: !ADCtrl.dataSet.is_clean}"
+        href="/data_set_manager/import/?data_set_title={{ ADCtrl.dataSet.title }}/#/isa-tab-import?data_set_uuid={{ ADCtrl.dataSet.uuid }}">
+        Revise Metadata
+      </a>
+     </span>
+    <span class="p-l-1-3" ng-if="ADCtrl.dataSet.is_owner">
+      <a
+        popover-placement="right"
+        uib-popover-html="'Redirects to the Data Set Upload page where you
+        can upload revised metadata. <strong>Note:</strong> Once you have
+        run an analysis or visualization on a data set, its metadata can no longer be revised.'"
+        popover-title="Revise Metadata"
+        popover-trigger="'outsideClick'"
+        popover-append-to-body="true">
+          <i class="fa fa-question-circle info-icon icon-only"></i>
+      </a>
   </span>
 </div>
 <div ng-if="ADCtrl.dataSet.pre_isa_archive && ADCtrl.fileStoreItem.datafile">
@@ -429,13 +433,17 @@
   <p class="emphasized">Not available.</p>
 </div>
 <div ng-if="ADCtrl.dataSet.pre_isa_archive">
-   <a
-    class="refinery-base btn btn-primary"
-    ng-if="ADCtrl.dataSet.is_owner"
-    ng-disabled="!ADCtrl.dataSet.is_clean"
-    href="/data_set_manager/import/?data_set_title={{ ADCtrl.dataSet.title }}/#/?data_set_uuid={{ ADCtrl.dataSet.uuid }}">
-    Revise Metadata
-  </a>
+  <span
+     class="p-l-1"
+     ng-class="{banned: !FBCtrl.dataSet.is_clean}"
+     ng-if="ADCtrl.dataSet.is_owner">
+     <a
+      class="refinery-base btn btn-default"
+      ng-class="{disabledLink: !ADCtrl.dataSet.is_clean}"
+      href="/data_set_manager/import/?data_set_title={{ ADCtrl.dataSet.title }}/#/?data_set_uuid={{ ADCtrl.dataSet.uuid }}">
+      Revise Metadata
+    </a>
+  </span>
   <span class="p-l-1-3" ng-if="ADCtrl.dataSet.is_owner">
     <a
       popover-placement="right"
@@ -450,7 +458,7 @@
   </span>
 </div>
 
-<span class="refinery-subheader">
+<span class="refinery-subheader p-t-1-2">
   <h3>Data Files</h3>
 </span>
 <p>


### PR DESCRIPTION
Ref #2875 
- Fixes the issue in the file browser
- Prevents non-owners from deleting a data set
- For ownership, check add_ perms and don't use group_perms
- Also resolved #2884 

*Note, issues with cached data sets in the launch pad (uses api v1).