### PR TITLE
Fix bug due to incorrect reference.

### DIFF
--- a/refinery/ui/source/js/dashboard/partials/collaboration-card.html
+++ b/refinery/ui/source/js/dashboard/partials/collaboration-card.html
@@ -74,7 +74,7 @@
               <li class='row' ng-repeat="member in group.member_list | orderBy:
               'last_name'">
                 <a
-                  ng-href="/users/{{ member.uuid }}"
+                  ng-href="/users/{{ member.profile.uuid }}"
                   class="member-info"
                   ng-class="{'col-md-6 col-xs-5': member.is_manager, 'col-md-10
                    col-xs-9': !member.is_manager}">


### PR DESCRIPTION
- On the collaboration page, the members link is broken due to incorrect reference. user.uuid vs user.profile.uuid

Group API updated https://github.com/refinery-platform/refinery-platform/pull/3300/files