### PR TITLE
Jkmarx/api prevent internal updates

### DIFF
--- a/refinery/core/views.py
+++ b/refinery/core/views.py
@@ -284,9 +284,7 @@ def data_set(request, data_set_uuid, analysis_uuid=None):
             "workflows": workflows,
             "isatab_archive": investigation.get_file_store_item(),
             "pre_isatab_archive": investigation.get_file_store_item(),
-            "attribute_edit_types": '{}'.format(
-                Attribute.editable_types.join(',')
-            )
+            "attribute_edit_types": ','.join(Attribute.editable_types)
         },
         context_instance=RequestContext(request))
 

--- a/refinery/core/views.py
+++ b/refinery/core/views.py
@@ -284,12 +284,8 @@ def data_set(request, data_set_uuid, analysis_uuid=None):
             "workflows": workflows,
             "isatab_archive": investigation.get_file_store_item(),
             "pre_isatab_archive": investigation.get_file_store_item(),
-            "attribute_edit_types": '{},{},{},{},{}'.format(
-                Attribute.MATERIAL_TYPE,
-                Attribute.CHARACTERISTICS,
-                Attribute.FACTOR_VALUE,
-                Attribute.LABEL,
-                Attribute.COMMENT
+            "attribute_edit_types": '{}'.format(
+                Attribute.get_editable_types().join(',')
             )
         },
         context_instance=RequestContext(request))

--- a/refinery/core/views.py
+++ b/refinery/core/views.py
@@ -44,6 +44,8 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 import xmltodict
 
+from data_set_manager.models import Attribute
+
 from .forms import UserForm, UserProfileForm, WorkflowForm
 from .models import (Analysis, CustomRegistrationProfile, DataSet, Event,
                      ExtendedGroup, Invitation, Ontology, SiteStatistics,
@@ -282,6 +284,13 @@ def data_set(request, data_set_uuid, analysis_uuid=None):
             "workflows": workflows,
             "isatab_archive": investigation.get_file_store_item(),
             "pre_isatab_archive": investigation.get_file_store_item(),
+            "attribute_edit_types": '{},{},{},{},{}'.format(
+                Attribute.MATERIAL_TYPE,
+                Attribute.CHARACTERISTICS,
+                Attribute.FACTOR_VALUE,
+                Attribute.LABEL,
+                Attribute.COMMENT
+            )
         },
         context_instance=RequestContext(request))
 

--- a/refinery/core/views.py
+++ b/refinery/core/views.py
@@ -285,7 +285,7 @@ def data_set(request, data_set_uuid, analysis_uuid=None):
             "isatab_archive": investigation.get_file_store_item(),
             "pre_isatab_archive": investigation.get_file_store_item(),
             "attribute_edit_types": '{}'.format(
-                Attribute.get_editable_types().join(',')
+                Attribute.editable_types.join(',')
             )
         },
         context_instance=RequestContext(request))

--- a/refinery/data_set_manager/models.py
+++ b/refinery/data_set_manager/models.py
@@ -780,6 +780,13 @@ class Attribute(models.Model):
             unicode(self.value)
         )
 
+    def get_editable_types(self):
+        """
+        Return a list of the attribute's editable type
+        """
+        return [self.MATERIAL_TYPE, self.CHARACTERISTICS, self.FACTOR_VALUE,
+                self.LABEL, self.COMMENT]
+
 
 # non-ISA Tab
 class AttributeDefinition(models.Model):

--- a/refinery/data_set_manager/models.py
+++ b/refinery/data_set_manager/models.py
@@ -736,6 +736,9 @@ class Attribute(models.Model):
     LABEL = "Label"
     COMMENT = "Comment"
 
+    editable_types = [MATERIAL_TYPE, CHARACTERISTICS, FACTOR_VALUE, LABEL,
+                      COMMENT]
+
     TYPES = {MATERIAL_TYPE, CHARACTERISTICS, FACTOR_VALUE, LABEL, COMMENT}
 
     ALL_FIELDS = [
@@ -779,13 +782,6 @@ class Attribute(models.Model):
             " = " +
             unicode(self.value)
         )
