### PR TITLE
IGV Bug Fix

### DIFF
--- a/refinery/tool_manager/models.py
+++ b/refinery/tool_manager/models.py
@@ -557,8 +557,8 @@ class VisualizationTool(Tool):
                 ),
                 self.AUXILIARY_FILE_LIST: [
                     get_file_url_from_node_uuid(
-                        child.uuid, require_valid_url=require_valid_urls
-                    ) for child in Node.objects.get(uuid=node["uuid"]).
+                        uuid, require_valid_url=require_valid_urls
+                    ) for uuid in Node.objects.get(uuid=node["uuid"]).
                     get_auxiliary_nodes()
                 ]
             }

--- a/refinery/tool_manager/tests.py
+++ b/refinery/tool_manager/tests.py
@@ -720,7 +720,7 @@ class VisualizationToolTests(ToolManagerTestBase):
             node.uuid: {
                 'file_url': self.node.file_item.get_datafile_url(),
                 'auxiliary_file_list': [
-                    child.uuid for child in
+                    child_uuid for child_uuid in
                     self.node.get_auxiliary_nodes()
                 ],
                 VisualizationTool.NODE_SOLR_INFO: {


### PR DESCRIPTION
`options.json` used in docker container was failing because of `child.uuid` throwing an error since `child` is a string.  this is tested and resolved