### PR TITLE
Delete stale content types

### DIFF
--- a/refinery/core/migrations/0017_delete_diskquota.py
+++ b/refinery/core/migrations/0017_delete_diskquota.py
@@ -4,6 +4,11 @@ from __future__ import unicode_literals
 from django.db import models, migrations
 
 
+def delete_diskquota_content_type(apps, schema_editor):
+    ContentType = apps.get_model('contenttypes', 'ContentType')
+    ContentType.objects.filter(app_label='core', model='diskquota').delete()
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -14,4 +19,7 @@ class Migration(migrations.Migration):
         migrations.DeleteModel(
             name='DiskQuota',
         ),
+        # to avoid a prompt about deleting stale content types
+        migrations.RunPython(delete_diskquota_content_type,
+                             migrations.RunPython.noop)
     ]

--- a/refinery/core/migrations/0018_auto_20180306_1333.py
+++ b/refinery/core/migrations/0018_auto_20180306_1333.py
@@ -4,6 +4,16 @@ from __future__ import unicode_literals
 from django.db import migrations, models
 
 
+def delete_workflowinput_content_types(apps, schema_editor):
+    ContentType = apps.get_model('contenttypes', 'ContentType')
+    ContentType.objects.filter(app_label='core',
+                               model='workflowdatainput').delete()
+    ContentType.objects.filter(app_label='core',
+                               model='workflowdatainputmap').delete()
+    ContentType.objects.filter(app_label='core',
+                               model='workflowinputrelationships').delete()
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -32,4 +42,7 @@ class Migration(migrations.Migration):
         migrations.DeleteModel(
             name='WorkflowInputRelationships',
         ),
+        # to avoid a prompt about deleting stale content types
+        migrations.RunPython(delete_workflowinput_content_types,
+                             migrations.RunPython.noop)
     ]

--- a/refinery/core/migrations/0032_delete_ontology.py
+++ b/refinery/core/migrations/0032_delete_ontology.py
@@ -4,6 +4,11 @@ from __future__ import unicode_literals
 from django.db import migrations
 
 
+def delete_ontology_content_type(apps, schema_editor):
+    ContentType = apps.get_model('contenttypes', 'ContentType')
+    ContentType.objects.filter(app_label='core', model='ontology').delete()
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -14,4 +19,7 @@ class Migration(migrations.Migration):
         migrations.DeleteModel(
             name='Ontology',
         ),
+        # to avoid a prompt about deleting stale content types
+        migrations.RunPython(delete_ontology_content_type,
+                             migrations.RunPython.noop)
     ]

--- a/refinery/data_set_manager/migrations/0007_remove_attribute_definition.py
+++ b/refinery/data_set_manager/migrations/0007_remove_attribute_definition.py
@@ -4,6 +4,12 @@ from __future__ import unicode_literals
 from django.db import migrations
 
 
+def delete_attributedefinition_content_type(apps, schema_editor):
+    ContentType = apps.get_model('contenttypes', 'ContentType')
+    ContentType.objects.filter(app_label='data_set_manager',
+                               model='attributedefinition').delete()
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -22,4 +28,7 @@ class Migration(migrations.Migration):
         migrations.DeleteModel(
             name='AttributeDefinition',
         ),
+        # to avoid a prompt about deleting stale content types
+        migrations.RunPython(delete_attributedefinition_content_type,
+                             migrations.RunPython.noop)
     ]


### PR DESCRIPTION
Content types are not deleted for several models that were removed. This results in a prompt to delete stale content types whenever `manage.py migrate` is run interactively.
```
The following content types are stale and need to be deleted:

    core | ontology
    core | workflowdatainput
    core | workflowinputrelationships
    core | diskquota
    core | workflowdatainputmap

Any objects related to these content types by a foreign key will also
be deleted. Are you sure you want to delete these content types?
If you're unsure, answer 'no'.

    Type 'yes' to continue, or 'no' to cancel: yes
The following content types are stale and need to be deleted:

    data_set_manager | attributedefinition

Any objects related to these content types by a foreign key will also
be deleted. Are you sure you want to delete these content types?
If you're unsure, answer 'no'.

    Type 'yes' to continue, or 'no' to cancel: yes
```
