### PR TITLE
Update version for security.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ psycopg2-binary==2.7.4
 pyasn1==0.1.9
 pycparser==2.13
 Pygments==1.6rc1
-pyOpenSSL==16.2.0
+pyOpenSSL==17.5.0
 pysam==0.9.1.4
 pysolr==3.3.2
 python-magic==0.4.6


### PR DESCRIPTION
Checked with pipdeptree

```ndg-httpsclient==0.3.2
  - PyOpenSSL [required: Any, installed: 16.2.0]```

Upgrade to 17.5.0 for security updates.