### PR TITLE
Missing quote mark in ERB template

### DIFF
--- a/deployment/aws-config/config.yaml.erb
+++ b/deployment/aws-config/config.yaml.erb
@@ -38,7 +38,7 @@ COGNITO_IDENTITY_POOL_ID: "<%= tf.identity_pool_id %>"
 VPC_ID: "<%= tf.vpc_id %>"
 PUBLIC_SUBNET_ID: "<%= tf.public_subnet_id %>"
 RDS_DB_SUBNET_GROUP_NAME: "<%= tf.rds_db_subnet_group_name %>"
-REFINERY_DOCKER_HOST: "<%= tf.docker_hostname %>
+REFINERY_DOCKER_HOST: "<%= tf.docker_hostname %>"
 
 # Prefix for all S3 bucket names (must not be shared among stacks)
 # Constraint: DNS-compliant without periods (".")


### PR DESCRIPTION
I'm a little curious why this wasn't noticed earlier... that line is from me a while ago, and I wouldn't think we'd have been filling it in by hand since then?