### PR TITLE
Update version of cryptography to match install dependency version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ certifi==2018.11.29
 cffi==1.9.1
 codecov==2.0.11
 coverage==4.0.3
-cryptography==2.1.4
+cryptography==2.5
 Django==1.8.18
 django-celery==3.2.2
 django-chunked-upload==1.1.0


### PR DESCRIPTION
Ref #3449 
- Update version of cryptography due to security updates. 
```CVE-2018-10903 More information
high severity
Vulnerable versions: >= 1.9.0, < 2.3
Patched version: 2.3
A flaw was found in python-cryptography versions between >=1.9.0 and <2.3. The finalize_with_tag API did not enforce a minimum tag length. If a user did not validate the input length prior to passing it to finalize_with_tag an attacker could craft an invalid payload with a shortened tag (e.g. 1 byte) such that they would have a 1 in 256 chance of passing the MAC check. GCM tag forgeries can cause key leakage.```

- Update to the install version required by paramiko