### PR TITLE
Scottx611x/fix refinery import pending state all local inputs

### DIFF
--- a/refinery/analysis_manager/models.py
+++ b/refinery/analysis_manager/models.py
@@ -70,7 +70,10 @@ class AnalysisStatus(models.Model):
             raise ValueError("Invalid Galaxy history state given")
 
     def refinery_import_state(self):
-        return get_task_group_state(self.refinery_import_task_group_id)
+        if self.analysis.has_all_local_input_files():
+            return [{'state': celery.states.SUCCESS, 'percent_done': 100}]
+        else:
+            return get_task_group_state(self.refinery_import_task_group_id)
 
     def galaxy_file_import_state(self):
         if self.galaxy_import_state and self.galaxy_import_progress != 0:

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -1522,6 +1522,10 @@ class Analysis(OwnableResource):
             workflow_output=analysis_node_connection.name
         )
 
+    def has_all_local_input_files(self):
+        return all(file_store_item.is_local() for file_store_item in
+                   self._get_input_file_store_items())
+
     def _get_input_nodes(self):
         return [analysis_node_connection.node for analysis_node_connection in
                 AnalysisNodeConnection.objects.filter(

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -1522,17 +1522,18 @@ class Analysis(OwnableResource):
             workflow_output=analysis_node_connection.name
         )
 
-    def _get_input_node(self):
-        return AnalysisNodeConnection.objects.filter(
-            analysis=self,
-            direction=INPUT_CONNECTION
-        ).first().node
+    def _get_input_nodes(self):
+        return [analysis_node_connection.node for analysis_node_connection in
+                AnalysisNodeConnection.objects.filter(
+                    analysis=self, direction=INPUT_CONNECTION
+                )]
+
 
     def get_input_node_study(self):
-        return self._get_input_node().study
+        return self._get_input_nodes()[0].study
 
     def get_input_node_assay(self):
-        return self._get_input_node().assay
+        return self._get_input_nodes()[0].assay
 
     def _create_data_transformation_nodes(self, graph):
         """create data transformation nodes for all Tool nodes"""

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -1528,6 +1528,9 @@ class Analysis(OwnableResource):
                     analysis=self, direction=INPUT_CONNECTION
                 )]
 
+    def _get_input_file_store_items(self):
+        return [node.get_file_store_item()
+                for node in self._get_input_nodes()]
 
     def get_input_node_study(self):
         return self._get_input_nodes()[0].study

--- a/refinery/core/tests.py
+++ b/refinery/core/tests.py
@@ -754,6 +754,10 @@ class AnalysisTests(TestCase):
         self.assertEqual(derived_data_file_node.workflow_output,
                          self.analysis_node_connection_a.name)
 
+    def test__get_input_nodes(self):
+        analysis = self.analysis_with_node_analyzed_further
+        self.assertEqual(analysis._get_input_nodes(), [self.node2])
+
 
 class UtilitiesTest(TestCase):
     def setUp(self):

--- a/refinery/core/tests.py
+++ b/refinery/core/tests.py
@@ -758,6 +758,12 @@ class AnalysisTests(TestCase):
         analysis = self.analysis_with_node_analyzed_further
         self.assertEqual(analysis._get_input_nodes(), [self.node2])
 
+    def test__get_input_file_store_items(self):
+        analysis = self.analysis_with_node_analyzed_further
+        self.assertEqual(
+            analysis._get_input_file_store_items(),
+            [self.node2.get_file_store_item()]
+        )
 
 class UtilitiesTest(TestCase):
     def setUp(self):

--- a/refinery/core/tests.py
+++ b/refinery/core/tests.py
@@ -765,6 +765,16 @@ class AnalysisTests(TestCase):
             [self.node2.get_file_store_item()]
         )
 
+    def test_has_all_local_input_files_non_local_inputs(self):
+        analysis = self.analysis_with_node_analyzed_further
+        node = analysis._get_input_nodes()[0]
+        node.get_file_store_item().delete_datafile()
+        self.assertFalse(analysis.has_all_local_input_files())
+
+    def test_has_all_local_input_files(self):
+        self.assertTrue(self.analysis.has_all_local_input_files())
+
+
 class UtilitiesTest(TestCase):
     def setUp(self):
         investigation = Investigation.objects.create()


### PR DESCRIPTION
Handles for the case where the Refinery Import State remains `PENDING` in the Analysis Monitoring UI when all inputs for an Analysis have already been imported into Refinery.

Before:
![screen shot 2018-08-30 at 2 49 47 pm](https://user-images.githubusercontent.com/5629547/44877877-57db3380-ac73-11e8-93ca-bf82ebe682fa.png)

After:
![screen shot 2018-08-30 at 4 41 56 pm](https://user-images.githubusercontent.com/5629547/44877971-a7b9fa80-ac73-11e8-9e9b-2abe569387f3.png)
