### PR TITLE
Update AMI version of the web app instance

### DIFF
--- a/deployment/terraform/modules/ec2/main.tf
+++ b/deployment/terraform/modules/ec2/main.tf
@@ -119,7 +119,7 @@ resource "aws_iam_instance_profile" "app_server" {
 
 resource "aws_instance" "app_server" {
   count                  = "${var.instance_count}"
-  ami                    = "ami-d05e75b8"
+  ami                    = "ami-03597b1b84c02cf7b"
   instance_type          = "${var.instance_type}"
   key_name               = "${var.key_pair_name}"
   monitoring             = true

--- a/deployment/terraform/modules/ec2/main.tf
+++ b/deployment/terraform/modules/ec2/main.tf
@@ -119,6 +119,7 @@ resource "aws_iam_instance_profile" "app_server" {
 
 resource "aws_instance" "app_server" {
   count                  = "${var.instance_count}"
+  # ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20181203
   ami                    = "ami-03597b1b84c02cf7b"
   instance_type          = "${var.instance_type}"
   key_name               = "${var.key_pair_name}"


### PR DESCRIPTION
Update AMI to match Vagrant box version of Ubuntu (ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20181203 and ubuntu/trusty64/20181203.0.1). Resolve #1813.
