### PR TITLE
Set wsgi_pass_authorization to 'On'

### DIFF
--- a/deployment/refinery-modules/refinery/manifests/apache2.pp
+++ b/deployment/refinery-modules/refinery/manifests/apache2.pp
@@ -90,6 +90,7 @@ class refinery::apache2 {
       python-path => "${::django_root}:${::virtualenv}/lib/python2.7/site-packages",
     },
     wsgi_process_group          => 'refinery',
+    wsgi_pass_authorization     => 'On',
     access_log_file             => 'refinery_access.log',
     access_log_format           => $::deployment_platform ? {
       'aws'   => 'aws-elb',


### PR DESCRIPTION
#3106 Introduced the use of the `Authorization` HTTP header to be able to use DRF TokenAuthentication when using the FileBrowser Download files functionality. Apache does not pass this header through to the WSGI application by default.

See: https://www.django-rest-framework.org/api-guide/authentication/#apache-mod_wsgi-specific-configuration