### PR TITLE
Scottx611x/properly reflect admin dataset ownership

### DIFF
--- a/refinery/core/api.py
+++ b/refinery/core/api.py
@@ -161,15 +161,6 @@ class SharableResourceAPIInterface(object):
                 )
 
         if cache_check is None:
-            # for ownership, don't check group perms
-            owned_res_set = Set(
-                get_objects_for_user(
-                    user,
-                    'core.share_%s' %
-                    self.res_type._meta.verbose_name,
-                    use_groups=False
-                ).values_list("id", flat=True))
-
             public_res_set = Set(
                 get_objects_for_group(
                     ExtendedGroup.objects.public_group(),
@@ -186,9 +177,9 @@ class SharableResourceAPIInterface(object):
 
             # instantiate owner and public fields
             for res in res_list:
-                is_owner = res.id in owned_res_set
-                setattr(res, 'is_owner', is_owner)
                 owner = res.get_owner()
+                is_owner = owner == user
+                setattr(res, 'is_owner', is_owner)
                 setattr(
                     res,
                     'owner',

--- a/refinery/core/api.py
+++ b/refinery/core/api.py
@@ -689,7 +689,7 @@ class DataSetResource(SharableResourceAPIInterface, ModelResource):
             if group.group == ExtendedGroup.objects.public_group():
                 is_public = True
 
-        is_owner = request.user.has_perm('core.share_dataset', ds)
+        is_owner = ds.get_owner() == request.user
 
         try:
             user_uuid = request.user.profile.uuid

--- a/refinery/core/test_api.py
+++ b/refinery/core/test_api.py
@@ -368,6 +368,30 @@ class DataSetResourceTest(LoginResourceTestCase):
         self.assertEqual(data["pre_isa_archive"],
                          pre_isa_archive_file_store_item.uuid)
 
+    def test_is_owner_reflects_actual_owner(self):
+        resp = self.api_client.get(api_uri(DataSetResource), format='json')
+        data = json.loads(resp.content)
+        dataset = data["objects"][0]
+        self.assertTrue(dataset["is_owner"])
+        self.assertEqual(dataset["owner"], self.user.profile.uuid)
+
+    def test_is_owner_reflects_actual_owner_with_admin_requester(self):
+        self.username = self.password = "admin"
+        admin_user = User.objects.create_superuser(
+            self.username, '', self.password
+        )
+
+        # use admin user's session authentication for this request
+        self.get_credentials()
+
+        resp = self.api_client.get(api_uri(DataSetResource), format='json')
+        data = json.loads(resp.content)
+        dataset = data["objects"][0]
+
+        # assert that the admin user isn't displayed as the DataSet's owner
+        self.assertFalse(dataset["is_owner"])
+        self.assertNotEqual(dataset["owner"], admin_user.profile.uuid)
+
 
 class NodeAPITest(LoginResourceTestCase):
 

--- a/refinery/core/views.py
+++ b/refinery/core/views.py
@@ -696,7 +696,7 @@ class DataSetsViewSet(APIView):
         for data_set in user_data_sets:
             is_public = all_public_perms.has_perm('read_meta_dataset',
                                                   data_set)
-            is_owner = all_owner_perms.has_perm('share_dataset', data_set)
+            is_owner = data_set.get_owner() == request.user
             setattr(data_set, 'public', is_public)
             setattr(data_set, 'is_owner', is_owner)
 


### PR DESCRIPTION
Fixes #825 

Take note of the `Owner` entry in the preview on the right, and the presence of a `person icon` next to the DataSet modification date on the left.

> **Note:** This change also has the added benefit of allowing the admin user to import other user's ISATab-based datasets into their own space allowing for easier debugging of analysis runs, metadata revisions etc.

Before:
![screen shot 2018-10-29 at 2 10 46 pm](https://user-images.githubusercontent.com/5629547/47670811-7e8aed00-db84-11e8-9d29-d910f959a833.png)

After:
![screen shot 2018-10-29 at 2 17 54 pm](https://user-images.githubusercontent.com/5629547/47671260-77b0aa00-db85-11e8-9eca-810fb490d030.png)

