### PR TITLE
Fix submit button activating after canceling post successful uploads

### DIFF
--- a/refinery/ui/source/js/data-set-import/controllers/file-upload-s3.js
+++ b/refinery/ui/source/js/data-set-import/controllers/file-upload-s3.js
@@ -147,8 +147,10 @@
         file.managedUpload.abort();
         $log.warn('Upload canceled: ' + file.name);
       }
-      if (vm.files.length) {
+      if (vm.areUploadsEnabled()) {
         fileUploadStatusService.setFileUploadStatus('queuing');
+      } else if (vm.areUploadsInProgress()) {
+        fileUploadStatusService.setFileUploadStatus('running');
       } else {
         fileUploadStatusService.setFileUploadStatus('none');
       }

--- a/refinery/ui/source/js/data-set-import/controllers/file-upload.js
+++ b/refinery/ui/source/js/data-set-import/controllers/file-upload.js
@@ -256,9 +256,9 @@ function RefineryFileUploadCtrl (
 
     // wait for digest to complete
     $timeout(function () {
-      if (totalNumFilesQueued === 0) {
+      if (totalNumFilesUploaded === totalNumFilesQueued) {
         vm.fileStatus = fileUploadStatusService.setFileUploadStatus('none');
-      } else if ($element.fileupload('active') === 0) {
+      } else {
         vm.fileStatus = fileUploadStatusService.setFileUploadStatus('queuing');
       }
     }, 110);


### PR DESCRIPTION
- Bug: after successfully uploading multiple files, add another file and hit cancel
The bug was on local and s3. It was less noticeable to the other submit bugs, but noticed after more manual testing. Ref #3229 