### PR TITLE
Raise error when user object is not found.

### DIFF
--- a/refinery/user_files_manager/utils.py
+++ b/refinery/user_files_manager/utils.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.models import User
+from django.http import Http404
 
 from guardian.shortcuts import get_objects_for_user
 
@@ -26,8 +27,12 @@ def generate_solr_params_for_user(params, user_id):
 
     try:
         user = User.objects.get(id=user_id)
-    except User.DoesNotExist:
+    except:
+        pass
+    try:
         user = User.get_anonymous()
+    except User.DoesNotExist:
+        raise Http404
 
     # will update to allow users to view read_meta datasets then we can
     # update to use get_resources_for_user method in core/utils

--- a/refinery/user_files_manager/utils.py
+++ b/refinery/user_files_manager/utils.py
@@ -1,11 +1,13 @@
-from django.contrib.auth.models import User
 from django.http import Http404
 
+from guardian.compat import get_user_model
 from guardian.shortcuts import get_objects_for_user
 
 from core.utils import accept_global_perms
 from data_set_manager.models import Assay, Study
 from data_set_manager.utils import generate_solr_params
+
+User = get_user_model()
 
 
 def generate_solr_params_for_user(params, user_id):

--- a/refinery/user_files_manager/utils.py
+++ b/refinery/user_files_manager/utils.py
@@ -24,15 +24,13 @@ def generate_solr_params_for_user(params, user_id):
         sort - Ordering include field name, whitespace, & asc or desc.
         fq - filter query
      """
-
     try:
         user = User.objects.get(id=user_id)
     except:
-        pass
-    try:
-        user = User.get_anonymous()
-    except User.DoesNotExist:
-        raise Http404
+        try:  # catches when guardian anon user is not created
+            user = User.get_anonymous()
+        except User.DoesNotExist:
+            raise Http404
 
     # will update to allow users to view read_meta datasets then we can
     # update to use get_resources_for_user method in core/utils


### PR DESCRIPTION
Resolves #3175 
- Handles the api error when the anon user is missing. Happens when user does not run fab vm update on a fresh instance. 

**Notes from issue**
"Once project is configured to work with django-guardian, calling syncdb management command would create User instance for anonymous user support (with name of AnonymousUser)." https://django-guardian.readthedocs.io/en/stable/configuration.html?highlight=anon