### PR TITLE
Fail fast on Travis when running Django tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ script:
   - echo 'travis_fold:end:grunt'
 
   - echo 'travis_fold:start:django-tests'
-  - coverage run manage.py test
+  - coverage run manage.py test --failfast
   - echo 'travis_fold:end:django-tests'
 
   - echo 'travis_fold:start:cypress'


### PR DESCRIPTION
To reduce the size of Travis log after a test failure
https://docs.djangoproject.com/en/1.8/ref/django-admin/#django-admin-option---failfast
