### PR TITLE
Replace a custom noop with RunPython.noop in database migrations

### DIFF
--- a/refinery/core/migrations/0016_update_read_meta_permissions.py
+++ b/refinery/core/migrations/0016_update_read_meta_permissions.py
@@ -29,17 +29,11 @@ def update_read_meta_dataset_permissions(apps, schema_editor):
                     assign_perm("core.read_meta_dataset", obj, dataset)
 
 
-def noop(apps, schema_editor):
-    return None  # Newer Django's >= 1.8 have a migrations.RunPython.noop to
-    # be able to move backwards in migrations yet have a data migration's
-    # results remain
-
-
 class Migration(migrations.Migration):
     dependencies = [
         ('core', '0015_auto_20171213_1429'),
     ]
 
     operations = [
-        migrations.RunPython(update_read_meta_dataset_permissions, noop),
+        migrations.RunPython(update_read_meta_dataset_permissions, migrations.RunPython.noop),
     ]

--- a/refinery/core/migrations/0020_create_initial_site_statistics.py
+++ b/refinery/core/migrations/0020_create_initial_site_statistics.py
@@ -36,12 +36,6 @@ def create_initial_site_statistics(apps, schema_editor):
     )
 
 
-def noop(apps, schema_editor):
-    return None  # Newer Django's >= 1.8 have a migrations.RunPython.noop to
-    # be able to move backwards in migrations yet have a data migration's
-    # results remain
-
-
 class Migration(migrations.Migration):
     dependencies = [
         ('core', '0019_sitestatistics'),
@@ -49,5 +43,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(create_initial_site_statistics, noop),
+        migrations.RunPython(create_initial_site_statistics, migrations.RunPython.noop),
     ]

--- a/refinery/data_set_manager/migrations/0005_update_attribute_orders.py
+++ b/refinery/data_set_manager/migrations/0005_update_attribute_orders.py
@@ -33,17 +33,11 @@ def create_missing_attribute_orders(apps, schema_editor):
     attribute_order_model.objects.bulk_create(attribute_orders_to_create)
 
 
-def noop(apps, schema_editor):
-    return None  # Newer Django's >= 1.8 have a migrations.RunPython.noop to
-    # be able to move backwards in migrations yet have a data migration's
-    # results remain
-
-
 class Migration(migrations.Migration):
     dependencies = [
         ('data_set_manager', '0004_auto_20171211_1145'),
     ]
 
     operations = [
-        migrations.RunPython(create_missing_attribute_orders, noop),
+        migrations.RunPython(create_missing_attribute_orders, migrations.RunPython.noop),
     ]


### PR DESCRIPTION
Toward #804 