### PR TITLE
Jkmarx/move node related to data set manager

### DIFF
--- a/refinery/config/urls.py
+++ b/refinery/config/urls.py
@@ -11,7 +11,7 @@ from tastypie.api import Api
 from config.utils import RouterCombiner
 from core.api import (AnalysisResource, DataSetResource, ExtendedGroupResource,
                       GroupManagementResource, InvitationResource,
-                      NodeResource, ProjectResource, StatisticsResource,
+                      ProjectResource, StatisticsResource,
                       UserAuthenticationResource, UserProfileResource,
                       WorkflowResource)
 from core.forms import RegistrationFormWithCustomFields
@@ -19,7 +19,7 @@ from core.models import AuthenticationFormUsernameOrEmail
 from core.urls import core_router
 from core.views import CustomRegistrationView
 from data_set_manager.api import (AssayResource, AttributeResource,
-                                  InvestigationResource,
+                                  InvestigationResource, NodeResource,
                                   ProtocolReferenceParameterResource,
                                   ProtocolReferenceResource, ProtocolResource,
                                   PublicationResource, StudyResource)

--- a/refinery/core/api.py
+++ b/refinery/core/api.py
@@ -40,7 +40,7 @@ from tastypie.utils import trailing_slash
 
 from data_set_manager.api import (AssayResource, InvestigationResource,
                                   StudyResource)
-from data_set_manager.models import Attribute, Node, Study
+from data_set_manager.models import Study
 from file_store.models import FileStoreItem
 from .models import (Analysis, DataSet, ExtendedGroup, GroupManagement,
                      Invitation, Project, ResourceStatistics, Tutorials,
@@ -1054,71 +1054,6 @@ class AnalysisResource(ModelResource):
         if request.GET.get('meta_only'):
             return {'meta': data['meta']}
         return data
-
-
-class NodeResource(ModelResource):
-    parents = fields.ToManyField('core.api.NodeResource', 'parents')
-    children = fields.ToManyField('core.api.NodeResource', 'children')
-    study = fields.ToOneField('data_set_manager.api.StudyResource', 'study')
-    assay = fields.ToOneField('data_set_manager.api.AssayResource', 'assay',
-                              null=True)
-    attributes = fields.ToManyField(
-        'data_set_manager.api.AttributeResource',
-        attribute=lambda bundle: (
-            Attribute.objects
-            .exclude(value__isnull=True)
-            .exclude(value__exact='')
-            .filter(node=bundle.obj, subtype='organism')
-        ), use_in='all', full=True, null=True
-    )
-
-    class Meta:
-        queryset = Node.objects.all()
-        resource_name = 'node'
-        detail_uri_name = 'uuid'  # for using UUIDs instead of pk in URIs
-        # required for public data set access by anonymous users
-        authentication = Authentication()
-        authorization = Authorization()
-        allowed_methods = ['get']
-        fields = ['analysis_uuid', 'assay', 'attributes', 'children',
-                  'file_url', 'file_uuid', 'name', 'parents', 'study',
-                  'subanalysis', 'type', 'uuid']
-        filtering = {
-            'uuid': ALL,
-            'study': ALL_WITH_RELATIONS,
-            'assay': ALL_WITH_RELATIONS,
-            'file_uuid': ALL,
-            'type': ALL
-        }
-        limit = 0
-        max_limit = 0
-
-    def prepend_urls(self):
-        return [
-            url((r"^(?P<resource_name>%s)/(?P<uuid>" + UUID_RE + r")/$") %
-                self._meta.resource_name,
-                self.wrap_view('dispatch_detail'),
-                name="api_dispatch_detail"),
-        ]
-
-    def dehydrate(self, bundle):
-        # return download URL of file if a file is associated with the node
-        try:
-            file_item = FileStoreItem.objects.get(uuid=bundle.obj.file_uuid)
-        except AttributeError:
-            logger.warning("No UUID provided")
-            bundle.data['file_url'] = None
-            bundle.data['file_import_status'] = None
-        except FileStoreItem.DoesNotExist:
-            logger.warning(
-                "Unable to find file store item with UUID '%s'",
-                bundle.obj.file_uuid)
-            bundle.data['file_url'] = None
-            bundle.data['file_import_status'] = None
-        else:
-            bundle.data['file_url'] = file_item.get_datafile_url()
-            bundle.data['file_import_status'] = file_item.get_import_status()
-        return bundle
 
 
 class StatisticsResource(Resource):

--- a/refinery/core/serializers.py
+++ b/refinery/core/serializers.py
@@ -4,8 +4,6 @@ from django.conf import settings
 from rest_framework import serializers
 from rest_framework.validators import UniqueValidator
 
-from data_set_manager.models import Node
-
 from .models import DataSet, Event, User, UserProfile, Workflow
 
 logger = logging.getLogger(__name__)
@@ -113,16 +111,6 @@ class WorkflowSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = Workflow
-
-
-class NodeSerializer(serializers.ModelSerializer):
-    file_uuid = serializers.CharField(max_length=36,
-                                      required=False,
-                                      allow_null=True)
-
-    class Meta:
-        model = Node
-        fields = ('uuid', 'file_uuid')
 
 
 class EventSerializer(serializers.ModelSerializer):

--- a/refinery/core/test_api.py
+++ b/refinery/core/test_api.py
@@ -11,8 +11,10 @@ from guardian.shortcuts import assign_perm
 from tastypie.exceptions import NotFound
 from tastypie.test import ResourceTestCase
 
+from data_set_manager.api import NodeResource
 from data_set_manager.models import Investigation, Study
-from .api import AnalysisResource, DataSetResource, NodeResource
+
+from .api import AnalysisResource, DataSetResource
 from .models import (Analysis, Node, Project, UserProfile, Workflow,
                      WorkflowEngine)
 

--- a/refinery/core/urls.py
+++ b/refinery/core/urls.py
@@ -10,8 +10,7 @@ from constants import UUID_RE
 from rest_framework.routers import DefaultRouter
 
 from .views import (AnalysesViewSet, DataSetsViewSet, EventViewSet,
-                    NodeViewSet, OpenIDToken, UserProfileViewSet,
-                    WorkflowViewSet)
+                    OpenIDToken, UserProfileViewSet, WorkflowViewSet)
 
 urlpatterns = patterns(
     'core.views',
@@ -84,8 +83,6 @@ core_router.urls.extend([
         DataSetsViewSet.as_view()),
     url(r'^analyses/(?P<uuid>' + UUID_RE + r')/$',
         AnalysesViewSet.as_view()),
-    url(r'^nodes/(?P<uuid>' + UUID_RE + r')/$',
-        NodeViewSet.as_view()),
     url(r'^openid_token/$',
         OpenIDToken.as_view(), name="openid-token")
 ])

