### PR TITLE
Add missing serializer fields.

### DIFF
--- a/refinery/core/serializers.py
+++ b/refinery/core/serializers.py
@@ -44,6 +44,7 @@ class DataSetSerializer(serializers.ModelSerializer):
     file_count = serializers.SerializerMethodField()
     analyses = serializers.SerializerMethodField()
     user_perms = serializers.SerializerMethodField()
+    version = serializers.SerializerMethodField()
 
     def get_analyses(self, data_set):
         return [dict(uuid=analysis.uuid,
@@ -93,11 +94,15 @@ class DataSetSerializer(serializers.ModelSerializer):
                 'read': 'read_dataset' in user_perms,
                 'read_meta': 'read_meta_dataset' in user_perms}
 
+    def get_version(self, data_set):
+        return data_set.get_version()
+
     class Meta:
         model = DataSet
-        fields = ('title', 'accession', 'analyses', 'summary', 'description',
-                  'slug', 'uuid', 'modification_date', 'id', 'is_owner',
-                  'owner', 'public', 'is_clean', 'file_count', 'user_perms')
+        fields = ('creation_date', 'title', 'accession', 'analyses', 'summary',
+                  'description', 'slug', 'uuid', 'modification_date', 'id',
+                  'is_owner', 'owner', 'public', 'is_clean', 'file_count',
+                  'user_perms', 'version')
 
     def partial_update(self, instance, validated_data):
         """

--- a/refinery/core/serializers.py
+++ b/refinery/core/serializers.py
@@ -99,9 +99,9 @@ class DataSetSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = DataSet
-        fields = ('creation_date', 'title', 'accession', 'analyses', 'summary',
-                  'description', 'slug', 'uuid', 'modification_date', 'id',
-                  'is_owner', 'owner', 'public', 'is_clean', 'file_count',
+        fields = ('accession', 'analyses', 'creation_date', 'description',
+                  'id', 'is_owner', 'modification_date', 'owner', 'public',
+                  'is_clean', 'file_count', 'slug', 'summary', 'title', 'uuid',
                   'user_perms', 'version')
 
     def partial_update(self, instance, validated_data):

--- a/refinery/core/serializers.py
+++ b/refinery/core/serializers.py
@@ -100,9 +100,9 @@ class DataSetSerializer(serializers.ModelSerializer):
     class Meta:
         model = DataSet
         fields = ('accession', 'analyses', 'creation_date', 'description',
-                  'id', 'is_owner', 'modification_date', 'owner', 'public',
-                  'is_clean', 'file_count', 'slug', 'summary', 'title', 'uuid',
-                  'user_perms', 'version')
+                  'file_count', 'id', 'is_clean', 'is_owner',
+                  'modification_date', 'owner', 'public', 'slug', 'summary',
+                  'title', 'uuid', 'user_perms', 'version')
 
     def partial_update(self, instance, validated_data):
         """

--- a/refinery/core/test_serializers.py
+++ b/refinery/core/test_serializers.py
@@ -109,12 +109,12 @@ class DataSetSerializerTests(TestCase):
                                              'test1234')
         self.data_set = create_dataset_with_necessary_models(user=self.user)
 
-    def test_seriailzer_returns_creation_date(self):
+    def test_serializer_returns_creation_date(self):
         serializer = DataSetSerializer(self.data_set)
         self.assertEqual(serializer.data.get('creation_date'),
                          self.data_set.creation_date())
 
-    def test_seriailzer_returns_version_field(self):
+    def test_serializer_returns_version_field(self):
         serializer = DataSetSerializer(self.data_set)
         self.assertEqual(serializer.data.get('version'),
                          self.data_set.get_version())

--- a/refinery/core/test_serializers.py
+++ b/refinery/core/test_serializers.py
@@ -111,8 +111,10 @@ class DataSetSerializerTests(TestCase):
 
     def test_serializer_returns_creation_date(self):
         serializer = DataSetSerializer(self.data_set)
+        isoformat = datetime.isoformat(self.data_set.creation_date)
+        drf_isoformat_creation_date = isoformat[:-6] + 'Z'
         self.assertEqual(serializer.data.get('creation_date'),
-                         self.data_set.creation_date())
+                         drf_isoformat_creation_date)
 
     def test_serializer_returns_version_field(self):
         serializer = DataSetSerializer(self.data_set)

--- a/refinery/core/test_serializers.py
+++ b/refinery/core/test_serializers.py
@@ -7,11 +7,13 @@ from django.test.testcases import TestCase
 from guardian.compat import get_user_model
 from django.utils import timezone
 from factory_boy.django_model_factories import GalaxyInstanceFactory
+from factory_boy.utils import create_dataset_with_necessary_models
 
 from .models import (Analysis, Assay, DataSet, ExtendedGroup, Investigation,
                      InvestigationLink, Invitation, Project, Study, Workflow,
                      WorkflowEngine)
