### PR TITLE
Fix Excessive File Downloading

### DIFF
--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -813,12 +813,13 @@ class WorkflowTool(Tool):
                 is_refinery_file=galaxy_dataset in exposed_workflow_outputs,
                 galaxy_dataset_name=galaxy_dataset['name']
             )
-            connection_dataset_list += [
-                {
-                    field: galaxy_dataset[field]
-                    for field in connection_dataset_list_fields
-                }
-            ]
+            if galaxy_dataset in exposed_workflow_outputs:
+                connection_dataset_list += [
+                    {
+                        field: galaxy_dataset[field]
+                        for field in connection_dataset_list_fields
+                    }
+                ]
         return connection_dataset_list
 
     def _create_collection_description(self):


### PR DESCRIPTION
The old `get_galaxy_dataset_download_list` function had an extra if-then check that I appear to have forgotten about when replicating it in the `create_analysis_output_node_connections`.  this doesn't break anything but does mean that too many files are downloaded:

https://github.com/refinery-platform/refinery-platform/pull/3461/files#diff-8beee8c9215c07566345b13603f3b9c6L1050

Specifically ` if galaxy_dataset["dataset_id"] in exposed_galaxy_dataset_ids` needs to be replicated, so I have added that in.