### PR TITLE
Update indexing logic to handle for unknown file_import tasks

### DIFF
--- a/refinery/data_set_manager/search_indexes.py
+++ b/refinery/data_set_manager/search_indexes.py
@@ -197,11 +197,11 @@ def _get_download_url_or_import_state(file_store_item):
 
     # "PENDING" if an import_task_id doesn't exist and
     # there is no valid download_url
-    import_state = file_store_item.get_import_status()
     if not file_store_item.import_task_id:
         return celery.states.PENDING
 
     # "N/A" if the import_state is in a "READY_STATE" or "PENDING" with an
     # import_task_id and without a valid download_url
+    import_state = file_store_item.get_import_status()
     if import_state in {celery.states.PENDING} | celery.states.READY_STATES:
         return constants.NOT_AVAILABLE

--- a/refinery/data_set_manager/search_indexes.py
+++ b/refinery/data_set_manager/search_indexes.py
@@ -181,6 +181,17 @@ class NodeIndex(indexes.SearchIndex, indexes.Indexable):
 
 
 def _get_download_url_or_import_state(file_store_item):
+    """
+    Discerns the download url or file import state for a given FileStoreItem
+    :param file_store_item: A FileStoreItem instance
+    :returns <String>:
+        - a valid url pointing to the FileStoreItem's datafile
+        - constants.NOT_AVAILABLE if the FileStoreItem's import_state is in
+        celery.READY_STATES w/o a valid url available or if there is no
+        available task information for said FileStoreItem's import_file task
+        - celery.states.PENDING if a FileStoreItem's import_file task hasn't
+        started yet
+    """
     download_url = constants.NOT_AVAILABLE
     if file_store_item is not None:
         download_url = file_store_item.get_datafile_url()

--- a/refinery/data_set_manager/search_indexes.py
+++ b/refinery/data_set_manager/search_indexes.py
@@ -202,6 +202,8 @@ def _get_download_url_or_import_state(file_store_item):
                 # download url
                 import_state = constants.NOT_AVAILABLE
             else:
+                if not file_store_item.import_task_id:
+                    return celery.states.PENDING
                 # The underlying Celery code in
                 # FileStoreItem.get_import_status() makes an assumption
                 # that a result is "probably" PENDING even if it can't

--- a/refinery/data_set_manager/search_indexes.py
+++ b/refinery/data_set_manager/search_indexes.py
@@ -211,15 +211,14 @@ def _get_download_url_or_import_state(file_store_item):
                 # https://github.com/celery/celery/blob/v3.1.20/celery/
                 # backends/amqp.py#L192-L193 So we double check here to
                 # make sure said assumption holds up
-                if file_store_item.import_task_id:
-                    try:
-                        TaskMeta.objects.get(
-                            task_id=file_store_item.import_task_id
-                        )
-                    except TaskMeta.DoesNotExist:
-                        logger.debug("No file_import task for FileStoreItem "
-                                     "with UUID: %s", file_store_item.uuid)
-                        import_state = constants.NOT_AVAILABLE
+                try:
+                    TaskMeta.objects.get(
+                        task_id=file_store_item.import_task_id
+                    )
+                except TaskMeta.DoesNotExist:
+                    logger.debug("No file_import task for FileStoreItem "
+                                 "with UUID: %s", file_store_item.uuid)
+                    import_state = constants.NOT_AVAILABLE
                 else:
                     import_state = celery.states.PENDING
             return import_state

--- a/refinery/data_set_manager/search_indexes.py
+++ b/refinery/data_set_manager/search_indexes.py
@@ -198,17 +198,15 @@ def _get_download_url_or_import_state(file_store_item):
                 # https://github.com/celery/celery/blob/v3.1.20/celery/
                 # backends/amqp.py#L192-L193 So we double check here to
                 # make sure said assumption holds up
-                try:
-                    TaskMeta.objects.get(
-                        task_id=file_store_item.import_task_id
-                    )
-                except TaskMeta.DoesNotExist:
-                    logger.debug(
-                        "No file_import task for FileStoreItem with "
-                        "UUID: %s",
-                        file_store_item.uuid
-                    )
-                    import_state = constants.NOT_AVAILABLE
+                if file_store_item.import_task_id:
+                    try:
+                        TaskMeta.objects.get(
+                            task_id=file_store_item.import_task_id
+                        )
+                    except TaskMeta.DoesNotExist:
+                        logger.debug("No file_import task for FileStoreItem "
+                                     "with UUID: %s", file_store_item.uuid)
+                        import_state = constants.NOT_AVAILABLE
                 else:
                     import_state = celery.states.PENDING
             return import_state

--- a/refinery/data_set_manager/tests.py
+++ b/refinery/data_set_manager/tests.py
@@ -1522,7 +1522,7 @@ class NodeIndexTests(APITestCase):
                                return_value=PENDING):
             self._assert_node_index_prepared_correctly(
                 self._prepare_node_index(self.node),
-                expected_download_url=PENDING
+                expected_download_url=constants.NOT_AVAILABLE
             )
 
     def test_prepare_node_pending_non_existent_file_import_task(self):


### PR DESCRIPTION
We should do something more elegant like utilizing celery's available signal: `task_published` signal, updating the state of published tasks to something we decide (`SENT`, `PUBLISHED` etc.) which would then allow us to treat the `PENDING` state that celery is assigning as a true "unknown" state. This would also lessen the `djcelery` package's grip on us.

To be able to achieve something like this, we first have to get our existing file import tasks in a good state (no pun intended) and properly categorized (Removal of false `PENDINGS`).


**Note: these changes warrant another run of: `./manage.py update_index`**