### PR TITLE
Remove duplicates.

### DIFF
--- a/refinery/ui/source/js/file-browser/services/factory.js
+++ b/refinery/ui/source/js/file-browser/services/factory.js
@@ -143,14 +143,19 @@
       return customColumnNames;
     }
 
-    // Helper method which makes display_names uniquey by adding attribute_type
+    // Helper method which makes display_names unique by adding attribute_type
     function createUniqueDisplayNames (outInd) {
       for (var inInd = outInd + 1; inInd < assayAttributes.length; inInd++) {
-        if (assayAttributes[outInd].display_name === assayAttributes[inInd].display_name) {
+        if (assayAttributes[outInd].display_name === assayAttributes[inInd].display_name &&
+            assayAttributes[inInd].attribute_type !== assayAttributes[outInd].attribute_type) {
           assayAttributes[outInd].display_name = assayAttributes[outInd]
               .display_name + '-' + assayAttributes[outInd].attribute_type;
           assayAttributes[inInd].display_name = assayAttributes[inInd]
               .display_name + '-' + assayAttributes[inInd].attribute_type;
+        } else if (assayAttributes[outInd].display_name === assayAttributes[inInd].display_name &&
+          assayAttributes[inInd].attribute_type === assayAttributes[outInd].attribute_type) {
+          // TODO add unit tests
+          assayAttributes.splice(inInd, 1);
         }
       }
     }

--- a/refinery/ui/source/js/file-browser/services/factory.js
+++ b/refinery/ui/source/js/file-browser/services/factory.js
@@ -1,3 +1,9 @@
+/**
+ * File Browser Factory
+ * @namespace fileBrowserFactory
+ * @desc Main services which formats the api response to grid data and columns
+ * @memberOf refineryFileBrowser.fileBrowserFactory
+ */
 (function () {
   'use strict';
 
@@ -143,7 +149,8 @@
       return customColumnNames;
     }
 
-    // Helper method which makes display_names unique by adding attribute_type
+    // Helper method which makes display_names unique by adding
+    // attribute_type or removing the attribute if the object is a duplidate
     function createUniqueDisplayNames (outInd) {
       for (var inInd = outInd + 1; inInd < assayAttributes.length; inInd++) {
         if (assayAttributes[outInd].display_name === assayAttributes[inInd].display_name &&
@@ -154,8 +161,7 @@
               .display_name + '-' + assayAttributes[inInd].attribute_type;
         } else if (assayAttributes[outInd].display_name === assayAttributes[inInd].display_name &&
           assayAttributes[inInd].attribute_type === assayAttributes[outInd].attribute_type) {
-          // TODO add unit tests
-          assayAttributes.splice(inInd, 1);
+          angular.copy(assayAttributes.splice(inInd, 1));
         }
       }
     }
@@ -171,7 +177,13 @@
       return arrayOfObjs;
     }
 
-
+    /**
+     * @name getAssayFiles
+     * @desc Get data and formats it for appropriate
+     * @memberOf refineryFileBrowser.getAssayFiles
+     * @param {object} unencodeParams - params for api request
+     * @param {str} scrollDirection - up or down to page data accordingly for cont strolling
+    **/
     function getAssayFiles (unencodeParams, scrollDirection) {
       var params = {};
       var additionalAssayFiles = [];

--- a/refinery/ui/source/js/file-browser/services/factory.spec.js
+++ b/refinery/ui/source/js/file-browser/services/factory.spec.js
@@ -8,6 +8,7 @@
     var fakeUuid;
     var mocker;
     var rootScope;
+    var underScore;
 
     beforeEach(module('refineryApp'));
     beforeEach(module('refineryFileBrowser'));
@@ -31,11 +32,13 @@
       var assayFiles;
 
       beforeEach(inject(function (
+        _,
         $q,
         $rootScope,
         assayFileService,
         nodeService
       ) {
+        underScore = _;
         assayFiles = {
           nodes: [
             {
@@ -121,6 +124,40 @@
         rootScope.$apply();
         expect(typeof response.then).toEqual('function');
         expect(successData).toEqual(assayFiles);
+      });
+
+      it('getAssayFiles removes duplicate attributes', function () {
+        assayFiles.attributes.push({
+          attribute_type: 'Characteristics',
+          file_ext: 's',
+          display_name: 'Author',
+          internal_name: 'Author_Characteristics_6_3_s'
+        });
+        expect(underScore.countBy(
+          assayFiles.attributes, 'internal_name').Author_Characteristics_6_3_s
+        ).toEqual(2);
+        factory.getAssayFiles({ uuid: mocker.generateUuid() });
+        rootScope.$apply();
+        expect(underScore.countBy(
+          factory.assayAttributes, 'internal_name').Author_Characteristics_6_3_s
+        ).toEqual(1);
+      });
+
+      it('getAssayFiles handles duplicate display names', function () {
+        assayFiles.attributes.push({
+          attribute_type: 'Factor',
+          file_ext: 's',
+          display_name: 'Author',
+          internal_name: 'Author_Characteristics_6_3_s'
+        });
+        factory.getAssayFiles({ uuid: mocker.generateUuid() });
+        rootScope.$apply();
+        expect(underScore.countBy(
+          factory.assayAttributes, 'display_name')['Author-Characteristics']
+        ).toEqual(1);
+        expect(underScore.countBy(
+          factory.assayAttributes, 'display_name')['Author-Factor']
+        ).toEqual(1);
       });
     });
 


### PR DESCRIPTION
Ref #2962   Ref#3188

- This update plus hiding any data files should prevent data loading from duplicate attributes. Tested locally with abc file with/without duplicate columns

![screen shot 2019-02-04 at 8 42 21 am](https://user-images.githubusercontent.com/9956764/52211894-28030e00-2859-11e9-9ff5-57dc4ee88561.png)