-
-    def get_editable_types(self):
-        """
-        Return a list of the attribute's editable type
-        """
-        return [self.MATERIAL_TYPE, self.CHARACTERISTICS, self.FACTOR_VALUE,
-                self.LABEL, self.COMMENT]
 
 
 # non-ISA Tab

--- a/refinery/data_set_manager/test_views.py
+++ b/refinery/data_set_manager/test_views.py
@@ -932,6 +932,23 @@ class NodeViewAPIV2Tests(APIV2TestCase):
         self.assertEqual(patch_response.status_code, 405)
 
     @mock.patch('data_set_manager.models.Node.update_solr_index')
+    def test_patch_return_405_non_edit_attributes(self,
+                                                  update_solr_index_mock):
+        node = self.hg_19_data_set.get_nodes().filter(
+            type=Node.RAW_DATA_FILE
+        )[0]
+        solr_name = '{}_{}_652_326_s'.format('REFINERY_NAME',
+                                             'Internal')
+        patch_request = self.factory.patch(
+            urljoin(self.url_root, node.uuid),
+            {"attribute_solr_name": solr_name,
+             "attribute_value": 'New Name'}
+        )
+        force_authenticate(patch_request, user=self.user)
+        patch_response = self.view(patch_request, node.uuid)
+        self.assertEqual(patch_response.status_code, 400)
+
+    @mock.patch('data_set_manager.models.Node.update_solr_index')
     def test_patch_edit_annotated_node(self, update_solr_index_mock):
         nodes = self.isatab_9909_data_set.get_nodes()
         file_node = nodes.filter(

--- a/refinery/data_set_manager/test_views.py
+++ b/refinery/data_set_manager/test_views.py
@@ -932,7 +932,7 @@ class NodeViewAPIV2Tests(APIV2TestCase):
         self.assertEqual(patch_response.status_code, 405)
 
     @mock.patch('data_set_manager.models.Node.update_solr_index')
-    def test_patch_return_405_non_edit_attributes(self,
+    def test_patch_return_400_non_edit_attributes(self,
                                                   update_solr_index_mock):
         node = self.hg_19_data_set.get_nodes().filter(
             type=Node.RAW_DATA_FILE

--- a/refinery/data_set_manager/utils.py
+++ b/refinery/data_set_manager/utils.py
@@ -816,7 +816,7 @@ def customize_attribute_response(facet_fields):
 
         field_edit_type = ''
         field_normalized = field.replace('_', ' ')
-        for edit_type in Attribute.get_editable_types():
+        for edit_type in Attribute.editable_types:
             if edit_type in field_normalized:
                 field_edit_type = edit_type
                 break

--- a/refinery/data_set_manager/utils.py
+++ b/refinery/data_set_manager/utils.py
@@ -814,15 +814,9 @@ def customize_attribute_response(facet_fields):
         if len(field_name) > 1:
             customized_field['file_ext'] = field_name[-1]
 
-        attribute_edit_types = [Attribute.MATERIAL_TYPE,
-                                Attribute.CHARACTERISTICS,
-                                Attribute.FACTOR_VALUE,
-                                Attribute.LABEL,
-                                Attribute.COMMENT]
-
         field_edit_type = ''
         field_normalized = field.replace('_', ' ')
-        for edit_type in attribute_edit_types:
+        for edit_type in Attribute.get_editable_types():
             if edit_type in field_normalized:
                 field_edit_type = edit_type
                 break

--- a/refinery/data_set_manager/utils.py
+++ b/refinery/data_set_manager/utils.py
@@ -814,6 +814,19 @@ def customize_attribute_response(facet_fields):
         if len(field_name) > 1:
             customized_field['file_ext'] = field_name[-1]
 
+        attribute_edit_types = [Attribute.MATERIAL_TYPE,
+                                Attribute.CHARACTERISTICS,
+                                Attribute.FACTOR_VALUE,
+                                Attribute.LABEL,
+                                Attribute.COMMENT]
+
+        field_edit_type = ''
+        field_normalized = field.replace('_', ' ')
+        for edit_type in attribute_edit_types:
+            if edit_type in field_normalized:
+                field_edit_type = edit_type
+                break
+
         if 'REFINERY_SUBANALYSIS' in field:
             customized_field['display_name'] = 'Analysis Group'
             customized_field['attribute_type'] = 'Internal'
@@ -826,21 +839,12 @@ def customize_attribute_response(facet_fields):
         elif 'REFINERY' in field:
             customized_field['display_name'] = field_name[1].title()
             customized_field['attribute_type'] = 'Internal'
-        elif 'Comment' in field:
-            index = field_name.index('Comment')
-            field_name = ' '.join(field_name[0:index])
+        elif field_edit_type:
+            index = field_name.index(field_edit_type.split(' ')[0])
+            # some attributes don't have a name hence the default 1
+            field_name = ' '.join(field_name[0:index or 1])
             customized_field['display_name'] = field_name.title()
-            customized_field['attribute_type'] = 'Comment'
-        elif 'Factor' in field:
-            index = field_name.index('Factor')
-            field_name = ' '.join(field_name[0:index])
-            customized_field['display_name'] = field_name.title()
-            customized_field['attribute_type'] = 'Factor Value'
-        elif 'Characteristics' in field:
-            index = field_name.index('Characteristics')
-            field_name = ' '.join(field_name[0:index])
-            customized_field['display_name'] = field_name.title()
-            customized_field['attribute_type'] = 'Characteristics'
+            customized_field['attribute_type'] = field_edit_type
         # For uuid fields
         elif len(field_name) == 1:
             customized_field['display_name'] = \

--- a/refinery/data_set_manager/views.py
+++ b/refinery/data_set_manager/views.py
@@ -39,7 +39,8 @@ from file_store.models import (FileStoreItem, generate_file_source_translator,
 from file_store.tasks import FileImportTask, download_file
 from file_store.utils import parse_s3_url
 
-from .models import AnnotatedNode, Assay, AttributeOrder, Node, Study
+from .models import (AnnotatedNode, Assay, Attribute, AttributeOrder, Node,
+                     Study)
 from .serializers import (AssaySerializer, AttributeOrderSerializer,
                           NodeSerializer)
 from .single_file_column_parser import process_metadata_table
@@ -1194,7 +1195,13 @@ class NodeViewSet(APIView):
                     )
                 )
 
-                if attribute_type not in ['Factors, Characteristics']:
+                attribute_editable_types = [Attribute.MATERIAL_TYPE,
+                                            Attribute.CHARACTERISTICS,
+                                            Attribute.FACTOR_VALUE,
+                                            Attribute.LABEL,
+                                            Attribute.COMMENT]
+
+                if attribute_type not in attribute_editable_types:
                     return HttpResponseBadRequest('Attribute is not an '
                                                   'editable type')
 

--- a/refinery/data_set_manager/views.py
+++ b/refinery/data_set_manager/views.py
@@ -1195,7 +1195,7 @@ class NodeViewSet(APIView):
                     )
                 )
 
