### PR TITLE
Remove swagger.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ script:
   - echo 'travis_fold:end:django-tests'
 
   - echo 'travis_fold:start:cypress'
-  - pushd ui && node_modules/.bin/cypress run --record && popd
+  - pushd ui && node_modules/.bin/cypress run && popd
   - echo 'travis_fold:end:cypress'
 
   - set +e # Currently, codecov does not always exit with 0, but that should not cause travis to fail.

--- a/refinery/config/settings/base.py
+++ b/refinery/config/settings/base.py
@@ -198,7 +198,6 @@ INSTALLED_APPS = (
     'flatblocks',
     'chunked_upload',
     'rest_framework',
-    'rest_framework_swagger',
     'django_docker_engine',
     'revproxy',
     'cuser',

--- a/refinery/config/urls.py
+++ b/refinery/config/urls.py
@@ -31,7 +31,6 @@ urlpatterns = patterns(
     url(r'^analysis_manager/', include('analysis_manager.urls')),
     url(r'^data_set_manager/', include('data_set_manager.urls')),
     url(r'^tasks/', include('djcelery.urls')),
-    url(r'^docs/', include('rest_framework_swagger.urls')),
 
     # NG: added to include additional views for admin
     # (this is not the recommended way but the only one I got to work)

--- a/refinery/core/utils.py
+++ b/refinery/core/utils.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import ast
 from functools import wraps
 import logging
 import sys
@@ -894,14 +893,7 @@ def filter_nodes_uuids_in_solr(assay_uuid, filter_out_uuids=[],
     # Add attribute filters and facet params to generate solr_params
     if filter_attribute:
         params['filter_attribute'] = filter_attribute
-        # unicode to object to grab keys
-        if isinstance(filter_attribute, unicode):
-            # handling unicode sent by swagger
-            params['facets'] = ','.join(
-                ast.literal_eval(filter_attribute).keys()
-            )
-        else:
-            params['facets'] = ','.join(filter_attribute.keys())
+        params['facets'] = ','.join(filter_attribute.keys())
 
     solr_params = data_set_manager.utils.generate_solr_params_for_assay(
         params, assay_uuid)

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,6 @@ django-override-storage==0.1.2
 django-registration-redux==1.9
 djangorestframework==3.3.3
 djangorestframework-recursive==0.1.1
-django-rest-swagger==0.3.4
 django-storages==1.6.0
 djangular==0.3.0b1
 factory_boy==2.8.1


### PR DESCRIPTION
- Resolves #1470 

Removing swagger until django upgrade to 1.11 so we can upgrade DRF to more compatible version for swagger.