### PR TITLE
Hide attributes related to downloading files.

### DIFF
--- a/refinery/data_set_manager/models.py
+++ b/refinery/data_set_manager/models.py
@@ -861,20 +861,18 @@ class AnnotatedNode(models.Model):
 
 
 def _is_internal_attribute(attribute):
-    return attribute in [
-        "uuid",
-        "study_uuid",
-        "assay_uuid",
-        "file_uuid",
-        "type",
-        "is_annotation",
-        "species",
-        "genome_build",
-        "name",
-        "analysis_uuid",
-        "subanalysis",
-        "output_type"
-    ]
+    return attribute in ["uuid",
+                         "study_uuid",
+                         "assay_uuid",
+                         "file_uuid",
+                         "type",
+                         "is_annotation",
+                         "species",
+                         "genome_build",
+                         "name",
+                         "analysis_uuid",
+                         "subanalysis",
+                         "output_type"]
 
 
 def _is_active_attribute(attribute):

--- a/refinery/data_set_manager/models.py
+++ b/refinery/data_set_manager/models.py
@@ -861,18 +861,20 @@ class AnnotatedNode(models.Model):
 
 
 def _is_internal_attribute(attribute):
-    return attribute in ["uuid",
-                         "study_uuid",
-                         "assay_uuid",
-                         "file_uuid",
-                         "type",
-                         "is_annotation",
-                         "species",
-                         "genome_build",
-                         "name",
-                         "analysis_uuid",
-                         "subanalysis",
-                         "output_type"]
+    return attribute in [
+        "uuid",
+        "study_uuid",
+        "assay_uuid",
+        "file_uuid",
+        "type",
+        "is_annotation",
+        "species",
+        "genome_build",
+        "name",
+        "analysis_uuid",
+        "subanalysis",
+        "output_type"
+    ]
 
 
 def _is_active_attribute(attribute):
@@ -880,7 +882,7 @@ def _is_active_attribute(attribute):
 
 
 def _is_exposed_attribute(attribute):
-    return True  # TODO: Could we get rid of this?
+    return True
 
 
 def _is_ignored_attribute(attribute):
@@ -952,13 +954,16 @@ def _is_facet_attribute(attribute, study, assay):
     facet attribute values is smaller than
     settings.DEFAULT_FACET_ATTRIBUTE_VALUES_RATIO, false otherwise.
     """
+    # download_url custom attribute which should not be treated as a facet
+    if data_set_manager.search_indexes.NodeIndex.DOWNLOAD_URL == attribute:
+        return False
+
     ratio = 0.5
     results = _query_solr(attribute=attribute, study=study, assay=assay)
     items = results['response']['numFound']
     attribute_values = len(
         results['facet_counts']['facet_fields'][attribute]
     ) / 2
-
     return (attribute_values / items) < ratio
 
 

--- a/refinery/data_set_manager/views.py
+++ b/refinery/data_set_manager/views.py
@@ -41,6 +41,7 @@ from file_store.utils import parse_s3_url
 
 from .models import (AnnotatedNode, Assay, Attribute, AttributeOrder, Node,
                      Study)
+from .search_indexes import NodeIndex
 from .serializers import (AssaySerializer, AttributeOrderSerializer,
                           NodeSerializer, StudySerializer)
 from .single_file_column_parser import process_metadata_table
@@ -954,7 +955,9 @@ class AssayAttributeAPIView(APIView):
             raise Http404
 
     def get(self, request, uuid, format=None):
-        attribute_order = self.get_objects(uuid)
+        attribute_order = self.get_objects(uuid).exclude(
+            solr_field__in=[NodeIndex.DOWNLOAD_URL, NodeIndex.DATAFILE]
+        )
         serializer = AttributeOrderSerializer(attribute_order, many=True)
         owner = get_owner_from_assay(uuid)
         request_user = request.user


### PR DESCRIPTION
Resolves #3277 

- Hide ToDo Question. is_exposed is currently used to control the table columns viewed
- Download_url should not be a facet
- Exclude the download and data file in the table config (they are not seen and used only to download files)