--- a/refinery/data_set_manager/api.py
+++ b/refinery/data_set_manager/api.py
@@ -3,14 +3,24 @@ Created on Nov 29, 2012
 
 @author: nils
 '''
+import logging
 
+from django.conf.urls import url
+
+from constants import UUID_RE
 from tastypie import fields
+from tastypie.authentication import Authentication
+from tastypie.authorization import Authorization
 from tastypie.constants import ALL, ALL_WITH_RELATIONS
 from tastypie.resources import ModelResource
+
+from file_store.models import FileStoreItem
 
 from .models import (Assay, Attribute, Investigation, Node, Protocol,
                      ProtocolReference, ProtocolReferenceParameter,
                      Publication, Study)
+
+logger = logging.getLogger(__name__)
 
 
 class AttributeResource(ModelResource):
@@ -35,6 +45,71 @@ class AttributeResource(ModelResource):
             'value_source',
             'value_unit'
         ]
+
+
+class NodeResource(ModelResource):
+    parents = fields.ToManyField('core.api.NodeResource', 'parents')
+    children = fields.ToManyField('core.api.NodeResource', 'children')
+    study = fields.ToOneField('data_set_manager.api.StudyResource', 'study')
+    assay = fields.ToOneField('data_set_manager.api.AssayResource', 'assay',
+                              null=True)
+    attributes = fields.ToManyField(
+        'data_set_manager.api.AttributeResource',
+        attribute=lambda bundle: (
+            Attribute.objects
+            .exclude(value__isnull=True)
+            .exclude(value__exact='')
+            .filter(node=bundle.obj, subtype='organism')
+        ), use_in='all', full=True, null=True
+    )
+
+    class Meta:
+        queryset = Node.objects.all()
+        resource_name = 'node'
+        detail_uri_name = 'uuid'  # for using UUIDs instead of pk in URIs
+        # required for public data set access by anonymous users
+        authentication = Authentication()
+        authorization = Authorization()
+        allowed_methods = ['get']
+        fields = ['analysis_uuid', 'assay', 'attributes', 'children',
+                  'file_url', 'file_uuid', 'name', 'parents', 'study',
+                  'subanalysis', 'type', 'uuid']
+        filtering = {
+            'uuid': ALL,
+            'study': ALL_WITH_RELATIONS,
+            'assay': ALL_WITH_RELATIONS,
+            'file_uuid': ALL,
+            'type': ALL
+        }
+        limit = 0
+        max_limit = 0
+
+    def prepend_urls(self):
+        return [
+            url((r"^(?P<resource_name>%s)/(?P<uuid>" + UUID_RE + r")/$") %
+                self._meta.resource_name,
+                self.wrap_view('dispatch_detail'),
+                name="api_dispatch_detail"),
+        ]
+
+    def dehydrate(self, bundle):
+        # return download URL of file if a file is associated with the node
+        try:
+            file_item = FileStoreItem.objects.get(uuid=bundle.obj.file_uuid)
+        except AttributeError:
+            logger.warning("No UUID provided")
+            bundle.data['file_url'] = None
+            bundle.data['file_import_status'] = None
+        except FileStoreItem.DoesNotExist:
+            logger.warning(
+                "Unable to find file store item with UUID '%s'",
+                bundle.obj.file_uuid)
+            bundle.data['file_url'] = None
+            bundle.data['file_import_status'] = None
+        else:
+            bundle.data['file_url'] = file_item.get_datafile_url()
+            bundle.data['file_import_status'] = file_item.get_import_status()
+        return bundle
 
 
 class InvestigationResource(ModelResource):

--- a/refinery/data_set_manager/serializers.py
+++ b/refinery/data_set_manager/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from .models import Assay, AttributeOrder
+from .models import Assay, AttributeOrder, Node
 
 
 class AssaySerializer(serializers.ModelSerializer):
@@ -35,3 +35,13 @@ class AttributeOrderSerializer(serializers.ModelSerializer):
                                                 instance.is_active)
         instance.save()
         return instance
+
+
+class NodeSerializer(serializers.ModelSerializer):
+    file_uuid = serializers.CharField(max_length=36,
+                                      required=False,
+                                      allow_null=True)
+
+    class Meta:
+        model = Node
+        fields = ('uuid', 'file_uuid')

--- a/refinery/data_set_manager/urls.py
+++ b/refinery/data_set_manager/urls.py
@@ -14,8 +14,9 @@ from rest_framework.routers import DefaultRouter
 from .views import (AddFileToNodeView, Assays, AssaysAttributes,
                     AssaysFiles, CheckDataFilesView,
                     ChunkedFileUploadCompleteView, ChunkedFileUploadView,
-                    DataSetImportView, ImportISATabView, ProcessISATabView,
-                    ProcessMetadataTableView, TakeOwnershipOfPublicDatasetView)
+                    DataSetImportView, ImportISATabView, NodeViewSet,
+                    ProcessISATabView, ProcessMetadataTableView,
+                    TakeOwnershipOfPublicDatasetView)
 
 urlpatterns = patterns(
     'data_set_manager.views',
@@ -56,4 +57,6 @@ data_set_manager_router.urls.extend([
         AssaysAttributes.as_view()),
     url(r'^data_set_manager/add-file/$',
         AddFileToNodeView.as_view()),
+    url(r'^nodes/(?P<uuid>' + UUID_RE + r')/$',
+        NodeViewSet.as_view()),
 ])


### PR DESCRIPTION
Resolves #2837 

- Node related code was moved from the core module to the data_set_manager. (No new code was introduced.)
- API V1, API V2, Serializer, API V1 Unit tests
* API V2 Unit test will be written in a separate pull request.