### PR TITLE
Set number of CPU cores in Vagrant to two to match t2.medium on AWS

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,7 +18,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provider "virtualbox" do |v|
     v.memory = 2048
-    v.cpus = 1
+    v.cpus = 2
     # To increase guest network performance (https://superuser.com/a/850389)
     v.customize ["modifyvm", :id, "--nictype1", "virtio"]
   end


### PR DESCRIPTION
See also #3157. This will also improve performance of concurrent operations in Vagrant.

