### PR TITLE
Jkmarx/extend group api to delete

### DIFF
--- a/refinery/core/test_views.py
+++ b/refinery/core/test_views.py
@@ -1982,7 +1982,7 @@ class CustomRegistrationViewTests(TestCase):
             }
         )
         self.assertTrue(response.wsgi_request.recaptcha_is_valid)
-        self.assertNotNone(User.objects.get(username=username))
+        self.assertIsNotNone(User.objects.get(username=username))
 
     @override_settings(
         REFINERY_GOOGLE_RECAPTCHA_SITE_KEY="invalid_site_key",

--- a/refinery/core/test_views.py
+++ b/refinery/core/test_views.py
@@ -854,13 +854,43 @@ class GroupApiV2Tests(APIV2TestCase):
         )
         self.patch_view = GroupViewSet.as_view({'patch': 'partial_update'})
         self.post_view = GroupViewSet.as_view({'post': 'create'})
+        self.delete_view = GroupViewSet.as_view({'delete': 'destroy'})
         self.data_set = create_dataset_with_necessary_models(user=self.user)
         self.group = ExtendedGroup.objects.create(name="Test Group")
+        self.group.manager_group.user_set.add(self.user)
         self.group_2 = ExtendedGroup.objects.create(name="Test Group 2")
+        self.group_2.manager_group.user_set.add(self.user)
         self.group.user_set.add(self.user)
         self.group_2.user_set.add(self.user)
         self.data_set.share(self.group)
         self.data_set.share(self.group_2)
+
+    def test_delete_group_returns_403_for_non_managers(self):
+        non_manager = User.objects.create_user('Non-owner',
+                                               'user@example.com',
+                                               self.password)
+        self.group.user_set.add(non_manager)
+        delete_request = self.factory.delete(urljoin(self.url_root,
+                                                     self.group.uuid))
+        force_authenticate(delete_request, user=non_manager)
+        delete_response = self.delete_view(delete_request, self.group.uuid)
+        self.assertEqual(delete_response.status_code, 403)
+
+    def test_delete_group_returns_200(self):
+        delete_request = self.factory.delete(urljoin(self.url_root,
+                                                     self.group.uuid))
+        force_authenticate(delete_request, user=self.user)
+        delete_response = self.delete_view(delete_request, self.group.uuid)
+        self.assertEqual(delete_response.status_code, 200)
+
+    def test_delete_group_deletes_group(self):
+        public_group = ExtendedGroup.objects.public_group()
+        delete_request = self.factory.delete(urljoin(self.url_root,
+                                                     self.group.uuid))
+        force_authenticate(delete_request, user=self.user)
+        delete_response = self.delete_view(delete_request, self.group.uuid)
+        remaining_group_uuids = [self.group_2.uuid, public_group.uuid]
+        self.assertNotIn(delete_response.data, remaining_group_uuids)
 
     def test_get_groups_no_params_returns_all_user_groups(self):
         public_group = ExtendedGroup.objects.public_group()
@@ -1952,7 +1982,7 @@ class CustomRegistrationViewTests(TestCase):
             }
         )
         self.assertTrue(response.wsgi_request.recaptcha_is_valid)
-        self.assertIsNotNone(User.objects.get(username=username))
+        self.assertNotNone(User.objects.get(username=username))
 
     @override_settings(
         REFINERY_GOOGLE_RECAPTCHA_SITE_KEY="invalid_site_key",

--- a/refinery/core/views.py
+++ b/refinery/core/views.py
@@ -908,7 +908,7 @@ class AnalysisViewSet(APIView):
 
 class GroupViewSet(viewsets.ViewSet):
     """API endpoint for viewing groups."""
-    http_method_names = ['get', 'patch', 'post']
+    http_method_names = ['get', 'delete', 'patch', 'post']
     lookup_field = 'uuid'
 
     def get_object(self, uuid):
@@ -942,7 +942,7 @@ class GroupViewSet(viewsets.ViewSet):
     def destroy(self, request, uuid):
         user = request.user
         group = self.get_object(uuid)
-        if not self.user_authorized(user, group):
+        if not self.is_user_a_group_manager(user, group):
             return Response('Only managers may delete groups',
                             status=status.HTTP_403_FORBIDDEN)
         group.delete()
@@ -1012,6 +1012,12 @@ class GroupViewSet(viewsets.ViewSet):
                                              context={'data_set': data_set})
 
         return Response(serializer.data)
+
+    def is_user_a_group_manager(self, user, group):
+        if group.is_manager_group():
+            return user in group.user_set.all()
+        else:
+            return user in group.manager_group.user_set.all()
 
 
 class CustomRegistrationView(RegistrationView):

--- a/refinery/core/views.py
+++ b/refinery/core/views.py
@@ -939,6 +939,15 @@ class GroupViewSet(viewsets.ViewSet):
             serializer.errors, status=status.HTTP_400_BAD_REQUEST
         )
 
+    def destroy(self, request, uuid):
+        user = request.user
+        group = self.get_object(uuid)
+        if not self.user_authorized(user, group):
+            return Response('Only managers may delete groups',
+                            status=status.HTTP_403_FORBIDDEN)
+        group.delete()
+        return Response(uuid)
+
     def list(self, request):
         data_set_uuid = request.query_params.get('dataSetUuid')
         all_perms_flag = request.query_params.get('allPerms', False)
@@ -1002,7 +1011,7 @@ class GroupViewSet(viewsets.ViewSet):
         serializer = ExtendedGroupSerializer(group,
                                              context={'data_set': data_set})
 
-        return Response(serializer.data, status=status.HTTP_200_OK)
+        return Response(serializer.data)
 
 
 class CustomRegistrationView(RegistrationView):


### PR DESCRIPTION
Ref #2618 
- Extend API to delete groups for managers only

**Branched off jkmarx/extend-group-api-return-all-user-groups**