### PR TITLE
Control NAT gateway deployment

### DIFF
--- a/deployment/terraform/live/main.tf
+++ b/deployment/terraform/live/main.tf
@@ -75,15 +75,16 @@ module "docker_host" {
 }
 
 module "vpc" {
-  source               = "../modules/vpc"
-  vpc_cidr_block       = "${var.vpc_cidr_block}"
-  public_cidr_block    = "${var.public_cidr_block}"
-  private_cidr_block_a = "${var.private_cidr_block_a}"
-  private_cidr_block_b = "${var.private_cidr_block_b}"
-  availability_zone_a  = "${var.availability_zone_a}"
-  availability_zone_b  = "${var.availability_zone_b}"
-  resource_name_prefix = "${terraform.workspace}"
-  tags                 = "${local.tags}"
+  source                   = "../modules/vpc"
+  vpc_cidr_block           = "${var.vpc_cidr_block}"
+  public_cidr_block        = "${var.public_cidr_block}"
+  private_cidr_block_a     = "${var.private_cidr_block_a}"
+  private_cidr_block_b     = "${var.private_cidr_block_b}"
+  availability_zone_a      = "${var.availability_zone_a}"
+  availability_zone_b      = "${var.availability_zone_b}"
+  docker_nat_gateway_count = "${var.docker_instance_count > 0 ? 1 : 0}"
+  resource_name_prefix     = "${terraform.workspace}"
+  tags                     = "${local.tags}"
 }
 
 module "database" {

--- a/deployment/terraform/modules/vpc/main.tf
+++ b/deployment/terraform/modules/vpc/main.tf
@@ -58,11 +58,13 @@ resource "aws_route_table_association" "public_subnet" {
 }
 
 resource "aws_eip" "docker_nat" {
-  vpc  = true
-  tags = "${merge(var.tags, map("Name", var.resource_name_prefix))}"
+  count = "${var.docker_nat_gateway_count}"
+  vpc   = true
+  tags  = "${merge(var.tags, map("Name", var.resource_name_prefix))}"
 }
 
 resource "aws_nat_gateway" "docker_nat" {
+  count         = "${var.docker_nat_gateway_count}"
   allocation_id = "${aws_eip.docker_nat.id}"
   subnet_id     = "${aws_subnet.public_subnet.id}"
   depends_on    = ["aws_internet_gateway.public_gateway"]
@@ -70,6 +72,7 @@ resource "aws_nat_gateway" "docker_nat" {
 }
 
 resource "aws_route_table" "private_route_table" {
+  count  = "${var.docker_nat_gateway_count}"
   vpc_id = "${aws_vpc.vpc.id}"
   tags   = "${merge(var.tags, map("Name", "${var.resource_name_prefix} nat"))}"
   route {
@@ -79,6 +82,7 @@ resource "aws_route_table" "private_route_table" {
 }
 
 resource "aws_route_table_association" "private_subnet" {
+  count          = "${var.docker_nat_gateway_count}"
   subnet_id      = "${aws_subnet.private_subnet_a.id}"
   route_table_id = "${aws_route_table.private_route_table.id}"
 }

--- a/deployment/terraform/modules/vpc/vars.tf
+++ b/deployment/terraform/modules/vpc/vars.tf
@@ -5,6 +5,7 @@ variable "private_cidr_block_b" {}
 variable "public_cidr_block" {}
 variable "availability_zone_a" {}
 variable "availability_zone_b" {}
+variable "docker_nat_gateway_count" {}
 variable "tags" {
   type        = "map"
   description = "Resource tags"


### PR DESCRIPTION
Avoid deploying NAT gateway and related resources if no Docker instances are provisioned