-                if attribute_type not in Attribute.get_editable_types:
+                if attribute_type not in Attribute.editable_types:
                     return HttpResponseBadRequest('Attribute is not an '
                                                   'editable type')
 

--- a/refinery/data_set_manager/views.py
+++ b/refinery/data_set_manager/views.py
@@ -1195,13 +1195,7 @@ class NodeViewSet(APIView):
                     )
                 )
 
-                attribute_editable_types = [Attribute.MATERIAL_TYPE,
-                                            Attribute.CHARACTERISTICS,
-                                            Attribute.FACTOR_VALUE,
-                                            Attribute.LABEL,
-                                            Attribute.COMMENT]
-
-                if attribute_type not in attribute_editable_types:
+                if attribute_type not in Attribute.get_editable_types():
                     return HttpResponseBadRequest('Attribute is not an '
                                                   'editable type')
 

--- a/refinery/data_set_manager/views.py
+++ b/refinery/data_set_manager/views.py
@@ -1185,13 +1185,18 @@ class NodeViewSet(APIView):
             elif solr_name and attribute_value and not node.is_derived():
                 # splits solr name into type and subtype
                 attribute_obj = customize_attribute_response([solr_name])[0]
+                attribute_type = attribute_obj.get('attribute_type')
                 annotated_nodes_query = AnnotatedNode.objects.filter(
                     node=node,
-                    attribute_type=attribute_obj.get('attribute_type'),
+                    attribute_type=attribute_type,
                     attribute_subtype__icontains=attribute_obj.get(
                         'display_name'
                     )
                 )
