### PR TITLE
Upgrade package to avoid travis error.

### DIFF
--- a/refinery/ui/package.json
+++ b/refinery/ui/package.json
@@ -34,7 +34,7 @@
     "grunt-contrib-watch": "1.0.0",
     "grunt-env": "0.4.4",
     "grunt-eslint": "18.0.0",
-    "grunt-jsdoc": "2.1.0",
+    "grunt-jsdoc": "2.2.0",
     "grunt-karma": "1.0.0",
     "grunt-newer": "1.2.0",
     "grunt-ng-annotate": "2.0.1",


### PR DESCRIPTION
- Could not pinpoint the issue with jsDoc, but following link recommended we upgrade to 2.2.0 to address issues for Node v8.5.0. Even though we have 6.11.0, it fixed the issue. Note, in the next milestone we are upgrading node to v8+ anyhow.
https://github.com/dc-js/dc.js/issues/1351

https://www.npmjs.com/package/grunt-jsdoc

```
Running "jsdoc:dist" (jsdoc) task
>> /home/travis/build/refinery-platform/refinery-platform/refinery/ui/node_modules/jsdoc/lib/jsdoc/fs.js:97
>>     fs.copyFileSync(inFile, path.join(outDir, fileName));
>>        ^
>> 
>> TypeError: fs.copyFileSync is not a function
>>     at Object.exports.copyFileSync (/home/travis/build/refinery-platform/refinery-platform/refinery/ui/node_modules/jsdoc/lib/jsdoc/fs.js:97:8)
>>     at staticFiles.forEach.fileName (/home/travis/build/refinery-platform/refinery-platform/refinery/ui/node_modules/jsdoc/templates/default/publish.js:506:12)
>>     at Array.forEach (native)
>>     at Object.exports.publish (/home/travis/build/refinery-platform/refinery-platform/refinery/ui/node_modules/jsdoc/templates/default/publish.js:502:17)
>>     at Object.module.exports.cli.generateDocs.e [as generateDocs] (/home/travis/build/refinery-platform/refinery-platform/refinery/ui/node_modules/jsdoc/cli.js:441:39)
>>     at Object.module.exports.cli.processParseResults (/home/travis/build/refinery-platform/refinery-platform/refinery/ui/node_modules/jsdoc/cli.js:392:24)
>>     at module.exports.cli.main (/home/travis/build/refinery-platform/refinery-platform/refinery/ui/node_modules/jsdoc/cli.js:235:18)
>>     at Object.module.exports.cli.runCommand.cb [as runCommand] (/home/travis/build/refinery-platform/refinery-platform/refinery/ui/node_modules/jsdoc/cli.js:186:9)
>>     at __dirname (/home/travis/build/refinery-platform/refinery-platform/refinery/ui/node_modules/jsdoc/jsdoc.js:92:9)
>>     at Object.<anonymous> (/home/travis/build/refinery-platform/refinery-platform/refinery/ui/node_modules/jsdoc/jsdoc.js:93:3)
>>     at Module._compile (module.js:570:32)
>>     at Object.Module._extensions..js (module.js:579:10)
>>     at Module.load (module.js:487:32)
>>     at tryModuleLoad (module.js:446:12)
>>     at Function.Module._load (module.js:438:3)
>>     at Module.runMain (module.js:604:10)
Warning: jsdoc terminated with a non-zero exit code Use --force to continue.
```