### PR TITLE
Simplify quickstart deployment on AWS

### DIFF
--- a/deployment/terraform/live/vars.tf
+++ b/deployment/terraform/live/vars.tf
@@ -63,11 +63,13 @@ variable "rds_master_user_password" {
 }
 
 variable "app_server_instance_type" {
-  default = "m3.medium"
+  description = "EC2 instance type of the main host"
+  default     = "m3.medium"
 }
 
 variable "app_server_key_pair_name" {
-  description = "Name of the key pair to use for the app server instance"
+  description = "Name of the SSH key pair to use for the app server instance"
+  default     = ""
 }
 
 variable "app_server_ssh_users" {


### PR DESCRIPTION
Make app_server_key_pair_name optional and add description for app_server_instance_type. Toward #2923.
