### PR TITLE
Fix Cypress error on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 sudo: required
 
 language: python
+python:
+  - "2.7"
+
 cache:
   directories:
     - /home/travis/.cache/pip
     - /home/travis/.cypress/Cypress
-
-python:
-  - 2.7
 
 addons:
   postgresql: "10"
@@ -15,6 +15,7 @@ addons:
     packages:
       - postgresql-10
       - postgresql-client-10
+      - libgconf-2-4  # for Cypress
 
 install:
   - node --version


### PR DESCRIPTION
To address a Cypress error in Travis CI (https://github.com/cypress-io/cypress/issues/4069):
```
libgconf-2.so.4: cannot open shared object file: No such file or directory
```

Also, convert Python version to a string (https://docs.travis-ci.com/user/languages/python/#specifying-python-versions).
