### PR TITLE
Get Absolute URL Always Returns Absolute URL or Raises Error

### DIFF
--- a/refinery/analysis_manager/tasks.py
+++ b/refinery/analysis_manager/tasks.py
@@ -422,7 +422,7 @@ def _galaxy_file_import(analysis_uuid, file_store_item_uuid, history_dict,
     file_store_url = file_store_item.get_datafile_url()
     try:
         file_url_absolute = core.utils.\
-                        get_absolute_url(file_store_url)
+                        build_absolute_url(file_store_url)
     except ValueError:
         logger.error('{} is not a relative URL'.format(str(file_store_url)))
         run_analysis.update_state(state=celery.states.FAILURE)

--- a/refinery/analysis_manager/tasks.py
+++ b/refinery/analysis_manager/tasks.py
@@ -427,11 +427,10 @@ def _galaxy_file_import(analysis_uuid, file_store_item_uuid, history_dict,
         logger.error('{} is not a relative URL'.format(str(file_store_url)))
         run_analysis.update_state(state=celery.states.FAILURE)
         return
-    else:
-        if file_url_absolute is None:
-            logger.error('No current site found')
-            run_analysis.update_state(state=celery.states.FAILURE)
-            return
+    except RuntimeError:
+        logger.error('Could not build URL for {}'.format(str(file_store_url)))
+        run_analysis.update_state(state=celery.states.FAILURE)
+        return
     library_dataset_dict = tool.upload_datafile_to_library_from_url(
         library_dict["id"],
         file_url_absolute

--- a/refinery/analysis_manager/tasks.py
+++ b/refinery/analysis_manager/tasks.py
@@ -419,9 +419,22 @@ def _galaxy_file_import(analysis_uuid, file_store_item_uuid, history_dict,
                      file_store_item_uuid, e)
         run_analysis.update_state(state=celery.states.FAILURE)
         return
+    file_store_url = file_store_item.get_datafile_url()
+    try:
+        file_url_absolute = core.utils.\
+                        get_absolute_url(file_store_url)
+    except ValueError:
+        logger.error('{} is not a relative URL'.format(str(file_store_url)))
+        run_analysis.update_state(state=celery.states.FAILURE)
+        return
+    else:
+        if file_url_absolute is None:
+            logger.error('No current site found')
+            run_analysis.update_state(state=celery.states.FAILURE)
+            return
     library_dataset_dict = tool.upload_datafile_to_library_from_url(
         library_dict["id"],
-        core.utils.get_absolute_url(file_store_item.get_datafile_url())
+        file_url_absolute
     )
     history_dataset_dict = tool.import_library_dataset_to_history(
         history_dict["id"],

--- a/refinery/core/test_utils.py
+++ b/refinery/core/test_utils.py
@@ -46,9 +46,8 @@ class TestGetAbsoluteURL(TestCase):
                              'http://example.org')
 
     def test_get_absolute_url_with_empty_input(self):
-        with override_settings(SITE_ID=self.current_site.id):
-            self.assertEqual(get_absolute_url(None), None)
-            self.assertEqual(get_absolute_url(''), '')
+        with self.assertRaises(ValueError):
+            get_absolute_url(None)
 
     def test_get_absolute_url_with_invalid_current_site(self):
         Site.objects.all().delete()

--- a/refinery/core/test_utils.py
+++ b/refinery/core/test_utils.py
@@ -51,7 +51,8 @@ class TestGetAbsoluteURL(TestCase):
 
     def test_build_absolute_url_with_invalid_current_site(self):
         Site.objects.all().delete()
-        self.assertIsNone(build_absolute_url('/path/to/file'))
+        with self.assertRaises(RuntimeError):
+            build_absolute_url('/path/to/file')
 
 
 class SimpleUtilitiesTest(TestCase):

--- a/refinery/core/test_utils.py
+++ b/refinery/core/test_utils.py
@@ -6,7 +6,7 @@ from django.test import TestCase, override_settings
 from factory_boy.utils import create_dataset_with_necessary_models
 
 from .models import ExtendedGroup
-from .utils import (get_absolute_url, is_absolute_url,
+from .utils import (build_absolute_url, is_absolute_url,
                     get_non_manager_groups_for_user, get_data_set_for_view_set,
                     get_group_for_view_set)
 
@@ -35,23 +35,23 @@ class TestGetAbsoluteURL(TestCase):
         self.current_site = Site.objects.get_or_create(name='Test',
                                                        domain='example.org')[0]
 
-    def test_get_absolute_url_with_relative_url(self):
+    def test_build_absolute_url_with_relative_url(self):
         with override_settings(SITE_ID=self.current_site.id):
-            self.assertEqual(get_absolute_url('/path/to/file'),
+            self.assertEqual(build_absolute_url('/path/to/file'),
                              'http://example.org/path/to/file')
 
-    def test_get_absolute_url_with_absolute_url(self):
+    def test_build_absolute_url_with_absolute_url(self):
         with override_settings(SITE_ID=self.current_site.id):
-            self.assertEqual(get_absolute_url('http://example.org'),
+            self.assertEqual(build_absolute_url('http://example.org'),
                              'http://example.org')
 
-    def test_get_absolute_url_with_empty_input(self):
+    def test_build_absolute_url_with_empty_input(self):
         with self.assertRaises(ValueError):
-            get_absolute_url(None)
+            build_absolute_url(None)
 
-    def test_get_absolute_url_with_invalid_current_site(self):
+    def test_build_absolute_url_with_invalid_current_site(self):
         Site.objects.all().delete()
-        self.assertIsNone(get_absolute_url('/path/to/file'))
+        self.assertIsNone(build_absolute_url('/path/to/file'))
 
 
 class SimpleUtilitiesTest(TestCase):

--- a/refinery/core/utils.py
+++ b/refinery/core/utils.py
@@ -116,7 +116,7 @@ def invalidate_cached_object(instance, is_test=False):
         return mc
 
 
-def get_absolute_url(string):
+def build_absolute_url(string):
     """Creates an absolute URL from a relative URL using the current Site
     domain and REFINERY_URL_SCHEME Django setting
     """

--- a/refinery/core/utils.py
+++ b/refinery/core/utils.py
@@ -120,9 +120,8 @@ def get_absolute_url(string):
     """Creates an absolute URL from a relative URL using the current Site
     domain and REFINERY_URL_SCHEME Django setting
     """
-    if not string or is_absolute_url(string):
-        return string
-
+    if not string:
+        raise ValueError('Only relative urls allowed, not: {}'.format(string))
     try:
         current_site = Site.objects.get_current()
     except Site.DoesNotExist:

--- a/refinery/core/utils.py
+++ b/refinery/core/utils.py
@@ -126,10 +126,10 @@ def build_absolute_url(string):
         return string
     try:
         current_site = Site.objects.get_current()
-    except Site.DoesNotExist:
+    except Site.DoesNotExist as e:
         logger.error("Can not construct a full URL: no Sites configured or "
                      "SITE_ID is invalid")
-        return None
+        raise RuntimeError(e.message)
 
     return "{}://{}{}".format(
         settings.REFINERY_URL_SCHEME, current_site.domain, string

--- a/refinery/core/utils.py
+++ b/refinery/core/utils.py
@@ -122,6 +122,8 @@ def get_absolute_url(string):
     """
     if not string:
         raise ValueError('Only relative urls allowed, not: {}'.format(string))
+    if is_absolute_url(string):
+        return string
     try:
         current_site = Site.objects.get_current()
     except Site.DoesNotExist:

--- a/refinery/data_set_manager/search_indexes.py
+++ b/refinery/data_set_manager/search_indexes.py
@@ -193,7 +193,16 @@ def _get_download_url_or_import_state(file_store_item):
 
     download_url = file_store_item.get_datafile_url()
     if download_url:
-        return get_absolute_url(download_url)
+        try:
+            absolute_download_url = get_absolute_url(download_url)
+            return absolute_download_url
+        except ValueError:
+            logger.error('{} is not a valid relative url'.format(download_url))
+            return None
+        else:
+            if not absolute_download_url:
+                logger.error('Could not fetch full absolute url')
+            return None
 
     # "PENDING" if an import_task_id doesn't exist and
     # there is no valid download_url

--- a/refinery/data_set_manager/search_indexes.py
+++ b/refinery/data_set_manager/search_indexes.py
@@ -15,7 +15,7 @@ from haystack.exceptions import SkipDocument
 
 import constants
 import core
-from core.utils import get_absolute_url
+from core.utils import build_absolute_url
 
 from .models import AnnotatedNode, Assay, Node
 
@@ -194,7 +194,7 @@ def _get_download_url_or_import_state(file_store_item):
     download_url = file_store_item.get_datafile_url()
     if download_url:
         try:
-            absolute_download_url = get_absolute_url(download_url)
+            absolute_download_url = build_absolute_url(download_url)
             return absolute_download_url
         except ValueError:
             logger.error('{} is not a valid relative url'.format(download_url))

--- a/refinery/data_set_manager/search_indexes.py
+++ b/refinery/data_set_manager/search_indexes.py
@@ -197,11 +197,16 @@ def _get_download_url_or_import_state(file_store_item):
             absolute_download_url = build_absolute_url(download_url)
             return absolute_download_url
         except ValueError:
-            logger.error('{} is not a valid relative url'.format(download_url))
+            logger.error('{} is not a valid relative url'.format(
+                    str(download_url)
+                )
+            )
             return None
-        else:
-            if not absolute_download_url:
-                logger.error('Could not fetch full absolute url')
+        except RuntimeError:
+            logger.error('Could not fetch full absolute url for {}'.format(
+                    str(download_url)
+                )
+            )
             return None
 
     # "PENDING" if an import_task_id doesn't exist and

--- a/refinery/data_set_manager/test_search_indexes.py
+++ b/refinery/data_set_manager/test_search_indexes.py
@@ -7,7 +7,7 @@ from django.contrib.auth.models import User
 from celery.states import FAILURE, PENDING
 from djcelery.models import TaskMeta
 
-from core.utils import get_absolute_url
+from core.utils import build_absolute_url
 from factory_boy.utils import make_analyses_with_single_dataset
 from haystack.exceptions import SkipDocument
 import mock
@@ -120,7 +120,7 @@ class NodeIndexTests(APITestCase):
                                return_value='/media/file_store/test_file.txt'):
             self._assert_node_index_prepared_correctly(
                 self._prepare_node_index(self.node),
-                expected_download_url=get_absolute_url(
+                expected_download_url=build_absolute_url(
                     self.file_store_item.get_datafile_url()
                 ),
                 expected_datafile=self.file_store_item.datafile
@@ -192,7 +192,7 @@ class NodeIndexTests(APITestCase):
                                return_value='/media/file_store/test.txt'):
             self._assert_node_index_prepared_correctly(
                 self._prepare_node_index(self.node),
-                expected_download_url=get_absolute_url(
+                expected_download_url=build_absolute_url(
                     self.file_store_item.get_datafile_url()
                 ),
                 expected_filetype=self.file_store_item.filetype,
@@ -221,7 +221,7 @@ class NodeIndexTests(APITestCase):
             self._create_analysis_node_connection(INPUT_CONNECTION, False)
             self._assert_node_index_prepared_correctly(
                 self._prepare_node_index(self.node),
-                expected_download_url=get_absolute_url(
+                expected_download_url=build_absolute_url(
                     self.file_store_item.get_datafile_url()
                 ),
                 expected_datafile=self.file_store_item.datafile
@@ -235,7 +235,7 @@ class NodeIndexTests(APITestCase):
             self._create_analysis_node_connection(INPUT_CONNECTION, True)
             self._assert_node_index_prepared_correctly(
                 self._prepare_node_index(self.node),
-                expected_download_url=get_absolute_url(
+                expected_download_url=build_absolute_url(
                     self.file_store_item.get_datafile_url()
                 ),
                 expected_datafile=self.file_store_item.datafile
@@ -256,7 +256,7 @@ class NodeIndexTests(APITestCase):
             self._create_analysis_node_connection(OUTPUT_CONNECTION, True)
             self._assert_node_index_prepared_correctly(
                 self._prepare_node_index(self.node),
-                expected_download_url=get_absolute_url(
+                expected_download_url=build_absolute_url(
                     self.file_store_item.get_datafile_url()
                 ),
                 expected_datafile=self.file_store_item.datafile

--- a/refinery/data_set_manager/test_utils.py
+++ b/refinery/data_set_manager/test_utils.py
@@ -1132,7 +1132,7 @@ class UtilitiesTests(TestCase):
         attribute_list = AttributeOrder.objects.filter(assay=self.assay)
         self.assertItemsEqual(old_attribute_list, attribute_list)
 
-    @mock.patch("data_set_manager.utils.core.utils.get_absolute_url")
+    @mock.patch("data_set_manager.utils.core.utils.build_absolute_url")
     def test_get_file_url_from_node_uuid_good_uuid(self, mock_get_url):
         mock_get_url.return_value = "test_file_a.txt"
         self.assertIn('test_file_a.txt',

--- a/refinery/data_set_manager/test_views.py
+++ b/refinery/data_set_manager/test_views.py
@@ -1880,7 +1880,7 @@ class TakeOwnershipOfPublicDatasetViewTest(APIV2TestCase):
     @mock.patch("data_set_manager.views.build_absolute_url")
     def test_take_ownership_returns_400_without_relative_url(self, mock_url):
         def raise_error(file):
-            raise ValueError
+            raise ValueError(str(file))
         mock_url.side_effect = raise_error
         post_request = self.factory.post(self.url_root,
                                          {'data_set_uuid': self.data_set.uuid},

--- a/refinery/data_set_manager/test_views.py
+++ b/refinery/data_set_manager/test_views.py
@@ -6,6 +6,7 @@ import uuid
 
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.contrib.sites.models import Site
 from django.forms.models import model_to_dict
 from django.http import QueryDict
 from django.test import LiveServerTestCase, override_settings
@@ -28,7 +29,8 @@ from .models import (AnnotatedNode, Assay, Attribute, AttributeOrder,
                      Investigation, Node, Study)
 from .tests import MetadataImportTestBase
 from .views import (AddFileToNodeView, AssayAPIView, AssayAttributeAPIView,
-                    NodeViewSet, StudyAPIView)
+                    NodeViewSet, StudyAPIView,
+                    TakeOwnershipOfPublicDatasetView)
 
 TEST_DATA_BASE_PATH = "data_set_manager/test-data/"
 
@@ -1838,3 +1840,39 @@ class StudyViewAPIV2Tests(APIV2TestCase):
         get_response = self.view(get_request)
         self.assertEqual(get_response.data[0].get('investigation'),
                          self.data_set.get_studies()[0].investigation.id)
+
+
+class TakeOwnershipOfPublicDatasetViewTest(APIV2TestCase):
+
+    def setUp(self, **kwargs):
+        super(TakeOwnershipOfPublicDatasetViewTest, self).setUp(
+            api_base_name="import/take_ownership/",
+            view=TakeOwnershipOfPublicDatasetView.as_view()
+        )
+        self.username_owner = 'owner'
+        self.password_owner = 'take_over'
+        self.user_owner = User.objects.create_user(
+            self.username_owner, 'user1@example.com', self.password_owner
+        )
+        self.data_set = create_dataset_with_necessary_models(user=self.user)
+        self.data_set.share(ExtendedGroup.objects.public_group())
+
+    def test_take_ownership_public_datafile_returns_url_in_cookies(self):
+        post_request = self.factory.post(self.url_root,
+                                         {'data_set_uuid': self.data_set.uuid},
+                                         'json')
+        post_request.user = self.user_owner
+        post_response = self.view(post_request)
+        self.assertEqual(
+            post_response.cookies.get('isa_tab_url').value,
+            'http://www.example.com/test.csv'
+        )
+
+    def test_take_ownership_returns_400_without_current_site(self):
+        Site.objects.all().delete()
+        post_request = self.factory.post(self.url_root,
+                                         {'data_set_uuid': self.data_set.uuid},
+                                         'json')
+        post_request.user = self.user_owner
+        post_response = self.view(post_request)
+        self.assertEqual(post_response.status_code, 400)

--- a/refinery/data_set_manager/test_views.py
+++ b/refinery/data_set_manager/test_views.py
@@ -1876,3 +1876,15 @@ class TakeOwnershipOfPublicDatasetViewTest(APIV2TestCase):
         post_request.user = self.user_owner
         post_response = self.view(post_request)
         self.assertEqual(post_response.status_code, 400)
+
+    @mock.patch("data_set_manager.views.build_absolute_url")
+    def test_take_ownership_returns_400_without_relative_url(self, mock_url):
+        def raise_error(file):
+            raise ValueError
+        mock_url.side_effect = raise_error
+        post_request = self.factory.post(self.url_root,
+                                         {'data_set_uuid': self.data_set.uuid},
+                                         'json')
+        post_request.user = self.user_owner
+        post_response = self.view(post_request)
+        self.assertEqual(post_response.status_code, 400)

--- a/refinery/data_set_manager/utils.py
+++ b/refinery/data_set_manager/utils.py
@@ -945,7 +945,11 @@ def get_file_url_from_node_uuid(node_uuid, require_valid_url=False):
                     "Node with uuid: {} has no associated file url"
                     .format(node_uuid)
                 )
-        return core.utils.get_absolute_url(url) if url else None
+        try:
+            return core.utils.get_absolute_url(url) if url else None
+        except ValueError as e:
+            logger.error('URL {} is not a valid relative url'.format(str(url)))
+            raise type(e)(e.message)
 
 
 def fix_last_column(file):

--- a/refinery/data_set_manager/utils.py
+++ b/refinery/data_set_manager/utils.py
@@ -946,7 +946,7 @@ def get_file_url_from_node_uuid(node_uuid, require_valid_url=False):
                     .format(node_uuid)
                 )
         try:
-            return core.utils.get_absolute_url(url) if url else None
+            return core.utils.build_absolute_url(url) if url else None
         except ValueError as e:
             logger.error('URL {} is not a valid relative url'.format(str(url)))
             raise type(e)(e.message)

--- a/refinery/data_set_manager/utils.py
+++ b/refinery/data_set_manager/utils.py
@@ -950,6 +950,12 @@ def get_file_url_from_node_uuid(node_uuid, require_valid_url=False):
         except ValueError as e:
             logger.error('URL {} is not a valid relative url'.format(str(url)))
             raise type(e)(e.message)
+        except RuntimeError as e:
+            logger.error('Could not build absolute URL for {}'.format(
+                    str(url)
+                )
+            )
+            raise type(e)(e.message)
 
 
 def fix_last_column(file):

--- a/refinery/data_set_manager/views.py
+++ b/refinery/data_set_manager/views.py
@@ -140,12 +140,32 @@ class TakeOwnershipOfPublicDatasetView(View):
         if request.user.has_perm('core.read_dataset', data_set) \
                 or 'read_dataset' in get_perms(public_group, data_set):
             investigation = data_set.get_investigation()
-            full_isa_tab_url = get_absolute_url(
-                investigation.get_file_store_item().get_datafile_url()
-            )
-            response = HttpResponseRedirect(
-                get_absolute_url(reverse('process_isa_tab', args=['ajax']))
-            )
+            file_url = investigation.get_file_store_item().get_datafile_url()
+            try:
+                full_isa_tab_url = get_absolute_url(file_url)
+            except ValueError:
+                logger.error('URL {} is not a relative url'.format(file_url))
+                return HttpResponseBadRequest('No file url found for '
+                                              'investigation of DataSet')
+            else:
+                if full_isa_tab_url is None:
+                    logger.error('No Current Site found')
+                    return HttpResponseBadRequest('No current site found')
+            relative_isa_tab_url = reverse('process_isa_tab', args=['ajax'])
+            try:
+                isa_tab_url = get_absolute_url(relative_isa_tab_url)
+            except ValueError:
+                logger.error(
+                    '{} is not relative url'.format(str(relative_isa_tab_url))
+                )
+                return HttpResponseBadRequest('Could not set isa_tab_url '
+                                              ' cookie due to bad redirect')
+            else:
+                if full_isa_tab_url is None:
+                    if full_isa_tab_url is None:
+                        logger.error('No Current Site found')
+                        return HttpResponseBadRequest('No current site found')
+            response = HttpResponseRedirect(isa_tab_url)
             # set cookie
             response.set_cookie('isa_tab_url', full_isa_tab_url)
             return response

--- a/refinery/data_set_manager/views.py
+++ b/refinery/data_set_manager/views.py
@@ -144,13 +144,19 @@ class TakeOwnershipOfPublicDatasetView(View):
             try:
                 full_isa_tab_url = build_absolute_url(file_url)
             except ValueError:
-                logger.error('URL {} is not a relative url'.format(file_url))
+                logger.error('URL {} is not a relative url'.format(
+                        str(file_url)
+                    )
+                )
                 return HttpResponseBadRequest('No file url found for '
                                               'investigation of DataSet')
-            else:
-                if full_isa_tab_url is None:
-                    logger.error('No Current Site found')
-                    return HttpResponseBadRequest('No current site found')
+            except RuntimeError as e:
+                logger.error('Could not build URL for {}'.format(
+                        str(file_url)
+                    )
+                )
+                return HttpResponseBadRequest('Could not build URL for {}'.
+                                              format(str(file_url)))
             relative_isa_tab_url = reverse('process_isa_tab', args=['ajax'])
             try:
                 isa_tab_url = build_absolute_url(relative_isa_tab_url)
@@ -160,11 +166,14 @@ class TakeOwnershipOfPublicDatasetView(View):
                 )
                 return HttpResponseBadRequest('Could not set isa_tab_url '
                                               ' cookie due to bad redirect')
-            else:
-                if full_isa_tab_url is None:
-                    if full_isa_tab_url is None:
-                        logger.error('No Current Site found')
-                        return HttpResponseBadRequest('No current site found')
+            except RuntimeError as e:
+                logger.error('No Current Site found')
+                logger.error('Could not build URL for {}'.format(
+                        str(relative_isa_tab_url)
+                    )
+                )
+                return HttpResponseBadRequest('Could not build URL for {}'.
+                                              format(str(file_url)))
             response = HttpResponseRedirect(isa_tab_url)
             # set cookie
             response.set_cookie('isa_tab_url', full_isa_tab_url)

--- a/refinery/data_set_manager/views.py
+++ b/refinery/data_set_manager/views.py
@@ -33,7 +33,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from core.models import (DataSet, ExtendedGroup, get_user_import_dir)
-from core.utils import get_absolute_url, get_data_set_for_view_set
+from core.utils import build_absolute_url, get_data_set_for_view_set
 from data_set_manager.isa_tab_parser import ParserException
 from file_store.models import generate_file_source_translator
 from file_store.tasks import FileImportTask, download_file
@@ -142,7 +142,7 @@ class TakeOwnershipOfPublicDatasetView(View):
             investigation = data_set.get_investigation()
             file_url = investigation.get_file_store_item().get_datafile_url()
             try:
-                full_isa_tab_url = get_absolute_url(file_url)
+                full_isa_tab_url = build_absolute_url(file_url)
             except ValueError:
                 logger.error('URL {} is not a relative url'.format(file_url))
                 return HttpResponseBadRequest('No file url found for '
@@ -153,7 +153,7 @@ class TakeOwnershipOfPublicDatasetView(View):
                     return HttpResponseBadRequest('No current site found')
             relative_isa_tab_url = reverse('process_isa_tab', args=['ajax'])
             try:
-                isa_tab_url = get_absolute_url(relative_isa_tab_url)
+                isa_tab_url = build_absolute_url(relative_isa_tab_url)
             except ValueError:
                 logger.error(
                     '{} is not relative url'.format(str(relative_isa_tab_url))

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -310,16 +310,15 @@ class Tool(OwnableResource):
             abs_url = build_absolute_url(self.container_input_json_url)
         except ValueError:
             logger.error('{} is not a relative url'.format(
-                    self.container_input_json_url
+                    str(self.container_input_json_url)
                 )
             )
-        else:
-            if abs_url is None:
-                logger.error('Could not get current site for URL {}'.format(
-                        abs_url
-                    )
+        except RuntimeError:
+            logger.error('Could not build URL for {}'.format(
+                    str(self.container_input_json_url)
                 )
-                return None
+            )
+            return None
         return DockerClientRunWrapper(
             DockerClientSpec(input_json_url=abs_url),
             mem_limit_mb=settings.DJANGO_DOCKER_ENGINE_MEM_LIMIT_MB

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -313,6 +313,7 @@ class Tool(OwnableResource):
                     str(self.container_input_json_url)
                 )
             )
+            return None
         except RuntimeError:
             logger.error('Could not build URL for {}'.format(
                     str(self.container_input_json_url)

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -306,10 +306,22 @@ class Tool(OwnableResource):
 
     @property
     def django_docker_client(self):
+        try:
+            abs_url = get_absolute_url(self.container_input_json_url)
+        except ValueError:
+            logger.error('{} is not a relative url'.format(
+                    self.container_input_json_url
+                )
+            )
+        else:
+            if abs_url is None:
+                logger.error('Could not get current site for URL {}'.format(
+                        abs_url
+                    )
+                )
+                return None
         return DockerClientRunWrapper(
-            DockerClientSpec(
-                input_json_url=get_absolute_url(self.container_input_json_url)
-            ),
+            DockerClientSpec(input_json_url=abs_url),
             mem_limit_mb=settings.DJANGO_DOCKER_ENGINE_MEM_LIMIT_MB
         )
 

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -32,7 +32,7 @@ from core.models import (INPUT_CONNECTION, OUTPUT_CONNECTION, Analysis,
                          Workflow)
 
 from core.models import Event
-from core.utils import get_absolute_url
+from core.utils import build_absolute_url
 from data_set_manager.models import Node
 from data_set_manager.utils import (
     get_file_url_from_node_uuid, get_solr_response_json
@@ -307,7 +307,7 @@ class Tool(OwnableResource):
     @property
     def django_docker_client(self):
         try:
-            abs_url = get_absolute_url(self.container_input_json_url)
+            abs_url = build_absolute_url(self.container_input_json_url)
         except ValueError:
             logger.error('{} is not a relative url'.format(
                     self.container_input_json_url


### PR DESCRIPTION
This PR closes out #2636 by forcing get_absolute_url() to always return an absolute url or raise an error