+
+                if attribute_type not in ['Factors, Characteristics']:
+                    return HttpResponseBadRequest('Attribute is not an '
+                                                  'editable type')
 
                 # update the source attribute
                 try:

--- a/refinery/data_set_manager/views.py
+++ b/refinery/data_set_manager/views.py
@@ -1195,7 +1195,7 @@ class NodeViewSet(APIView):
                     )
                 )
 
-                if attribute_type not in Attribute.get_editable_types():
+                if attribute_type not in Attribute.get_editable_types:
                     return HttpResponseBadRequest('Attribute is not an '
                                                   'editable type')
 

--- a/refinery/templates/core/data_set.html
+++ b/refinery/templates/core/data_set.html
@@ -119,8 +119,9 @@
     var externalStudyUuid = "{{ study_uuid }}";
     var dataSetUuid = "{{ data_set.uuid }}";
     var analysisUuid = "{{ analysis_uuid }}";
-
     var csrf_token = "{{ csrf_token }}";
+    // already defined in base html
+    window.djangoApp.attributeEditTypes = "{{ attribute_edit_types }}";
   </script>
 
   <!-- Scripts for popup content in the ui-grid-->

--- a/refinery/ui/source/js/file-browser/services/factory.js
+++ b/refinery/ui/source/js/file-browser/services/factory.js
@@ -69,7 +69,6 @@
 
     // helper method which returns  whether a cell is editable
     function isCellEditable (attributeType) {
-      console.log(attributeType);
       return dataSetPropsService.dataSet.is_owner &&
         settings.djangoApp.attributeEditTypes.split(',').includes(attributeType);
     }

--- a/refinery/ui/source/js/file-browser/services/factory.js
+++ b/refinery/ui/source/js/file-browser/services/factory.js
@@ -16,6 +16,7 @@
     'fileBrowserSettings',
     'nodeService',
     'selectedFilterService',
+    'settings',
     'toolSelectService'
   ];
 
@@ -30,6 +31,7 @@
     fileBrowserSettings,
     nodeService,
     selectedFilterService,
+    settings,
     toolSelectService
     ) {
     // assayfiles has max 300 rows, ctrl adds/subtracts rows to maintain count
@@ -67,8 +69,9 @@
 
     // helper method which returns  whether a cell is editable
     function isCellEditable (attributeType) {
+      console.log(attributeType);
       return dataSetPropsService.dataSet.is_owner &&
-        ['Factors', 'Characteristics'].includes(attributeType);
+        settings.djangoApp.attributeEditTypes.split(',').includes(attributeType);
     }
 
     // helper method which returns css class for non-editable cells


### PR DESCRIPTION
- Update api to prevent editing of  non-editable attributes 
- Sync up front end to this edit attributes list
- Refactor format to return attribute types for all editable attributes (ex label, material type, comment)
Ref #2982 