### PR TITLE
Limit workflow api urls.

### DIFF
--- a/refinery/core/views.py
+++ b/refinery/core/views.py
@@ -430,7 +430,7 @@ def pubmed_summary(request, id):
     return HttpResponse(response, content_type='application/json')
 
 
-class WorkflowViewSet(viewsets.ModelViewSet):
+class WorkflowViewSet(viewsets.ViewSet):
     """
         API endpoint that allows a workflow graph to be viewed.
         ---


### PR DESCRIPTION
Resolves #3352 

Limits Workflow API Urls. This api is only used to retrieve a workflow graph json. 

From
```
^api/v2/ ^workflows/$ [name='workflow-list']
^api/v2/ ^workflows\.(?P<format>[a-z0-9]+)/?$ [name='workflow-list']
^api/v2/ ^workflows/(?P<uuid>[^/.]+)/$ [name='workflow-detail']
^api/v2/ ^workflows/(?P<uuid>[^/.]+)\.(?P<format>[a-z0-9]+)/?$ [name='workflow-detail']
^api/v2/ ^workflows/(?P<uuid>[^/.]+)/graph/$ [name='workflow-graph']
^api/v2/ ^workflows/(?P<uuid>[^/.]+)/graph\.(?P<format>[a-z0-9]+)/?$ [name='workflow-graph']
```

TO
```
^api/v2/ ^workflows/(?P<uuid>[^/.]+)/graph/$ [name='workflow-graph']
^api/v2/ ^workflows/(?P<uuid>[^/.]+)/graph\.(?P<format>[a-z0-9]+)/?$ [name='workflow-graph']
```
