### PR TITLE
Remove unused template dependency, Jinja2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,6 @@ djangular==0.3.0b1
 factory_boy==2.8.1
 flake8==2.5.4
 flower==0.9.1
-Jinja2==2.6
 jsonschema==2.6.0
 librabbitmq==2.0.0
 Markdown==2.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,6 @@ pysam==0.9.1.4
 pysolr==3.3.2
 python-magic==0.4.6
 python-memcached==1.57
-PyYAML==3.11
 readline==6.2.2
 requests==2.21.0
 six==1.10.0


### PR DESCRIPTION
- Remove unused template dependency.
- Came on our radar due to dependency security issues
- Originally added to support workflow graph, https://github.com/refinery-platform/refinery-platform/blame/f012ae90ae0bdd3c328740bdbea242a9001a6106/requirements.txt