### PR TITLE
Jkmarx/fix analysis auto call bug

### DIFF
--- a/refinery/ui/source/js/analysis-monitor/ctrls/ctrl.js
+++ b/refinery/ui/source/js/analysis-monitor/ctrls/ctrl.js
@@ -74,12 +74,6 @@ function AnalysisMonitorCtrl (
     }
   };
 
-  vm.cancelTimerRunningList = function () {
-    if (typeof vm.timerRunList !== 'undefined') {
-      $timeout.cancel(vm.timerRunList);
-    }
-  };
-
   /**
    * @name getRunningAnalyses
    * @desc  Helper function to update running analyses with details

--- a/refinery/ui/source/js/analysis-monitor/ctrls/ctrl.js
+++ b/refinery/ui/source/js/analysis-monitor/ctrls/ctrl.js
@@ -26,6 +26,10 @@ function AnalysisMonitorCtrl (
   vm.initializedFlag = {};
   vm.openAnalysisDeleteModal = openAnalysisDeleteModal;
 
+  vm.$onDestroy = function () {
+    $timeout.cancel(vm.timerList);
+  };
+
   // On data set browser analysis tab, method set timer and refreshes the
   // analysis list and refreshes details for running analyses.
   vm.updateAnalysesList = function () {
@@ -34,10 +38,6 @@ function AnalysisMonitorCtrl (
     };
 
     vm.timerList = $timeout(vm.updateAnalysesList, 15000);
-    // Cancels timer when away from analyses tab
-    $scope.$on('refinery/analyze-tab-inactive', function () {
-      $timeout.cancel(vm.timerList);
-    });
 
     return analysisMonitorFactory.getAnalysesList(param)
       .then(function (response) {
@@ -57,7 +57,6 @@ function AnalysisMonitorCtrl (
         $timeout.cancel(vm.timerList);
 
         vm.updateAnalysesList().then(function () {
-          $rootScope.$broadcast('rf/cancelAnalysis');
           // Removes flag because list is updated
           vm.setCancelAnalysisFlag(false, uuid);
         });

--- a/refinery/ui/source/js/analysis-monitor/ctrls/ctrl.spec.js
+++ b/refinery/ui/source/js/analysis-monitor/ctrls/ctrl.spec.js
@@ -5,12 +5,11 @@ describe('Controller: AnalysisMonitorCtrl', function () {
   var factory;
   var fakeUuid = 'x508x83x-x9xx-4740-x9x7-x7x0x631280x';
   var fakeInvalidUuid = 'xxxxx';
-  var timeout;
 
   beforeEach(module('refineryApp'));
   beforeEach(module('refineryAnalysisMonitor'));
   beforeEach(inject(function (
-    $controller, $rootScope, $timeout, $window, analysisMonitorFactory
+    $controller, $rootScope, $window, analysisMonitorFactory
   ) {
     ctrl = $controller('AnalysisMonitorCtrl', {
       $scope: $rootScope.$new()
@@ -111,9 +110,7 @@ describe('Controller: AnalysisMonitorCtrl', function () {
   });
 
   describe('Helper functions', function () {
-    beforeEach(inject(function ($timeout) {
-      timeout = $timeout;
-
+    beforeEach(inject(function () {
       ctrl.analysesDetail[fakeUuid] = {
         refineryImport: [{
           status: 'PROGRESS',
@@ -159,17 +156,6 @@ describe('Controller: AnalysisMonitorCtrl', function () {
       expect(ctrl.analysesRunningList).toEqual(ctrl.analysesList);
       expect(ctrl.updateAnalysesDetail.calls.count())
         .toEqual(ctrl.analysesList.length);
-    });
-
-    it('cancelTimerRunningList method is function', function () {
-      expect(angular.isFunction(ctrl.cancelTimerRunningList)).toBe(true);
-    });
-
-    it('cancelTimerRunningList method cancel timerRunList', function () {
-      ctrl.timerRunList = timeout(10);
-      expect(typeof ctrl.timerRunList.$$state.value).toEqual('undefined');
-      ctrl.cancelTimerRunningList();
-      expect(ctrl.timerRunList.$$state.value).toEqual('canceled');
     });
 
     it('setAnalysesLoadingFlag method is function', function () {

--- a/refinery/ui/source/js/data-set-nav/state.js
+++ b/refinery/ui/source/js/data-set-nav/state.js
@@ -23,9 +23,7 @@ function refineryDataSetNavConfig (
         templateUrl: function () {
           // unit tests redefine $window and thus make it unusable here
           return window.getStaticUrl('partials/analysis-monitor/views/analyses-tab.html');
-        },
-        controller: 'AnalysisMonitorCtrl',
-        controllerAs: 'AMCtrl'
+        }
       },
       '^\/data_sets\/.*\/$',
       true


### PR DESCRIPTION
- Resolves this bug: In the file browser, when navigating away the analyses calls should stop. 
- Remove reinitializing the analyses monitor controller twice (both in nav state and component)
- Remove unused helper method