-from .serializers import AnalysisSerializer, InvitationSerializer
+from .serializers import (AnalysisSerializer, DataSetSerializer,
+                          InvitationSerializer)
 
 User = get_user_model()
 
@@ -98,6 +100,24 @@ class AnalysisSerializerTests(TestCase):
     def test_serializer_returns_workflow(self):
         self.assertEqual(self.serializer.data.get('workflow'),
                          self.analysis.workflow.id)
+
+
+class DataSetSerializerTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user('JaneDoe',
+                                             'user@example.com',
+                                             'test1234')
+        self.data_set = create_dataset_with_necessary_models(user=self.user)
+
+    def test_seriailzer_returns_creation_date(self):
+        serializer = DataSetSerializer(self.data_set)
+        self.assertEqual(serializer.data.get('creation_date'),
+                         self.data_set.creation_date())
+
+    def test_seriailzer_returns_version_field(self):
+        serializer = DataSetSerializer(self.data_set)
+        self.assertEqual(serializer.data.get('version'),
+                         self.data_set.get_version())
 
 
 class InvitationSerializerTests(TestCase):

--- a/refinery/core/test_views.py
+++ b/refinery/core/test_views.py
@@ -114,7 +114,7 @@ class DataSetApiV2Tests(APIV2TestCase):
                                                'john@example.com',
                                                'coffeecoffee')
         self.user_3_data_set = create_dataset_with_necessary_models(
-            user=self.user_3
+            is_isatab_based=True, user=self.user_3
         )
         self.user_2_data_set.share(ExtendedGroup.objects.public_group())
         self.user_3_data_set.share(ExtendedGroup.objects.public_group())
@@ -254,6 +254,46 @@ class DataSetApiV2Tests(APIV2TestCase):
                                                self.data_set.uuid))
         get_ds_response = self.get_ds_view(get_request, self.data_set.uuid)
         self.assertEqual(get_ds_response.data.get('uuid'), self.data_set.uuid)
