### PR TITLE
Fix Dict/Unicode bug

### DIFF
--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -1067,9 +1067,10 @@ class Analysis(OwnableResource):
                                      self.summary)
 
     def get_expanded_workflow_graph(self):
-        return tool_manager.utils.create_expanded_workflow_graph(
-            ast.literal_eval(self.workflow_copy)
-        )
+        workflow_copy = self.workflow_copy
+        if type(workflow_copy) in [str, unicode]:
+            workflow_copy = ast.literal_eval(workflow_copy)
+        return tool_manager.utils.create_expanded_workflow_graph(workflow_copy)
 
     def has_nodes_used_in_downstream_analyses(self):
         """

--- a/refinery/core/models.py
+++ b/refinery/core/models.py
@@ -1067,9 +1067,8 @@ class Analysis(OwnableResource):
                                      self.summary)
 
     def get_expanded_workflow_graph(self):
-        workflow_copy = self.workflow_copy
-        if type(workflow_copy) in [str, unicode]:
-            workflow_copy = ast.literal_eval(workflow_copy)
+        self.refresh_from_db(fields=['workflow_copy'])
+        workflow_copy = ast.literal_eval(self.workflow_copy)
         return tool_manager.utils.create_expanded_workflow_graph(workflow_copy)
 
     def has_nodes_used_in_downstream_analyses(self):

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -1255,6 +1255,7 @@ class WorkflowTool(Tool):
     def _get_workflow_dict(self):
         # separate if-then assignment needed to avoid using the dict stored
         # in workflow_copy before .save() is called
+        self.analysis.refresh_from_db(fields=['workflow_copy'])
         if self.analysis.workflow_copy == u'' \
                 or self.analysis.workflow_copy is None:
             workflow_copy = \
@@ -1264,10 +1265,7 @@ class WorkflowTool(Tool):
             self.analysis.workflow_copy = workflow_copy
             self.analysis.save()
         else:
-            if type(self.analysis.workflow_copy) in [str, unicode]:
-                workflow_copy = ast.literal_eval(self.analysis.workflow_copy)
-            else:
-                workflow_copy = self.analysis.workflow_copy
+            workflow_copy = ast.literal_eval(self.analysis.workflow_copy)
         return workflow_copy
 
     def get_workflow_internal_id(self):

--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -1255,7 +1255,7 @@ class WorkflowTool(Tool):
     def _get_workflow_dict(self):
         # separate if-then assignment needed to avoid using the dict stored
         # in workflow_copy before .save() is called
-        if self.analysis.workflow_copy == '' \
+        if self.analysis.workflow_copy == u'' \
                 or self.analysis.workflow_copy is None:
             workflow_copy = \
                 self.galaxy_connection.workflows.export_workflow_dict(
@@ -1264,7 +1264,10 @@ class WorkflowTool(Tool):
             self.analysis.workflow_copy = workflow_copy
             self.analysis.save()
         else:
-            workflow_copy = ast.literal_eval(self.analysis.workflow_copy)
+            if type(self.analysis.workflow_copy) in [str, unicode]:
+                workflow_copy = ast.literal_eval(self.analysis.workflow_copy)
+            else:
+                workflow_copy = self.analysis.workflow_copy
         return workflow_copy
 
     def get_workflow_internal_id(self):


### PR DESCRIPTION
Related to the fix for #3435 we need to actually check types first -as I understand it, if the dict was stored and then is immediately reused, the django model returns a dict while a subsequent call later will return a string when it actually hits the database.  Correct me if I'm wrong.  In general, it's probably worth migrating to https://docs.djangoproject.com/en/1.9/ref/contrib/postgres/fields/#jsonfield once we have it.  Feel free to comment