### PR TITLE
Scottx611x/fix add users to public group timeout

### DIFF
--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -133,15 +133,16 @@ post_save.connect(create_user_profile, sender=User)
 
 
 @receiver(post_save, sender=User)
-def add_user_to_public_group(sender, **kwargs):
-    """Add users to Public group automatically"""
-    user = kwargs["instance"]
+def add_user_to_public_group(sender, instance, created, **kwargs):
+    """Add users to Public group automatically
+
+    """
     public_group = ExtendedGroup.objects.public_group()
     # need to check if Public group exists to avoid errors when creating
     # user accounts (like superuser and AnonymousUser) before the group
     # is created by init_refinery command
-    if public_group and user not in public_group.user_set.all():
-        user.groups.add(public_group)
+    if public_group:
+        instance.groups.add(public_group)
 
 
 def create_user_profile_registered(sender, user, request, **kwargs):

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -1977,17 +1977,18 @@ class Invitation(models.Model):
 def _add_user_to_neo4j(sender, **kwargs):
     user = kwargs['instance']
 
-    add_or_update_user_to_neo4j(user.id, user.username)
-    add_read_access_in_neo4j(
-        map(
-            lambda ds: ds.uuid, get_objects_for_group(
-                ExtendedGroup.objects.public_group(),
-                'core.read_dataset'
-            )
-        ),
-        [user.id]
-    )
-    sync_update_annotation_sets_neo4j(user.username)
+    if kwargs['created']:
+        add_or_update_user_to_neo4j(user.id, user.username)
+        add_read_access_in_neo4j(
+            map(
+                lambda ds: ds.uuid, get_objects_for_group(
+                    ExtendedGroup.objects.public_group(),
+                    'core.read_dataset'
+                )
+            ),
+            [user.id]
+        )
+        sync_update_annotation_sets_neo4j(user.username)
 
 
 @receiver(pre_delete, sender=User)

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -133,16 +133,15 @@ post_save.connect(create_user_profile, sender=User)
 
 
 @receiver(post_save, sender=User)
-def add_user_to_public_group(sender, instance, created, **kwargs):
-    """Add users to Public group automatically
-
-    """
+def add_user_to_public_group(sender, **kwargs):
+    """Add users to Public group automatically"""
+    user = kwargs["instance"]
     public_group = ExtendedGroup.objects.public_group()
     # need to check if Public group exists to avoid errors when creating
     # user accounts (like superuser and AnonymousUser) before the group
     # is created by init_refinery command
-    if public_group:
-        instance.groups.add(public_group)
+    if public_group and user not in public_group.user_set.all():
+        user.groups.add(public_group)
 
 
 def create_user_profile_registered(sender, user, request, **kwargs):

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -1978,7 +1978,7 @@ class Invitation(models.Model):
 def _add_user_to_neo4j(sender, **kwargs):
     user = kwargs['instance']
 
-    if kwargs['created']:
+    if user.is_active:
         add_or_update_user_to_neo4j(user.id, user.username)
         add_read_access_in_neo4j(
             map(

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -1978,18 +1978,21 @@ class Invitation(models.Model):
 def _add_user_to_neo4j(sender, **kwargs):
     user = kwargs['instance']
 
-    if user.is_active:
-        add_or_update_user_to_neo4j(user.id, user.username)
-        add_read_access_in_neo4j(
-            map(
-                lambda ds: ds.uuid, get_objects_for_group(
-                    ExtendedGroup.objects.public_group(),
-                    'core.read_dataset'
-                )
-            ),
-            [user.id]
-        )
-        sync_update_annotation_sets_neo4j(user.username)
+    if not user.is_active:
+        logger.debug("User: %s has not been activated. Not adding them to "
+                     "Neo4J.", user.username)
+        return
+    add_or_update_user_to_neo4j(user.id, user.username)
+    add_read_access_in_neo4j(
+        map(
+            lambda ds: ds.uuid, get_objects_for_group(
+                ExtendedGroup.objects.public_group(),
+                'core.read_dataset'
+            )
+        ),
+        [user.id]
+    )
+    sync_update_annotation_sets_neo4j(user.username)
 
 
 @receiver(pre_delete, sender=User)


### PR DESCRIPTION
While trying to deploy an AWS instance for `hotfix-1.6.6.1` I consistently ran into a timeout that didn't allow for the Puppet manifest to apply completely. 

This is due to the fact that we have a bunch of spam `User` instances hanging around and for each `user.save()` being called within the `add_users_to_public_group` mgmt command `_add_user_to_neo4j` is being run unnecessairily.

This PR only adds a user to neo4j on a `User.post_save` signal being hit if we have activated said user prior.