### PR TITLE
Avoid refinery generated auxiliary_nodes in ds_file_count.

### DIFF
--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -683,7 +683,8 @@ class DataSet(SharableResource):
     def get_file_nodes(self):
         return Node.objects.filter(
             study__in=self.get_investigation().study_set.all(),
-            file_item__isnull=False
+            file_item__isnull=False,
+            is_auxiliary_node=False
         )
 
     def get_file_count(self):


### PR DESCRIPTION
- Avoid returning auxiliary_nodes in count.
Resolves Case 2, ignoring the index files generated from running analyses
Ref #3456 