+
+    def test_get_data_set_returns_isa_archive(self):
+        investigation_link = \
+            self.user_3_data_set.get_latest_investigation_link()
+        investigation = investigation_link.investigation
+        file_store_item = investigation.get_file_store_item()
+        isa_archive = file_store_item.uuid
+        get_request = self.factory.get(urljoin(self.url_root,
+                                               self.user_3_data_set.uuid))
+        get_request.user = self.user_3
+        get_ds_response = self.get_ds_view(get_request,
+                                           self.user_3_data_set.uuid)
+        self.assertEqual(get_ds_response.data.get('isa_archive'),
+                         isa_archive)
+
+    def test_get_data_set_returns_isa_archive_url(self):
+        investigation_link = \
+            self.user_3_data_set.get_latest_investigation_link()
+        investigation = investigation_link.investigation
+        file_store_item = investigation.get_file_store_item()
+        isa_archive_url = file_store_item.get_datafile_url()
+        get_request = self.factory.get(urljoin(self.url_root,
+                                               self.user_3_data_set.uuid))
+        get_request.user = self.user_3
+        get_ds_response = self.get_ds_view(get_request,
+                                           self.user_3_data_set.uuid)
+        self.assertEqual(get_ds_response.data.get('isa_archive_url'),
+                         isa_archive_url)
+
+    def test_get_data_set_returns_pre_isa_archive(self):
+        investigation_link = self.data_set.get_latest_investigation_link()
+        investigation = investigation_link.investigation
+        file_store_item = investigation.get_file_store_item()
+        pre_isa_archive = file_store_item.uuid
+        get_request = self.factory.get(urljoin(self.url_root,
+                                               self.data_set.uuid))
+        get_request.user = self.user
+        get_ds_response = self.get_ds_view(get_request, self.data_set.uuid)
+        self.assertEqual(get_ds_response.data.get('pre_isa_archive'),
+                         pre_isa_archive)
 
     def test_get_data_set_returns_title(self):
         get_request = self.factory.get(urljoin(self.url_root,

--- a/refinery/core/test_views.py
+++ b/refinery/core/test_views.py
@@ -255,19 +255,19 @@ class DataSetApiV2Tests(APIV2TestCase):
         get_ds_response = self.get_ds_view(get_request, self.data_set.uuid)
         self.assertEqual(get_ds_response.data.get('uuid'), self.data_set.uuid)
 
-    def test_get_data_set_returns_isa_archive(self):
+    def test_get_data_set_returns_isa_archive_uuid(self):
         investigation_link = \
             self.user_3_data_set.get_latest_investigation_link()
         investigation = investigation_link.investigation
         file_store_item = investigation.get_file_store_item()
-        isa_archive = file_store_item.uuid
+        isa_archive_uuid = file_store_item.uuid
         get_request = self.factory.get(urljoin(self.url_root,
                                                self.user_3_data_set.uuid))
         get_request.user = self.user_3
         get_ds_response = self.get_ds_view(get_request,
                                            self.user_3_data_set.uuid)
-        self.assertEqual(get_ds_response.data.get('isa_archive'),
-                         isa_archive)
+        self.assertEqual(get_ds_response.data.get('isa_archive_uuid'),
+                         isa_archive_uuid)
 
     def test_get_data_set_returns_isa_archive_url(self):
         investigation_link = \
@@ -283,17 +283,17 @@ class DataSetApiV2Tests(APIV2TestCase):
         self.assertEqual(get_ds_response.data.get('isa_archive_url'),
                          isa_archive_url)
 
-    def test_get_data_set_returns_pre_isa_archive(self):
+    def test_get_data_set_returns_pre_isa_archive_uuid(self):
         investigation_link = self.data_set.get_latest_investigation_link()
         investigation = investigation_link.investigation
         file_store_item = investigation.get_file_store_item()
-        pre_isa_archive = file_store_item.uuid
+        pre_isa_archive_uuid = file_store_item.uuid
         get_request = self.factory.get(urljoin(self.url_root,
                                                self.data_set.uuid))
         get_request.user = self.user
         get_ds_response = self.get_ds_view(get_request, self.data_set.uuid)
-        self.assertEqual(get_ds_response.data.get('pre_isa_archive'),
-                         pre_isa_archive)
+        self.assertEqual(get_ds_response.data.get('pre_isa_archive_uuid'),
+                         pre_isa_archive_uuid)
 
     def test_get_data_set_returns_title(self):
         get_request = self.factory.get(urljoin(self.url_root,

--- a/refinery/core/views.py
+++ b/refinery/core/views.py
@@ -665,7 +665,20 @@ class DataSetViewSet(viewsets.ViewSet):
             )
 
         serializer = DataSetSerializer(data_set, context={'request': request})
-        return Response(serializer.data)
+        serialized_data = serializer.data
+        # isa_archive only needed for data set details
+        investigation_link = data_set.get_latest_investigation_link()
+        investigation = investigation_link.investigation
+        file_store_item = investigation.get_file_store_item()
+
+        if investigation.is_isa_tab_based():
+            serialized_data['isa_archive'] = file_store_item.uuid
+            serialized_data['isa_archive_url'] = \
+                file_store_item.get_datafile_url()
+        else:
+            serialized_data['pre_isa_archive'] = file_store_item.uuid
+
+        return Response(serialized_data)
 
     def is_user_authorized(self, user, data_set):
         if (not user.is_authenticated() or

--- a/refinery/core/views.py
+++ b/refinery/core/views.py
@@ -666,17 +666,17 @@ class DataSetViewSet(viewsets.ViewSet):
 
         serializer = DataSetSerializer(data_set, context={'request': request})
         serialized_data = serializer.data
-        # isa_archive only needed for data set details
+        # isa_archive_uuid only needed for data set details
         investigation_link = data_set.get_latest_investigation_link()
         investigation = investigation_link.investigation
         file_store_item = investigation.get_file_store_item()
 
         if investigation.is_isa_tab_based():
-            serialized_data['isa_archive'] = file_store_item.uuid
+            serialized_data['isa_archive_uuid'] = file_store_item.uuid
             serialized_data['isa_archive_url'] = \
                 file_store_item.get_datafile_url()
         else:
-            serialized_data['pre_isa_archive'] = file_store_item.uuid
+            serialized_data['pre_isa_archive_uuid'] = file_store_item.uuid
 
         return Response(serialized_data)
 

--- a/refinery/ui/source/js/data-set-about/ctrls/details-ctrl.js
+++ b/refinery/ui/source/js/data-set-about/ctrls/details-ctrl.js
@@ -79,10 +79,10 @@
           // initialize the edited dataset, avoids updating while user edits
           angular.copy(vm.dataSet, vm.editedDataSet);
           // grab meta-data info
-          if (dataSetAboutFactory.dataSet.isa_archive) {
-            vm.refreshFileStoreItem(dataSetAboutFactory.dataSet.isa_archive);
-          } else if (dataSetAboutFactory.dataSet.pre_isa_archive) {
-            vm.refreshFileStoreItem(dataSetAboutFactory.dataSet.pre_isa_archive);
+          if (dataSetAboutFactory.dataSet.isa_archive_uuid) {
+            vm.refreshFileStoreItem(dataSetAboutFactory.dataSet.isa_archive_uuid);
+          } else if (dataSetAboutFactory.dataSet.pre_isa_archive_uuid) {
+            vm.refreshFileStoreItem(dataSetAboutFactory.dataSet.pre_isa_archive_uuid);
           }
         }, function (error) {
           $log.error(error);

--- a/refinery/ui/source/js/data-set-about/partials/details.html
+++ b/refinery/ui/source/js/data-set-about/partials/details.html
@@ -395,7 +395,7 @@
   ng-if="ADCtrl.userPerms === 'read' || ADCtrl.userPerms === 'change'">
   <h3>Metadata</h3>
 </span>
-<div ng-if="ADCtrl.dataSet.isa_archive">
+<div ng-if="ADCtrl.dataSet.isa_archive_uuid">
   <p>
      <a href="{{ADCtrl.fileStoreItem.datafile}}">
       {{ADCtrl.fileStoreItem.datafile | basePathFilter}}
@@ -426,7 +426,7 @@
       </a>
   </span>
 </div>
-<div ng-if="ADCtrl.dataSet.pre_isa_archive && ADCtrl.fileStoreItem.datafile">
+<div ng-if="ADCtrl.dataSet.pre_isa_archive_uuid && ADCtrl.fileStoreItem.datafile">
   <p>
     <a href="{{ADCtrl.fileStoreItem.datafile}}">
     {{ADCtrl.fileStoreItem.datafile | basePathFilter}}
@@ -434,10 +434,11 @@
     - {{ADCtrl.fileStoreItem.file_size | fileSizeFormat}}
   </p>
 </div>
-<div ng-if="!(ADCtrl.dataSet.isa_archive || ADCtrl.dataSet.pre_isa_archive && ADCtrl.fileStoreItem.datafile)">
+<div ng-if="!(ADCtrl.dataSet.isa_archive_uuid || ADCtrl.dataSet.pre_isa_archive_uuid
+&& ADCtrl.fileStoreItem.datafile)">
   <p class="emphasized">Not available.</p>
 </div>
-<div ng-if="ADCtrl.dataSet.pre_isa_archive">
+<div ng-if="ADCtrl.dataSet.pre_isa_archive_uuid">
   <span
      class="p-l-1"
      ng-class="{banned: !FBCtrl.dataSet.is_clean}"
@@ -515,8 +516,8 @@
 <div
   id="isaTabImportForm"
   ng-if="(ADCtrl.userPerms === 'read' || ADCtrl.userPerms === 'change') &&
-  (ADCtrl.dataSet.isa_archive || ADCtrl.dataSet.pre_isa_archive && ADCtrl
-  .fileStoreItem.datafile) && !ADCtrl.dataSet.is_owner && ADCtrl.loggedIn">
+  (ADCtrl.dataSet.isa_archive_uuid || ADCtrl.dataSet.pre_isa_archive_uuid &&
+  ADCtrl.fileStoreItem.datafile) && !ADCtrl.dataSet.is_owner && ADCtrl.loggedIn">
   <button
     id="isa-import-button"
     class="refinery-base btn btn-default"

--- a/refinery/ui/source/js/data-set-about/services/factory.spec.js
+++ b/refinery/ui/source/js/data-set-about/services/factory.spec.js
@@ -46,7 +46,7 @@ describe('Data Set About Factory', function () {
           id: 5,
           is_owner: true,
           is_shared: false,
-          isa_archive: '89774554-c1c4-459f-af3a-059de6eaffdf',
+          isa_archive_uuid: '89774554-c1c4-459f-af3a-059de6eaffdf',
           modification_date: '2016-05-27T09:33:18.696246',
           name: 'Test 1: Request for Comments (RFC) Test',
           owner: '5377caec-0e4f-4de5-9db5-3214b6ef0857',

--- a/refinery/ui/source/js/file-browser/views/files-tab.html
+++ b/refinery/ui/source/js/file-browser/views/files-tab.html
@@ -95,7 +95,7 @@
           </span>
           <span class="p-l-1-2"
             ng-class="{banned: !FBCtrl.dataSet.is_clean}"
-            ng-if="FBCtrl.dataSet.isa_archive.length">
+            ng-if="FBCtrl.dataSet.isa_archive_uuid.length">
             <a
               ng-class="{disabledLink: !FBCtrl.dataSet.is_clean}"
               class="refinery-base btn btn-default btn-xs header-button"
@@ -106,7 +106,7 @@
           </span>
           <span class="p-l-1-2"
             ng-class="{banned: !FBCtrl.dataSet.is_clean}"
-            ng-if="FBCtrl.dataSet.pre_isa_archive.length">
+            ng-if="FBCtrl.dataSet.pre_isa_archive_uuid.length">
             <a
               ng-class="{disabledLink: !FBCtrl.dataSet.is_clean}"
               class="refinery-base btn btn-default btn-xs header-button"


### PR DESCRIPTION
- Fix bug related to missing data set fields on the data set details page
    - Added creation_date and version in serializer
    - Added isa_archive, isa_archive_url, and pre_isa_archive for retrieves. It's only needed when data set details
    - Did alphabetize the serializer fields


