### PR TITLE
Handle botocore.exceptions.ClientError

### DIFF
--- a/refinery/file_store/management/commands/ebs_to_s3.py
+++ b/refinery/file_store/management/commands/ebs_to_s3.py
@@ -45,8 +45,8 @@ class Command(BaseCommand):
             try:
                 s3.upload_file(item.datafile.path, settings.MEDIA_BUCKET, key,
                                ExtraArgs=S3_WRITE_ARGS)
-            except (EnvironmentError,
-                    botocore.exceptions.BotoCoreError) as exc:
+            except (EnvironmentError, botocore.exceptions.BotoCoreError,
+                    botocore.exceptions.ClientError) as exc:
                 raise CommandError(
                     "Error uploading from '{}' to 's3://{}/{}': {}".format(
                         item.datafile.path, settings.MEDIA_BUCKET, key, exc

--- a/refinery/file_store/models.py
+++ b/refinery/file_store/models.py
@@ -146,7 +146,8 @@ class FileStoreItem(models.Model):
             return self.datafile.size
         except ValueError:  # no datafile
             return 0
-        except (EnvironmentError, botocore.exceptions.BotoCoreError) as exc:
+        except (EnvironmentError, botocore.exceptions.BotoCoreError,
+                botocore.exceptions.ClientError) as exc:
             # file is missing
             logger.critical("Error getting size for '%s': %s", self, exc)
             return 0
@@ -165,8 +166,8 @@ class FileStoreItem(models.Model):
             file_name = self.datafile.name
             try:
                 self.datafile.delete(save=save_instance)
-            except (EnvironmentError,
-                    botocore.exceptions.BotoCoreError) as exc:
+            except (EnvironmentError, botocore.exceptions.BotoCoreError,
+                    botocore.exceptions.ClientError) as exc:
                 logger.error("Error deleting file '%s': %s", file_name, exc)
             else:
                 logger.info("Deleted datafile '%s'", file_name)
@@ -185,7 +186,8 @@ class FileStoreItem(models.Model):
                 try:
                     copy_s3_object(storage.bucket_name, self.datafile.name,
                                    storage.bucket_name, new_file_store_name)
-                except botocore.exceptions.BotoCoreError as exc:
+                except (botocore.exceptions.BotoCoreError,
+                        botocore.exceptions.ClientError) as exc:
                     logger.error("Renaming datafile '%s' failed: %s",
                                  self.datafile.name, exc)
                 else:

--- a/refinery/file_store/tasks.py
+++ b/refinery/file_store/tasks.py
@@ -134,7 +134,8 @@ class FileImportTask(celery.Task):
                     source_file_object, settings.MEDIA_BUCKET, file_store_name,
                     ProgressPercentage(source_path, self.request.id)
                 )
-        except (EnvironmentError, botocore.exceptions.BotoCoreError) as exc:
+        except (EnvironmentError, botocore.exceptions.BotoCoreError,
+                botocore.exceptions.ClientError) as exc:
             raise RuntimeError("Error copying from '{}': {}".format(
                 source_path, exc))
         logger.info("Finished transferring from '%s' to 's3://%s/%s'",
@@ -160,7 +161,8 @@ class FileImportTask(celery.Task):
                 download_s3_object(source_bucket, source_key, destination,
                                    ProgressPercentage(source_url,
                                                       self.request.id))
-        except (EnvironmentError, botocore.exceptions.BotoCoreError) as exc:
+        except (EnvironmentError, botocore.exceptions.BotoCoreError,
+                botocore.exceptions.ClientError) as exc:
             delete_file(file_store_path)
             raise RuntimeError(
                 "Error downloading from '{}' to '{}': {}".format(
@@ -190,7 +192,8 @@ class FileImportTask(celery.Task):
                 file_store_name, ProgressPercentage(source_url,
                                                     self.request.id)
             )
-        except botocore.exceptions.BotoCoreError as exc:
+        except (botocore.exceptions.BotoCoreError,
+                botocore.exceptions.ClientError) as exc:
             raise RuntimeError(
                 "Error copying from '{}' to 's3://{}/{}': {}".format(
                     source_url, settings.MEDIA_BUCKET, file_store_name, exc
@@ -249,7 +252,8 @@ class FileImportTask(celery.Task):
                     response, settings.MEDIA_BUCKET, file_store_name,
                     ProgressPercentage(source_url, self.request.id)
                 )
-        except (EnvironmentError, botocore.exceptions.BotoCoreError) as exc:
+        except (EnvironmentError, botocore.exceptions.BotoCoreError,
+                botocore.exceptions.ClientError) as exc:
             raise RuntimeError(
                 "Error transferring from '{}' to 's3://{}/{}': {}".format(
                     source_url, settings.MEDIA_BUCKET, file_store_name, exc

--- a/refinery/file_store/utils.py
+++ b/refinery/file_store/utils.py
@@ -127,7 +127,8 @@ def delete_s3_object(bucket, key):
     logger.debug("Deleting 's3://%s/%s'",  bucket, key)
     try:
         s3.delete_object(Bucket=bucket, Key=key)
-    except botocore.exceptions.BotoCoreError as exc:
+    except (botocore.exceptions.BotoCoreError,
+            botocore.exceptions.ClientError) as exc:
         logger.error("Error deleting 's3://%s/%s': %s", bucket, key, exc)
     else:
         logger.info("Deleted 's3://%s/%s'", bucket, key)
@@ -155,7 +156,8 @@ def get_file_size(file_location):
         bucket, key = parse_s3_url(file_location)
         try:
             return s3.head_object(Bucket=bucket, Key=key)['ContentLength']
-        except botocore.exceptions.BotoCoreError:
+        except (botocore.exceptions.BotoCoreError,
+                botocore.exceptions.ClientError):
             return UNKNOWN_FILE_SIZE
     else:
         try:


### PR DESCRIPTION
Make exception handling more robust (botocore.exceptions.ClientError is not a subclass of botocore.exceptions.BotoCoreError)
